### PR TITLE
Add the ability to explicitly exclude lot-tracked paths

### DIFF
--- a/src/lotman.cpp
+++ b/src/lotman.cpp
@@ -1445,6 +1445,12 @@ int lotman_get_lot_as_json(const char *lot_name, const bool recursive, char **ou
 		if (recursive) {
 			output_obj["owners"] = rp_vec_str.first;
 		} else {
+			if (rp_vec_str.first.empty()) {
+				if (err_msg) {
+					*err_msg = strdup("get_owners returned empty result");
+				}
+				return -1;
+			}
 			output_obj["owner"] = rp_vec_str.first[0]; // Only one owner, this is where it will be.
 		}
 

--- a/src/lotman_db.h
+++ b/src/lotman_db.h
@@ -82,6 +82,7 @@ struct Path {
 	std::string lot_name;
 	std::string path;
 	int recursive; // SQLite doesn't have native bool, stored as int
+	int exclude;   // If true, this path is excluded from the lot's tracking
 };
 
 struct ManagementPolicyAttributes {
@@ -132,7 +133,8 @@ inline auto create_storage(const std::string &db_path) {
 		make_table("parents", make_column("lot_name", &Parent::lot_name), make_column("parent", &Parent::parent),
 				   primary_key(&Parent::lot_name, &Parent::parent)),
 		make_table("paths", make_column("lot_name", &Path::lot_name), make_column("path", &Path::path, unique()),
-				   make_column("recursive", &Path::recursive)),
+				   make_column("recursive", &Path::recursive),
+				   make_column("exclude", &Path::exclude, default_value(0))),
 		make_table("management_policy_attributes",
 				   make_column("lot_name", &ManagementPolicyAttributes::lot_name, primary_key()),
 				   make_column("dedicated_GB", &ManagementPolicyAttributes::dedicated_GB),

--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -554,6 +554,7 @@ std::pair<json, std::string> lotman::Lot::get_lot_dirs(const bool recursive) {
 			path_obj_internal["lot_name"] = this->lot_name;
 			path_obj_internal["recursive"] = static_cast<bool>(path_rec.recursive);
 			path_obj_internal["path"] = path_rec.path;
+			path_obj_internal["exclude"] = static_cast<bool>(path_rec.exclude);
 			path_arr.push_back(path_obj_internal);
 		}
 
@@ -572,6 +573,7 @@ std::pair<json, std::string> lotman::Lot::get_lot_dirs(const bool recursive) {
 					path_obj_internal["lot_name"] = child.lot_name;
 					path_obj_internal["recursive"] = static_cast<bool>(path_rec.recursive);
 					path_obj_internal["path"] = path_rec.path;
+					path_obj_internal["exclude"] = static_cast<bool>(path_rec.exclude);
 					path_arr.push_back(path_obj_internal);
 				}
 			}
@@ -1042,11 +1044,12 @@ std::pair<bool, std::string> lotman::Lot::update_parents(const json &update_arr)
 }
 
 std::pair<bool, std::string> lotman::Lot::update_paths(const json &update_arr) {
-	// incoming update map looks like {"path1" --> {"path" : "path2", "recursive" : false}}
+	// incoming update map looks like {"path1" --> {"path" : "path2", "recursive" : false, "exclude": false}}
 	std::string paths_update_stmt = "UPDATE paths SET path=? WHERE lot_name=? and path=?;";
 	std::string recursive_update_stmt = "UPDATE paths SET recursive=? WHERE lot_name=? and path=?;";
+	std::string exclude_update_stmt = "UPDATE paths SET exclude=? WHERE lot_name=? and path=?;";
 
-	// Iterate through updates, first perform recursive update THEN path
+	// Iterate through updates, first perform recursive update, then exclude update, THEN path
 	for (const auto &update_obj : update_arr /*update_map*/) {
 		// Normalize paths with trailing slash
 		std::string current_path = ensure_trailing_slash(update_obj["current"].get<std::string>());
@@ -1061,6 +1064,19 @@ std::pair<bool, std::string> lotman::Lot::update_paths(const json &update_arr) {
 			std::string int_err = rp.second;
 			std::string ext_err = "Failure on call to lotman::Lot::store_updates when storing paths recursive update: ";
 			return std::make_pair(false, ext_err + int_err);
+		}
+
+		// Exclude update (if provided)
+		if (update_obj.contains("exclude")) {
+			std::map<int64_t, std::vector<int>> exclude_update_int_map{{update_obj["exclude"].get<int>(), {1}}};
+			std::map<std::string, std::vector<int>> exclude_update_str_map{{lot_name, {2}}, {current_path, {3}}};
+			rp = store_updates(exclude_update_stmt, exclude_update_str_map, exclude_update_int_map);
+			if (!rp.first) {
+				std::string int_err = rp.second;
+				std::string ext_err =
+					"Failure on call to lotman::Lot::store_updates when storing paths exclude update: ";
+				return std::make_pair(false, ext_err + int_err);
+			}
 		}
 
 		// Path update
@@ -1850,18 +1866,41 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_from_dir(
 		dir_for_like.pop_back();
 	}
 
-	// Query logic:
+	// Query logic for path exclusions:
+	// We need to find the best matching path rule for this directory. The algorithm is:
+	// 1. Find all path rules (both inclusions and exclusions) that match this directory
+	// 2. The longest matching path "wins" - if it's an exclusion, the path is not in that lot
+	// 3. If the longest match is an exclusion, we need to find the next longest inclusion
+	//    that is NOT overridden by an exclusion
+	//
+	// The query uses a subquery to check if there's a longer exclusion that would override
+	// any given inclusion match.
+	//
+	// Path matching rules:
 	// - path = ?1 : exact match (normalized input matches stored path exactly)
 	// - ?2 LIKE path || '%' : input is a subdirectory of a stored recursive path
-	//   The trailing slash in stored paths prevents false prefix matches
-	// - ?3 is used for non-recursive path exact matching
+	// - For non-recursive paths, only exact matches count
+	// - exclude = 0 means this is an inclusion (the path IS tracked)
+	// - exclude = 1 means this is an exclusion (the path is NOT tracked by this lot)
+	//
+	// We select the longest non-excluded path that doesn't have a longer exclusion overriding it
 	std::string lots_from_dir_query =
-		"SELECT lot_name FROM paths "
+		"SELECT lot_name FROM paths p "
 		"WHERE "
-		"(path = ? OR ? LIKE path || '%') " // Exact match or subdirectory of stored path
+		"(p.path = ?1 OR ?2 LIKE p.path || '%') " // Exact match or subdirectory of stored path
 		"AND "
-		"(recursive OR path = ?) " // If the stored file path is not recursive, we only match the exact file path
-		"ORDER BY LENGTH(path) DESC LIMIT 1;"; // We prefer longer matches over shorter ones
+		"(p.recursive OR p.path = ?3) " // If not recursive, only match exact path
+		"AND "
+		"p.exclude = 0 "	// Only consider inclusion paths
+		"AND NOT EXISTS ( " // Ensure no longer exclusion overrides this inclusion
+		"    SELECT 1 FROM paths e "
+		"    WHERE e.lot_name = p.lot_name "			  // Same lot
+		"    AND e.exclude = 1 "						  // Is an exclusion
+		"    AND (e.path = ?1 OR ?2 LIKE e.path || '%') " // Matches the input path
+		"    AND (e.recursive OR e.path = ?3) "			  // Respects recursive flag
+		"    AND LENGTH(e.path) > LENGTH(p.path) "		  // Exclusion is more specific (longer)
+		") "
+		"ORDER BY LENGTH(p.path) DESC LIMIT 1;"; // Prefer longest matching inclusion
 	std::map<std::string, std::vector<int>> dir_str_map{{dir, {1, 3}}, {dir_for_like, {2}}};
 	auto rp = lotman::db::SQL_get_matches(lots_from_dir_query, dir_str_map);
 	if (!rp.second.empty()) {

--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -524,14 +524,21 @@ std::pair<json, std::string> lotman::Lot::get_restricting_attribute(const std::s
 				}
 
 				std::vector<std::string> compare_value = rp.first;
-				if (std::stod(compare_value[0]) < std::stod(value[0])) {
+				if (!compare_value.empty() && !value.empty() && std::stod(compare_value[0]) < std::stod(value[0])) {
 					value[0] = compare_value[0];
 					restricting_parent_name = parent.lot_name;
 				}
 			}
-			internal_obj["lot_name"] = restricting_parent_name;
-			internal_obj["value"] = std::stod(value[0]);
+			if (!value.empty()) {
+				internal_obj["lot_name"] = restricting_parent_name;
+				internal_obj["value"] = std::stod(value[0]);
+			} else {
+				return std::make_pair(json(), "No valid policy attribute value found");
+			}
 		} else {
+			if (value.empty()) {
+				return std::make_pair(json(), "Policy attribute query returned empty result");
+			}
 			internal_obj["value"] = std::stod(value[0]);
 		}
 		return std::make_pair(internal_obj, "");
@@ -652,6 +659,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_multi_out = rp_multi.first;
+			if (query_multi_out.empty() || query_multi_out[0].size() < 3) {
+				return std::make_pair(json(), "Multi-column query returned insufficient results for dedicated_GB");
+			}
 			output_obj["total"] = std::stod(query_multi_out[0][0]);
 			output_obj["self_contrib"] = std::stod(query_multi_out[0][1]);
 			output_obj["children_contrib"] = std::stod(query_multi_out[0][2]);
@@ -676,6 +686,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_output = rp_single.first;
+			if (query_output.empty()) {
+				return std::make_pair(json(), "Query returned empty result for dedicated_GB");
+			}
 			output_obj["self_contrib"] = std::stod(query_output[0]);
 		}
 	}
@@ -728,6 +741,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_multi_out = rp_multi.first;
+			if (query_multi_out.empty() || query_multi_out[0].size() < 3) {
+				return std::make_pair(json(), "Multi-column query returned insufficient results for opportunistic_GB");
+			}
 			output_obj["total"] = std::stod(query_multi_out[0][0]);
 			output_obj["self_contrib"] = std::stod(query_multi_out[0][1]);
 			output_obj["children_contrib"] = std::stod(query_multi_out[0][2]);
@@ -754,6 +770,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_output = rp_single.first;
+			if (query_output.empty()) {
+				return std::make_pair(json(), "Query returned empty result for opportunistic_GB");
+			}
 			output_obj["self_contrib"] = std::stod(query_output[0]);
 		}
 	}
@@ -771,6 +790,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_multi_out = rp_multi.first;
+			if (query_multi_out.empty() || query_multi_out[0].size() < 2) {
+				return std::make_pair(json(), "Multi-column query returned insufficient results for num_objects");
+			}
 			output_obj["self_contrib"] = std::stod(query_multi_out[0][0]);
 			output_obj["children_contrib"] = std::stod(query_multi_out[0][1]);
 			output_obj["total"] = std::stod(query_multi_out[0][0]) + std::stod(query_multi_out[0][1]);
@@ -784,6 +806,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_output = rp_single.first;
+			if (query_output.empty()) {
+				return std::make_pair(json(), "Query returned empty result for num_objects");
+			}
 			output_obj["self_contrib"] = std::stod(query_output[0]);
 		}
 	}
@@ -799,6 +824,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_multi_out = rp_multi.first;
+			if (query_multi_out.empty() || query_multi_out[0].size() < 2) {
+				return std::make_pair(json(), "Multi-column query returned insufficient results for GB_being_written");
+			}
 			output_obj["self_contrib"] = std::stod(query_multi_out[0][0]);
 			output_obj["children_contrib"] = std::stod(query_multi_out[0][1]);
 			output_obj["total"] = std::stod(query_multi_out[0][0]) + std::stod(query_multi_out[0][1]);
@@ -813,6 +841,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_output = rp_single.first;
+			if (query_output.empty()) {
+				return std::make_pair(json(), "Query returned empty result for GB_being_written");
+			}
 			output_obj["self_contrib"] = std::stod(query_output[0]);
 		}
 	}
@@ -830,6 +861,10 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_multi_out = rp_multi.first;
+			if (query_multi_out.empty() || query_multi_out[0].size() < 2) {
+				return std::make_pair(json(),
+									  "Multi-column query returned insufficient results for objects_being_written");
+			}
 			output_obj["self_contrib"] = std::stod(query_multi_out[0][0]);
 			output_obj["children_contrib"] = std::stod(query_multi_out[0][1]);
 			output_obj["total"] = std::stod(query_multi_out[0][0]) + std::stod(query_multi_out[0][1]);
@@ -844,6 +879,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_output = rp_single.first;
+			if (query_output.empty()) {
+				return std::make_pair(json(), "Query returned empty result for objects_being_written");
+			}
 			output_obj["self_contrib"] = std::stod(query_output[0]);
 		}
 	}
@@ -861,6 +899,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_multi_out = rp_multi.first;
+			if (query_multi_out.empty() || query_multi_out[0].size() < 2) {
+				return std::make_pair(json(), "Multi-column query returned insufficient results for max_num_objects");
+			}
 			output_obj["self_contrib"] = std::stod(query_multi_out[0][0]);
 			output_obj["children_contrib"] = std::stod(query_multi_out[0][1]);
 			output_obj["total"] = std::stod(query_multi_out[0][0]) + std::stod(query_multi_out[0][1]);
@@ -876,6 +917,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				return std::make_pair(json(), ext_err + int_err);
 			}
 			query_output = rp_single.first;
+			if (query_output.empty()) {
+				return std::make_pair(json(), "Query returned empty result for max_num_objects");
+			}
 			output_obj["self_contrib"] = std::stod(query_output[0]);
 		}
 	}

--- a/src/lotman_internal.h
+++ b/src/lotman_internal.h
@@ -290,6 +290,9 @@ class DirUsageUpdate : public Lot {
 				std::string ext_err = "Failure on call to get_lots_from_dir: ";
 				return std::make_pair(false, ext_err + int_err);
 			}
+			if (rp_vec_str.first.empty()) {
+				return std::make_pair(false, "get_lots_from_dir returned empty result");
+			}
 
 			Lot lot(rp_vec_str.first[0]);
 			lot.init_self_usage();
@@ -353,7 +356,8 @@ class DirUsageUpdate : public Lot {
 					}
 
 					auto subdir_lot_rp = get_lots_from_dir(subdir_path, false);
-					if (subdir_lot_rp.second.empty() && subdir_lot_rp.first[0] != lot.lot_name) {
+					if (subdir_lot_rp.second.empty() && !subdir_lot_rp.first.empty() &&
+						subdir_lot_rp.first[0] != lot.lot_name) {
 						// Subdir belongs to a different lot (e.g., due to exclusion)
 						other_lot_subdirs.push_back(subdir);
 					}

--- a/src/lotman_internal.h
+++ b/src/lotman_internal.h
@@ -316,26 +316,70 @@ class DirUsageUpdate : public Lot {
 				}
 			}
 
-			// If the dir includes values from subdirs and it is not recursive, we need to subtract subdir usage per
-			// attribute
-			if (update["includes_subdirs"].get<bool>() && !recursive) {
-				for (const auto &subdir : update["subdirs"]) {
+			// Handle subdirs when includes_subdirs is true.
+			// We need to process subdirs in two cases:
+			// 1. The lot's path is not recursive - standard behavior, process each subdir
+			// 2. The lot's path IS recursive BUT some subdirs might be excluded - we need to
+			//    check each subdir and attribute excluded subdirs to their proper lot
+			//
+			// To handle case 2, we check if any subdir maps to a different lot than the parent.
+			// If so, we subtract that subdir's usage from the parent and process it separately.
+			if (update["includes_subdirs"].get<bool>() && !update["subdirs"].empty()) {
+				// Helper to subtract subdir values from parent totals
+				auto subtract_subdir_values = [&](const json &subdir) {
 					if (subdir.contains("size_GB")) {
 						usage_GB -= subdir["size_GB"].get<double>();
 					}
 					if (subdir.contains("num_obj")) {
 						num_obj -= subdir["num_obj"].get<int64_t>();
 					}
-
 					if (subdir.contains("GB_being_written")) {
 						GB_being_written -= subdir["GB_being_written"].get<double>();
 					}
 					if (subdir.contains("objects_being_written")) {
 						objects_being_written -= subdir["objects_being_written"].get<int64_t>();
 					}
+				};
+
+				// Separate subdirs into those belonging to other lots (due to exclusions)
+				json other_lot_subdirs = json::array();
+
+				for (const auto &subdir : update["subdirs"]) {
+					std::string subdir_path;
+					if (subdir["path"].get<std::string>().substr(0, 1) != "/") {
+						subdir_path = m_current_path + "/" + subdir["path"].get<std::string>();
+					} else {
+						subdir_path = m_current_path + subdir["path"].get<std::string>();
+					}
+
+					auto subdir_lot_rp = get_lots_from_dir(subdir_path, false);
+					if (subdir_lot_rp.second.empty() && subdir_lot_rp.first[0] != lot.lot_name) {
+						// Subdir belongs to a different lot (e.g., due to exclusion)
+						other_lot_subdirs.push_back(subdir);
+					}
+					// If we can't determine the lot or it's the same lot, no special handling needed
 				}
-				DirUsageUpdate dirUpdate(m_depth + 1, m_current_path);
-				dirUpdate.JSON_math(update["subdirs"], return_lots);
+
+				// For non-recursive paths, always subtract ALL subdirs and process them
+				// For recursive paths, only subtract subdirs that belong to OTHER lots
+				if (!recursive) {
+					// Non-recursive: subtract all subdirs from parent, process all subdirs
+					for (const auto &subdir : update["subdirs"]) {
+						subtract_subdir_values(subdir);
+					}
+					DirUsageUpdate dirUpdate(m_depth + 1, m_current_path);
+					dirUpdate.JSON_math(update["subdirs"], return_lots);
+				} else if (!other_lot_subdirs.empty()) {
+					// Recursive path but some subdirs are excluded - subtract only those
+					for (const auto &subdir : other_lot_subdirs) {
+						subtract_subdir_values(subdir);
+					}
+					// Process only the subdirs that belong to other lots
+					DirUsageUpdate dirUpdate(m_depth + 1, m_current_path);
+					dirUpdate.JSON_math(other_lot_subdirs, return_lots);
+				}
+				// If recursive and all subdirs belong to same lot, do nothing extra -
+				// the full usage_GB already includes them correctly
 			}
 
 			std::vector<std::string> lot_update_keys;

--- a/src/schemas.h
+++ b/src/schemas.h
@@ -51,6 +51,10 @@ json new_lot_schema = R"(
                     },
                     "recursive": {
                         "type": "boolean"
+                    },
+                    "exclude": {
+                        "type": "boolean",
+                        "description": "If true, this path is excluded from the lot's tracking"
                     }
                 },
                 "required": ["path", "recursive"]
@@ -163,6 +167,10 @@ json lot_update_schema = R"(
                     },
                     "recursive": {
                         "description": "whether new path is recursive",
+                        "type": "boolean"
+                    },
+                    "exclude": {
+                        "description": "whether new path is an exclusion",
                         "type": "boolean"
                     }
                 },
@@ -283,6 +291,10 @@ json lot_additions_schema = R"(
                     },
                     "recursive": {
                         "type": "boolean"
+                    },
+                    "exclude": {
+                        "type": "boolean",
+                        "description": "If true, this path is excluded from the lot's tracking"
                     }
                 },
                 "required": ["path", "recursive"]


### PR DESCRIPTION
Previously, a lot may have set a recursive path like /foo such that /foo/* was attributed to the lot. However, consider the case where you want /foo/bar/ to be excluded, but otherwise 1000+ other things under /foo/ should be included as belonging to the lot. Without a way to exclude only /foo/bar/, this setup would require enumerating every subpath because you wouldn't be able to set /foo as recursive without including /foo/bar

This new addition lets you create a JSON like:
```
{
  "lot_name": "lot1",
  "paths": [
    {
      "path": "/foo/",
      "recursive": true,
    },
    {
      "path": "/foo/bar/",
      "recursive: <could be true or false>,
      "exclude": true
  ]
}
```

With this paths instantiation, `/foo/bar/` can be excluded from `lot1` even though `/foo/` is recursive. By setting a value for `recursive` on `/foo/bar/`, you can choose to exclude everything under `/foo/bar`, or only `/foo/bar` itself.

Closes #24 