### PR TITLE
Strict hierarchy enforcement and reservation semantics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,5 +39,5 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        args: ['--skip', '*.json,*.lock', '--ignore-words-list', 'fo,te']
+        args: ['--skip', '*.json,*.lock', '--ignore-words-list', 'fo,te,ded']
         types_or: [c++, c, cmake, markdown, yaml]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Lot objects are comprised of several components:
 - **Parents:** Every lot must have at least one parent. Parent/child relationships are used for calculating lot usage statistics and identifying lots that may be in violation of their management policy attributes. When a lot is assigned children, it is signifying that the parent not only owns the data associated with those lots, but that it also owns those lots themselves, which gives the owner of the parent lot the ability to modify parameters of the children lots. In the case that a lot is a self parent, the owner of the lot is also able to modify attributes for the lot itself. When querying LotMan for usage statistics, the usage of a lot's children *may* be counted toward the quotas of the parent; queries can be made to return information only about lots themselves, or about lots and their children. Lots with only themselves as parents are *root* lots.
 - **Paths:** The list of paths/objects tied to the lot whose statistics should be tracked. One design consideration of LotMan is that these paths need not be rigidly tied to traditional filesystems. While the term *paths* is natural in the context of filesystems, LotMan can also use the URI of any object as a path. When a path is associated with a lot, it can be done so either recursively or non-recursively. If recursive is set to true, it indicates that any sub directories should also be attributed to a lot. For example, if path `/foo` is explicitly tied to a lot with recursive set to true, then `/foo/bar` is as well such that `/foo/bar` cannot be tied to another lot. Conversely, if `/foo` is tied to a lot with recursive set to false, then `/foo/bar` may be tied to another lot. When querying LotMan for information about a path that is not explicitly tied to a lot, LotMan will treat that path as belonging to the default lot.
 - **Management Policy Attributes (MPAs):** These are the attributes that can be used to make decisions about a lot and its associated data. They are:
-    - *Creation Time* -- The unix epoch timestamp in milliseconds at which a lot becomes valid.
+    - *Creation Time* -- The unix epoch timestamp in milliseconds at which a lot becomes valid. Together with *Expiration Time*, this defines the half-open interval `[creation_time, expiration_time)` over which the lot is considered active. Two lots may track the same path concurrently only if their active intervals do not overlap.
     - *Expiration Time* -- The unix epoch timestamp in milliseconds at which a lot expires. Expired lots and their associated data should be considered transient. That is, the owner of the system's storage resources *may* choose to allow a lot to continue using resources if resources are abundant, but the lot's owner should have no expectations.
     - *Deletion Time* -- The unix epoch timestamp in milliseconds at which a lot and its associated data should be deleted.
     - *Dedicated GB* -- The amount of storage made available to the lot owner. Owners who stay within this limit should be guaranteed this amount of storage while the lot is still viable.
@@ -30,7 +30,46 @@ Lot objects are comprised of several components:
     - *Children GB Being Written* -- The number of GB associated with a lot's children being written to disk, not including itself in cases where a lot is a self parent.
     - *Self Objects Being Written* -- The number of objects associated with a lot being written to disk, not including those of its children.
     - *Children Objects Being Written* -- The number of objects associated with a lot's children being written to disk, not including itself in cases where a lot is a self parent.
+## Reservations and Strict Hierarchy
 
+LotMan supports a *reservation* model in which a parent lot's resources (dedicated GB, opportunistic GB, max objects) are explicitly partitioned among its children over time. Reservation enforcement is opt-in and is governed by a small set of context flags plus a per-child *parent_attributions* field on the lot APIs.
+
+### Context flags
+
+These are set with `lotman_set_context_str` and read with `lotman_get_context_str`:
+
+- **`strict_hierarchy`** (`"true"` / `"false"`, default `"false"`) -- When enabled, every operation that creates or mutates a lot is validated against the following axioms before it is committed; failure rolls the change back atomically:
+    1. **Axiom 1** -- A child's MPAs may not exceed the sum of its parents' attributions to it.
+    2. **Axiom 2** -- For any parent, the *peak concurrent* attributed usage across its children (over their active time windows) must not exceed the parent's own MPAs. This is checked with a sweep-line algorithm over the children's `[creation_time, expiration_time)` intervals so that two children whose windows don't overlap can both reserve the same capacity.
+    3. **Axiom 3** -- A child's active interval must lie within each of its parents' intervals.
+- **`contraction_policy`** (`"none"` / `"strict"`, default `"none"`) -- Controls whether MPAs may be *reduced* on an existing lot. Under `"strict"`, an update that would lower a parent's capacity below what its children have already reserved is rejected.
+- **`admin_override`** (`"true"` / `"false"`, default `"false"`) -- Bypasses contraction-policy restrictions for privileged callers. Strict-hierarchy axioms are still enforced.
+
+### Specifying attributions
+
+The `parent_attributions` field tells LotMan how each parent's allocation should be apportioned to a child. It is accepted by `lotman_add_lot`, `lotman_update_lot`, and `lotman_add_to_lot` as a JSON object keyed by parent lot name:
+
+```json
+"parent_attributions": {
+    "parent_a": {"dedicated_GB": 5.0, "opportunistic_GB": 2.0, "max_num_objects": 100},
+    "parent_b": {"dedicated_GB": 3.0, "opportunistic_GB": 1.0, "max_num_objects":  50}
+}
+```
+
+Semantics:
+- **Wholesale-replace.** On every call, the supplied object replaces the lot's full attribution set. Any parent omitted from the object receives the *equal-split remainder* of the child's MPAs after the explicitly listed parents are subtracted out.
+- **Unknown keys are rejected.** A parent name that does not match an actual parent of the lot is treated as a typo and produces an error rather than being silently ignored.
+- **Shortfalls are rejected.** Explicit attributions that sum to less than the child's totals are rejected; LotMan will not invent slack.
+- **In `lotman_add_to_lot`,** `parent_attributions` is processed *after* `parents`, so newly added parents may appear as keys in the same call.
+- Under `strict_hierarchy`, axioms 1 and 2 are re-validated after any attribution change; on failure the attribution writes are rolled back.
+
+### Querying available capacity
+
+`lotman_get_available_capacity(parent_lot_name, start_time, end_time, output, err_msg)` returns peak and available resource metrics under a parent during a time window as a JSON document (caller-owned; `free()` it). This is **advisory only** and is intended for monitoring and pre-flight planning -- the authoritative reservation check is performed atomically by Axiom 2 inside the lot-creation transaction, so another caller may legitimately claim capacity between the query and the subsequent create.
+
+### Hierarchical "past quota" queries
+
+`lotman_get_lots_past_ded`, `lotman_get_lots_past_opp`, and `lotman_get_lots_past_obj` accept a `hierarchical` boolean. When `true`, each parent's effective usage is adjusted by adding any child *overage* (usage in excess of the child's own attributed share), and results are returned deepest-first. This pairs naturally with the reservation model: a child that exceeds its slice flows the overage up to whichever parent is actually footing the bill.
 ## Example Usage Scenario
 
 One scenario in which LotMan's features becomes particularly relevant is in the case of data caches, where the desire is to be using as much system storage as possible (which is arguably the cache's job). In this case, the cache may be configured to start clearing files after storage use reaches a certain threshold, perhaps until storage use dips below a separate threshold -- a high watermark and low watermark scheme. If the cache is configured to use LotMan, then when it comes time to delete files, it can implement a priority-based deletion loop. For example, it may first ask LotMan for all the paths associated with lots past their deletion point, choosing to delete those files first. Until the low watermark has been reached, it may then ask for paths associated with lots past their expiration time, past their opportunistic storage, past their max number of objects, and past their dedicated storage. For each query, LotMan is capable of returning all of the paths associated with any lot that meets the supplied criteria, including whether to count children statistics toward the lot's quoats.

--- a/src/lotman.cpp
+++ b/src/lotman.cpp
@@ -1,9 +1,11 @@
 #include "lotman.h"
 
+#include "lotman_db.h"
 #include "lotman_internal.h"
 #include "lotman_version.h"
 #include "schemas.h"
 
+#include <chrono>
 #include <nlohmann/json-schema.hpp>
 #include <nlohmann/json.hpp>
 #include <string.h>
@@ -17,6 +19,15 @@ std::shared_ptr<std::string> lotman::Context::m_caller = std::make_shared<std::s
 
 // Lot home
 std::shared_ptr<std::string> lotman::Context::m_home = std::make_shared<std::string>("");
+
+// Strict hierarchy enforcement (off by default for backward compatibility)
+bool lotman::Context::m_strict_hierarchy = false;
+
+// Contraction policy ("none" by default for backward compatibility)
+std::string lotman::Context::m_contraction_policy = "none";
+
+// Admin override (off by default)
+bool lotman::Context::m_admin_override = false;
 
 std::shared_ptr<int> lotman_db_timeout = std::make_shared<int>(5000); // in ms
 
@@ -72,6 +83,12 @@ int lotman_add_lot(const char *lotman_JSON_str, char **err_msg) {
 
 		lotman::Lot lot(lot_JSON_obj);
 
+		// Extract parent_attributions if provided
+		json parent_attributions;
+		if (lot_JSON_obj.contains("parent_attributions") && !lot_JSON_obj["parent_attributions"].is_null()) {
+			parent_attributions = lot_JSON_obj["parent_attributions"];
+		}
+
 		// Check for context and make sure caller is allowed to add the lot as specified
 		rp = lot.check_context_for_parents(lot.parents, false, true);
 		if (!rp.first) {
@@ -92,7 +109,7 @@ int lotman_add_lot(const char *lotman_JSON_str, char **err_msg) {
 			return -1;
 		}
 
-		rp = lot.store_lot();
+		rp = lot.store_lot(parent_attributions);
 		if (!rp.first) {
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -296,55 +313,57 @@ int lotman_update_lot(const char *lotman_JSON_str, char **err_msg) {
 			return -1;
 		}
 
-		// Start checking which keys to operate on
-		if (update_JSON_obj.contains("owner")) {
-			rp = lot.update_owner(update_JSON_obj["owner"].get<std::string>());
-			if (!rp.first) {
-				if (err_msg) {
-					std::string int_err = rp.second;
-					std::string ext_err = "Failed on call to lot.update_owner: ";
-					*err_msg = strdup((ext_err + int_err).c_str());
+		// Start checking which keys to operate on. All write operations are run
+		// inside a single outer storage.transaction() so the entire update is
+		// atomic: if any sub-step fails, every preceding sub-step is rolled back.
+		auto &storage = lotman::db::StorageManager::get_storage();
+		std::string txn_error;
+		bool committed = storage.transaction([&]() -> bool {
+			if (update_JSON_obj.contains("owner")) {
+				if (!lot.update_owner_in_txn(update_JSON_obj["owner"].get<std::string>(), txn_error)) {
+					txn_error = "Failed on call to lot.update_owner: " + txn_error;
+					return false;
 				}
-				return -1;
 			}
-		}
 
-		if (update_JSON_obj.contains("parents")) {
-			rp = lot.update_parents(update_JSON_obj["parents"]);
-			if (!rp.first) {
-				if (err_msg) {
-					std::string int_err = rp.second;
-					std::string ext_err = "Failed on call to lot.update_parents";
-					*err_msg = strdup((ext_err + int_err).c_str());
+			if (update_JSON_obj.contains("parents")) {
+				if (!lot.update_parents_in_txn(update_JSON_obj["parents"], txn_error)) {
+					txn_error = "Failed on call to lot.update_parents: " + txn_error;
+					return false;
 				}
-				return -1;
 			}
-		}
 
-		if (update_JSON_obj.contains("paths")) {
-			rp = lot.update_paths(update_JSON_obj["paths"]);
-			if (!rp.first) {
-				if (err_msg) {
-					std::string int_err = rp.second;
-					std::string ext_err = "Failed on call to lot.update_paths";
-					*err_msg = strdup((ext_err + int_err).c_str());
+			if (update_JSON_obj.contains("paths")) {
+				if (!lot.update_paths_in_txn(update_JSON_obj["paths"], txn_error)) {
+					txn_error = "Failed on call to lot.update_paths: " + txn_error;
+					return false;
 				}
-				return -1;
 			}
-		}
 
-		if (update_JSON_obj.contains("management_policy_attrs")) {
-			for (const auto &update_attr : update_JSON_obj["management_policy_attrs"].items()) {
-				auto rp = lot.update_man_policy_attrs(update_attr.key(), update_attr.value());
-				if (!rp.first) {
-					if (err_msg) {
-						std::string int_err = rp.second;
-						std::string ext_err = "Failed on call to lot.update_paths";
-						*err_msg = strdup((ext_err + int_err).c_str());
+			if (update_JSON_obj.contains("management_policy_attrs")) {
+				for (const auto &update_attr : update_JSON_obj["management_policy_attrs"].items()) {
+					if (!lot.update_man_policy_attrs_in_txn(update_attr.key(), update_attr.value(), txn_error)) {
+						txn_error = "Failed on call to lot.update_man_policy_attrs: " + txn_error;
+						return false;
 					}
-					return -1;
 				}
 			}
+
+			if (update_JSON_obj.contains("parent_attributions")) {
+				if (!lot.update_attributions_in_txn(update_JSON_obj["parent_attributions"], txn_error)) {
+					txn_error = "Failed on call to lot.update_attributions: " + txn_error;
+					return false;
+				}
+			}
+
+			return true;
+		});
+
+		if (!committed) {
+			if (err_msg) {
+				*err_msg = strdup(txn_error.empty() ? "Update transaction failed" : txn_error.c_str());
+			}
+			return -1;
 		}
 
 		return 0;
@@ -421,13 +440,27 @@ int lotman_rm_paths_from_lots(const char *lotman_JSON_str, char **err_msg) {
 		validator.set_root_schema(lotman_schemas::lot_rm_paths_schema);
 		validator.validate(subtraction_JSON_obj);
 
-		// For each path, figure out which lot it belongs to
-		// Knowing the lot name is required for context checking
+		// Phase 1 (read-only): For each path, find matching lots and check context.
+		// Collect (lot_name, path) pairs to remove.
+		struct PathRemoval {
+			std::string lot_name;
+			std::string path;
+		};
+		std::vector<PathRemoval> removals;
+
 		for (const auto &path : subtraction_JSON_obj["paths"]) {
 			std::string path_str{path.get<std::string>()};
 
-			// Check if this path actually exists in the database
-			auto rp_str_str = lotman::Lot::get_lot_from_dir(path_str);
+			// Check if this path actually exists in the database (no temporal filtering —
+			// path removal should work regardless of lot's time range)
+			std::string normalized_path = path_str;
+			if (normalized_path.empty() || normalized_path.back() != '/') {
+				normalized_path += '/';
+			}
+			std::string query = "SELECT lot_name FROM paths WHERE path = ?1;";
+			std::map<std::string, std::vector<int>> str_map{{normalized_path, {1}}};
+			std::map<int64_t, std::vector<int>> int_map;
+			auto rp_str_str = lotman::db::SQL_get_matches(query, str_map, int_map);
 			if (!rp_str_str.second.empty()) { // There was an error
 				if (err_msg) {
 					std::string int_err = rp_str_str.second;
@@ -442,29 +475,49 @@ int lotman_rm_paths_from_lots(const char *lotman_JSON_str, char **err_msg) {
 				continue;
 			}
 
-			// Initialize the lot
-			lotman::Lot lot(rp_str_str.first);
+			// The same path can appear in multiple lots (with non-overlapping time
+			// ranges), so iterate over every matching lot_name.
+			for (const auto &matching_lot_name : rp_str_str.first) {
+				lotman::Lot lot(matching_lot_name);
 
-			// Check for context
-			lot.get_parents(true, true);
-			auto rp = lot.check_context_for_parents(lot.recursive_parents, true);
-			if (!rp.first) {
-				if (err_msg) {
-					std::string int_err = rp.second;
-					std::string ext_err = "Error while checking context for parents: ";
-					*err_msg = strdup((ext_err + int_err).c_str());
+				// Check for context
+				lot.get_parents(true, true);
+				auto rp = lot.check_context_for_parents(lot.recursive_parents, true);
+				if (!rp.first) {
+					if (err_msg) {
+						std::string int_err = rp.second;
+						std::string ext_err = "Error while checking context for parents: ";
+						*err_msg = strdup((ext_err + int_err).c_str());
+					}
+					return -1;
 				}
-				return -1;
-			}
 
-			std::vector<std::string> plc_hldr_vec{path_str};
-			rp = lot.remove_paths(plc_hldr_vec); // Keeping std::vector<std::string> signature for now, even though it
-												 // only gets passed one thing at a time
-			if (!rp.first) {
+				removals.push_back({matching_lot_name, path_str});
+			}
+		}
+
+		// Phase 2 (write): Execute all removals in a single atomic transaction.
+		if (!removals.empty()) {
+			auto &storage = lotman::db::StorageManager::get_storage();
+			using namespace sqlite_orm;
+			std::string txn_error;
+			bool committed = storage.transaction([&] {
+				try {
+					for (const auto &rm : removals) {
+						std::string normalized = lotman::ensure_trailing_slash(rm.path);
+						storage.remove_all<lotman::db::Path>(where(c(&lotman::db::Path::lot_name) == rm.lot_name and
+																   c(&lotman::db::Path::path) == normalized));
+					}
+				} catch (const std::exception &e) {
+					txn_error = e.what();
+					return false; // rollback
+				}
+				return true;
+			});
+
+			if (!committed) {
 				if (err_msg) {
-					std::string int_err = rp.second;
-					std::string ext_err = "Failed on call to lot.remove_paths: ";
-					*err_msg = strdup((ext_err + int_err).c_str());
+					*err_msg = strdup(txn_error.empty() ? "Transaction failed" : txn_error.c_str());
 				}
 				return -1;
 			}
@@ -517,35 +570,49 @@ int lotman_add_to_lot(const char *lotman_JSON_str, char **err_msg) {
 			return -1;
 		}
 
-		// Start checking which keys to operate on
-		if (addition_obj.contains("parents")) {
-			std::vector<lotman::Lot> parent_lots;
-			for (const auto &parent_name : addition_obj["parents"]) {
-				lotman::Lot parent_lot(parent_name.get<std::string>());
-				parent_lots.push_back(parent_lot);
+		// Run all additions inside a single outer storage.transaction() so the
+		// envelope is atomic: a late failure (e.g. attribution validation)
+		// rolls back any preceding parent/path additions.
+		auto &storage = lotman::db::StorageManager::get_storage();
+		std::string txn_error;
+		bool committed = storage.transaction([&]() -> bool {
+			if (addition_obj.contains("parents")) {
+				std::vector<lotman::Lot> parent_lots;
+				for (const auto &parent_name : addition_obj["parents"]) {
+					lotman::Lot parent_lot(parent_name.get<std::string>());
+					parent_lots.push_back(parent_lot);
+				}
+
+				if (!lot.add_parents_in_txn(parent_lots, txn_error)) {
+					txn_error = "Failure to add parents: " + txn_error;
+					return false;
+				}
 			}
 
-			rp = lot.add_parents(parent_lots);
-			if (!rp.first) {
-				if (err_msg) {
-					std::string int_err = rp.second;
-					std::string ext_err = "Failure to add parents: ";
-					*err_msg = strdup((ext_err + int_err).c_str());
+			if (addition_obj.contains("paths")) {
+				if (!lot.add_paths_in_txn(addition_obj["paths"], txn_error)) {
+					txn_error = "Failure to add paths: " + txn_error;
+					return false;
 				}
-				return -1;
 			}
-		}
 
-		if (addition_obj.contains("paths")) {
-			rp = lot.add_paths(addition_obj["paths"]);
-			if (!rp.first) {
-				if (err_msg) {
-					std::string int_err = rp.second;
-					std::string ext_err = "Failure to add paths: ";
-					*err_msg = strdup((ext_err + int_err).c_str());
+			// `parent_attributions` runs last so any parents added above are visible
+			// when attributions are recomputed.
+			if (addition_obj.contains("parent_attributions")) {
+				if (!lot.update_attributions_in_txn(addition_obj["parent_attributions"], txn_error)) {
+					txn_error = "Failure to update parent attributions: " + txn_error;
+					return false;
 				}
-				return -1;
 			}
+
+			return true;
+		});
+
+		if (!committed) {
+			if (err_msg) {
+				*err_msg = strdup(txn_error.empty() ? "Add-to-lot transaction failed" : txn_error.c_str());
+			}
+			return -1;
 		}
 
 		return 0;
@@ -997,7 +1064,7 @@ int lotman_update_lot_usage(const char *update_JSON_str, bool deltaMode, char **
 	}
 }
 
-int lotman_update_lot_usage_by_dir(const char *update_JSON_str, bool deltaMode, char **err_msg) {
+int lotman_update_lot_usage_by_dir(const char *update_JSON_str, bool deltaMode, int64_t query_time, char **err_msg) {
 	try {
 		json update_JSON = json::parse(update_JSON_str);
 
@@ -1012,7 +1079,7 @@ int lotman_update_lot_usage_by_dir(const char *update_JSON_str, bool deltaMode, 
 			validator.validate(update);
 		}
 
-		auto rp = lotman::Lot::update_usage_by_dirs(update_JSON, deltaMode);
+		auto rp = lotman::Lot::update_usage_by_dirs(update_JSON, deltaMode, query_time);
 
 		if (!rp.first) {
 			if (err_msg) {
@@ -1202,7 +1269,7 @@ int lotman_get_lots_past_del(const bool recursive, char ***output, char **err_ms
 }
 
 int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_children, char ***output,
-							 char **err_msg) {
+							 const bool hierarchical, char **err_msg) {
 	try {
 		auto rp_bool_str = lotman::Lot::update_db_children_usage();
 		if (!rp_bool_str.first) {
@@ -1214,7 +1281,7 @@ int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_ch
 			return -1;
 		}
 
-		auto rp = lotman::Lot::get_lots_past_opp(recursive_quota, recursive_children);
+		auto rp = lotman::Lot::get_lots_past_opp(recursive_quota, recursive_children, hierarchical);
 		if (!rp.second.empty()) {
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -1251,7 +1318,7 @@ int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_ch
 }
 
 int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_children, char ***output,
-							 char **err_msg) {
+							 const bool hierarchical, char **err_msg) {
 	try {
 		auto rp_bool_str = lotman::Lot::update_db_children_usage();
 		if (!rp_bool_str.first) {
@@ -1263,7 +1330,7 @@ int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_ch
 			return -1;
 		}
 
-		auto rp = lotman::Lot::get_lots_past_ded(recursive_quota, recursive_children);
+		auto rp = lotman::Lot::get_lots_past_ded(recursive_quota, recursive_children, hierarchical);
 		if (!rp.second.empty()) {
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -1300,7 +1367,7 @@ int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_ch
 }
 
 int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_children, char ***output,
-							 char **err_msg) {
+							 const bool hierarchical, char **err_msg) {
 	try {
 		auto rp_bool_str = lotman::Lot::update_db_children_usage();
 		if (!rp_bool_str.first) {
@@ -1312,7 +1379,7 @@ int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_ch
 			return -1;
 		}
 
-		auto rp = lotman::Lot::get_lots_past_obj(recursive_quota, recursive_children);
+		auto rp = lotman::Lot::get_lots_past_obj(recursive_quota, recursive_children, hierarchical);
 		if (!rp.second.empty()) {
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -1339,6 +1406,46 @@ int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_ch
 			idx++;
 		}
 		*output = past_obj_lots_c;
+		return 0;
+	} catch (std::exception &exc) {
+		if (err_msg) {
+			*err_msg = strdup(exc.what());
+		}
+		return -1;
+	}
+}
+
+int lotman_get_available_capacity(const char *parent_lot_name, int64_t start_time, int64_t end_time, char **output,
+								  char **err_msg) {
+	try {
+		if (!parent_lot_name) {
+			if (err_msg) {
+				*err_msg = strdup("parent_lot_name must not be a null pointer.");
+			}
+			return -1;
+		}
+		if (!output) {
+			if (err_msg) {
+				*err_msg = strdup("output must not be a null pointer.");
+			}
+			return -1;
+		}
+
+		auto rp = lotman::Lot::get_available_capacity(parent_lot_name, start_time, end_time);
+		if (!rp.second.empty()) {
+			if (err_msg) {
+				*err_msg = strdup(rp.second.c_str());
+			}
+			return -1;
+		}
+
+		*output = strdup(rp.first.dump().c_str());
+		if (!*output) {
+			if (err_msg) {
+				*err_msg = strdup("Failed to allocate output buffer.");
+			}
+			return -1;
+		}
 		return 0;
 	} catch (std::exception &exc) {
 		if (err_msg) {
@@ -1570,10 +1677,11 @@ int lotman_get_lot_as_json(const char *lot_name, const bool recursive, char **ou
 	}
 }
 
-int lotman_get_lots_from_dir(const char *dir, const bool recursive, char ***output, char **err_msg) {
+int lotman_get_lots_from_dir(const char *dir, const bool recursive, int64_t query_time, char ***output,
+							 char **err_msg) {
 	try {
 
-		auto rp = lotman::Lot::get_lots_from_dir(dir, recursive);
+		auto rp = lotman::Lot::get_lots_from_dir(dir, recursive, query_time);
 		if (!rp.second.empty()) { // There was an error
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -1622,6 +1730,36 @@ int lotman_set_context_str(const char *key, const char *value, char **err_msg) {
 			lotman::Context::set_caller(value);
 		} else if (strcmp(key, "lot_home") == 0) {
 			lotman::Context::set_lot_home(value);
+		} else if (strcmp(key, "strict_hierarchy") == 0) {
+			if (strcmp(value, "true") == 0 || strcmp(value, "1") == 0) {
+				lotman::Context::set_strict_hierarchy(true);
+			} else if (strcmp(value, "false") == 0 || strcmp(value, "0") == 0) {
+				lotman::Context::set_strict_hierarchy(false);
+			} else {
+				if (err_msg) {
+					*err_msg = strdup("Value for strict_hierarchy must be 'true', 'false', '1', or '0'.");
+				}
+				return -1;
+			}
+		} else if (strcmp(key, "contraction_policy") == 0) {
+			auto rv = lotman::Context::set_contraction_policy(value);
+			if (!rv.first) {
+				if (err_msg) {
+					*err_msg = strdup(rv.second.c_str());
+				}
+				return -1;
+			}
+		} else if (strcmp(key, "admin_override") == 0) {
+			if (strcmp(value, "true") == 0 || strcmp(value, "1") == 0) {
+				lotman::Context::set_admin_override(true);
+			} else if (strcmp(value, "false") == 0 || strcmp(value, "0") == 0) {
+				lotman::Context::set_admin_override(false);
+			} else {
+				if (err_msg) {
+					*err_msg = strdup("Value for admin_override must be 'true', 'false', '1', or '0'.");
+				}
+				return -1;
+			}
 		}
 
 		else {
@@ -1653,6 +1791,12 @@ int lotman_get_context_str(const char *key, char **output, char **err_msg) {
 			*output = strdup(lotman::Context::get_caller().c_str());
 		} else if (strcmp(key, "lot_home") == 0) {
 			*output = strdup(lotman::Context::get_lot_home().c_str());
+		} else if (strcmp(key, "strict_hierarchy") == 0) {
+			*output = strdup(lotman::Context::get_strict_hierarchy() ? "true" : "false");
+		} else if (strcmp(key, "contraction_policy") == 0) {
+			*output = strdup(lotman::Context::get_contraction_policy().c_str());
+		} else if (strcmp(key, "admin_override") == 0) {
+			*output = strdup(lotman::Context::get_admin_override() ? "true" : "false");
 		} else {
 			if (err_msg) {
 				std::string err = "Unrecognized key: " + static_cast<std::string>(key);

--- a/src/lotman.h
+++ b/src/lotman.h
@@ -91,9 +91,12 @@ int lotman_add_lot(const char *lotman_JSON_str, char **err_msg);
 		"max_num_objects": An int64 indicating the maxiximum number of objects a lot may have attributed to it.
 		"creation_time":
 			REQUIRED: A Unix timestamp in milliseconds indicating when the lot should begin its existence.
+			The lot is considered active starting at this time (inclusive). Together with expiration_time,
+			this defines a half-open interval [creation_time, expiration_time).
 		"expiration_time":
-			REQUIRED: A Unix timestamp in milliseconds indicating when the lot "expires". In a similar vein
-			as opp storage, a lot and its storage become transient after its expiration time has passed. If
+			REQUIRED: A Unix timestamp in milliseconds indicating when the lot "expires". The lot is
+			considered active up to, but not including, this time (half-open interval). In a similar vein
+			as opp storage, a lot and its storage become transient once expiration time is reached. If
 			the system determines there is unused space, the lot may continue to exist, but all storage tied
 			to the lot should be considered opportunistic.
 		"deletion_time":
@@ -213,6 +216,12 @@ int lotman_update_lot(const char *lotman_JSON_str, char **err_msg);
 			"deletion_time":
 				OPTIONAL: A Unix timestamp in milliseconds indicating the lot's new deletion time.
 		}
+	"parent_attributions":
+		OPTIONAL: An object specifying how each parent's allocation is attributed to this lot.
+		Wholesale-replace semantics: any parent omitted from this object receives the equal-split
+		remainder of the child's MPAs. When strict_hierarchy is enabled, Axioms 1 and 2 are
+		re-validated after the update; failure rolls back the attribution writes.
+		Form: {"parent_name": {"dedicated_GB": 2.5, "opportunistic_GB": 1.0, "max_num_objects": 10}, ...}
 }
 */
 
@@ -292,6 +301,12 @@ int lotman_add_to_lot(const char *additions_JSON_str, char **err_msg);
 	"parents":
 		OPTIONAL: An array of strings indicating the new parents to be added to the lot. These
 		parents must be existing, valid lot names.
+	"parent_attributions":
+		OPTIONAL: An object specifying how each parent's allocation is attributed to this lot.
+		Processed after `parents`, so newly added parents may appear here. Wholesale-replace
+		semantics: any parent omitted from this object receives the equal-split remainder of the
+		child's MPAs. When strict_hierarchy is enabled, Axioms 1 and 2 are re-validated.
+		Form: {"parent_name": {"dedicated_GB": 2.5, "opportunistic_GB": 1.0, "max_num_objects": 10}, ...}
 }
 */
 
@@ -580,7 +595,7 @@ int lotman_update_lot_usage(const char *update_JSON_str, bool delta_mode, char *
 }
 */
 
-int lotman_update_lot_usage_by_dir(const char *update_JSON_str, bool delta_mode, char **err_msg);
+int lotman_update_lot_usage_by_dir(const char *update_JSON_str, bool delta_mode, int64_t query_time, char **err_msg);
 /**
 	DESCRIPTION: A function for reporting lot usage metrics to LotMan by directory tree. Unlike
 		lotman_update_lot_usage, this function only takes a JSON-encoded directory tree, with no
@@ -689,7 +704,8 @@ int lotman_get_lots_past_del(const bool recursive, char ***output, char **err_ms
 		A reference to a char array that can store any error messages.
 */
 
-int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_children, char ***output, char **err_msg);
+int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_children, char ***output,
+							 const bool hierarchical, char **err_msg);
 /**
 	DESCRIPTION: A function for determining all lots in the database that are past their opportunistic storage.
 		The function can determine which lots meet this criteria either by looking at the opportunistic storage
@@ -714,11 +730,19 @@ int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_ch
 		A reference to a char ** for storing an array of lots passed their opportunistic storage quota.
 		NOTE: Requires the use of lotman_free_string_list to free the memory allocated for this array.
 
+	hierarchical:
+		A boolean indicating whether the query should use hierarchy-aware adjusted usage.
+		When true, a parent's usage is adjusted by adding any overage from its children
+		(usage exceeding the child's own threshold). Results are returned depth-ordered
+		(deepest/leaf lots first). When true, recursive_quota and recursive_children
+		are not used by the hierarchical query path.
+
 	err_msg:
 		A reference to a char array that can store any error messages.
 */
 
-int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_children, char ***output, char **err_msg);
+int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_children, char ***output,
+							 const bool hierarchical, char **err_msg);
 /**
 	DESCRIPTION: A function for determining all lots in the database that are past their dedicated storage.
 		The function can determine which lots meet this criteria either by looking at the dedicated storage
@@ -743,11 +767,19 @@ int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_ch
 		A reference to a char ** for storing an array of lots passed their dedicated storage quota.
 		NOTE: Requires the use of lotman_free_string_list to free the memory allocated for this array.
 
+	hierarchical:
+		A boolean indicating whether the query should use hierarchy-aware adjusted usage.
+		When true, a parent's usage is adjusted by adding any overage from its children
+		(usage exceeding the child's own threshold). Results are returned depth-ordered
+		(deepest/leaf lots first). When true, recursive_quota and recursive_children
+		are not used by the hierarchical query path.
+
 	err_msg:
 		A reference to a char array that can store any error messages.
 */
 
-int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_children, char ***output, char **err_msg);
+int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_children, char ***output,
+							 const bool hierarchical, char **err_msg);
 /**
 	DESCRIPTION: A function for determining all lots in the database that are past their object storage quota.
 		The function can determine which lots meet this criteria either by looking at the object storage quota
@@ -772,8 +804,62 @@ int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_ch
 		A reference to a char ** for storing an array of lots passed their opportunistic storage quota.
 		NOTE: Requires the use of lotman_free_string_list to free the memory allocated for this array.
 
+	hierarchical:
+		A boolean indicating whether the query should use hierarchy-aware adjusted usage.
+		When true, a parent's usage is adjusted by adding any overage from its children
+		(usage exceeding the child's own threshold). Results are returned depth-ordered
+		(deepest/leaf lots first). When true, recursive_quota and recursive_children
+		are not used by the hierarchical query path.
+
 	err_msg:
 		A reference to a char array that can store any error messages.
+*/
+
+int lotman_get_available_capacity(const char *parent_lot_name, int64_t start_time, int64_t end_time, char **output,
+								  char **err_msg);
+/**
+	DESCRIPTION: Compute available and peak capacity under a parent lot during a time window.
+		Sums each child's parent_attributions over the supplied window using a sweep-line
+		algorithm that accounts for overlapping active intervals, then subtracts the peak
+		concurrent usage from the parent's MPAs.
+
+		WARNING: This is an *advisory* query, not a reservation mechanism. Reservation
+		enforcement is performed atomically by Axiom 2 inside the lot-creation transaction
+		when strict_hierarchy is enabled, so another caller may legitimately claim capacity
+		between this query and the subsequent create.
+
+	RETURNS: Returns 0 on success. Any other values indicate an error.
+
+	INPUTS:
+	parent_lot_name:
+		The name of the parent lot whose capacity should be queried.
+
+	start_time:
+		Beginning of the query window, as a Unix timestamp in milliseconds (inclusive).
+
+	end_time:
+		End of the query window, as a Unix timestamp in milliseconds (exclusive). Children
+		whose active intervals overlap [start_time, end_time) are clipped to that window
+		before being summed.
+
+	output:
+		A reference to a char * for storing the result, formatted as a JSON object (see
+		specification below).
+		NOTE: The caller owns the returned string and must free() it.
+
+	err_msg:
+		A reference to a char array that can store any error messages.
+
+	Output JSON Specification:
+{   "available_dedicated_GB":     <number>,  // parent dedicated_GB minus peak concurrent attributed dedicated_GB
+	"available_opportunistic_GB": <number>,  // analogous for opportunistic_GB
+	"available_max_num_objects":  <int64>,   // analogous for max_num_objects
+	"available_total_GB":         <number>,  // (parent dedicated_GB + opportunistic_GB) minus peak (ded+opp)
+	"peak_dedicated_GB":          <number>,
+	"peak_opportunistic_GB":      <number>,
+	"peak_max_num_objects":       <int64>,
+	"peak_total_GB":              <number>   // peak (ded+opp) at any single instant in the window
+}
 */
 
 int lotman_list_all_lots(char ***output, char **err_msg);
@@ -843,7 +929,7 @@ for the 'recursive' flag. When recursive is true, each MPA will contain a JSON o
 }
 */
 
-int lotman_get_lots_from_dir(const char *dir, const bool recursive, char ***output, char **err_msg);
+int lotman_get_lots_from_dir(const char *dir, const bool recursive, int64_t query_time, char ***output, char **err_msg);
 /**
 	DESCRIPTION: A function for getting any lots associated with the supplied path. The function can
 		return either solely the lot tracking the path, or any parent lots who might also be affected

--- a/src/lotman_db.cpp
+++ b/src/lotman_db.cpp
@@ -81,19 +81,18 @@ void migrate_db(Storage &storage, int current_version, int target_version) {
 				// 2. The 'exclude' column is added to the paths table by sync_schema().
 				//    This supports path exclusions where a lot can track /foo recursively
 				//    but exclude /foo/bar from that tracking.
+				// 3. The paths table uses a composite primary key (lot_name, path) instead
+				//    of unique(path), allowing different lots to share paths with
+				//    non-overlapping time ranges.
+				// 4. The parent_child_attributions table is created by sync_schema().
 				//
 				// v0 databases are those created before the schema_versions table existed.
 				// They may have paths stored without trailing slashes.
 				//
-				// Note: This iterates through paths and issues individual UPDATE statements.
-				// While a single raw SQL UPDATE would be more efficient, this approach:
-				// 1. Uses the ORM consistently with the rest of the codebase
-				// 2. Only runs once per database (on upgrade from v0)
-				// 3. The paths table is typically small enough that this is acceptable
-				//
-				// Note: The 'exclude' column is added automatically by sync_schema() which
-				// is called before migrations. New columns with default values are handled
-				// safely by SQLite's ALTER TABLE ADD COLUMN.
+				// Note: The constraint change on paths (unique→composite PK) requires
+				// recreating the table. Since this version is unreleased, sync_schema()
+				// handles this. For pre-existing test databases, a manual DB reset may
+				// be needed.
 				using namespace sqlite_orm;
 
 				// Normalize paths with trailing slashes
@@ -825,50 +824,57 @@ std::pair<std::vector<std::vector<std::string>>, std::string> SQL_get_matches_mu
 // Implementation of Lot and Checks database methods
 
 std::pair<bool, std::string> Lot::write_new() {
+	// Note: caller (store_lot) must wrap this in a transaction.
 	try {
 		auto &storage = db::StorageManager::get_storage();
 
-		// Use a transaction for atomicity
-		storage.transaction([&] {
-			// Use replace() for tables with text primary keys
-			db::Owner owner_record{lot_name, owner};
-			storage.replace(owner_record);
+		db::Owner owner_record{lot_name, owner};
+		storage.replace(owner_record);
 
-			// Insert parents
-			for (const auto &parent : parents) {
-				db::Parent parent_record{lot_name, parent};
-				storage.replace(parent_record);
+		for (const auto &parent : parents) {
+			db::Parent parent_record{lot_name, parent};
+			storage.replace(parent_record);
+		}
+
+		// Temporal overlap check: ensure no other lot claims the same path
+		// during an overlapping time period before inserting paths.
+		for (const auto &path_json : paths) {
+			std::string path_str = path_json.at("path").get<std::string>();
+			std::string normalized = ensure_trailing_slash(path_str);
+			bool exclude = path_json.contains("exclude") ? path_json["exclude"].get<bool>() : false;
+
+			if (!exclude) {
+				auto overlap = check_path_temporal_overlap(lot_name, normalized, man_policy_attr.creation_time,
+														   man_policy_attr.expiration_time);
+				if (!overlap.first) {
+					return overlap;
+				}
 			}
+		}
 
-			// Insert paths
-			for (const auto &path : paths) {
-				storage.replace(db::create_path_record(lot_name, path));
-			}
+		for (const auto &path : paths) {
+			storage.replace(db::create_path_record(lot_name, path));
+		}
 
-			// Insert management policy attributes
-			db::ManagementPolicyAttributes mpa{lot_name,
-											   man_policy_attr.dedicated_GB,
-											   man_policy_attr.opportunistic_GB,
-											   man_policy_attr.max_num_objects,
-											   man_policy_attr.creation_time,
-											   man_policy_attr.expiration_time,
-											   man_policy_attr.deletion_time};
-			storage.replace(mpa);
+		db::ManagementPolicyAttributes mpa{lot_name,
+										   man_policy_attr.dedicated_GB,
+										   man_policy_attr.opportunistic_GB,
+										   man_policy_attr.max_num_objects,
+										   man_policy_attr.creation_time,
+										   man_policy_attr.expiration_time,
+										   man_policy_attr.deletion_time};
+		storage.replace(mpa);
 
-			// Insert initial usage (all zeros)
-			db::LotUsage usage_record{lot_name,
-									  usage.self_GB,
-									  usage.children_GB,
-									  usage.self_objects,
-									  usage.children_objects,
-									  usage.self_GB_being_written,
-									  usage.children_GB_being_written,
-									  usage.self_objects_being_written,
-									  usage.children_objects_being_written};
-			storage.replace(usage_record);
-
-			return true; // Commit transaction
-		});
+		db::LotUsage usage_record{lot_name,
+								  usage.self_GB,
+								  usage.children_GB,
+								  usage.self_objects,
+								  usage.children_objects,
+								  usage.self_GB_being_written,
+								  usage.children_GB_being_written,
+								  usage.self_objects_being_written,
+								  usage.children_objects_being_written};
+		storage.replace(usage_record);
 
 		return std::make_pair(true, "");
 	} catch (const std::exception &e) {
@@ -877,22 +883,26 @@ std::pair<bool, std::string> Lot::write_new() {
 }
 
 std::pair<bool, std::string> Lot::delete_lot_from_db() {
+	// Note: caller (destroy_lot, destroy_lot_recursive) must wrap this in a transaction.
 	try {
 		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
 
-		storage.transaction([&] {
-			using namespace sqlite_orm;
+		// Delete from all tables where lot_name matches
+		storage.remove_all<db::Owner>(where(c(&db::Owner::lot_name) == lot_name));
+		storage.remove_all<db::Parent>(where(c(&db::Parent::lot_name) == lot_name));
+		storage.remove_all<db::Path>(where(c(&db::Path::lot_name) == lot_name));
+		storage.remove_all<db::ManagementPolicyAttributes>(
+			where(c(&db::ManagementPolicyAttributes::lot_name) == lot_name));
+		storage.remove_all<db::LotUsage>(where(c(&db::LotUsage::lot_name) == lot_name));
 
-			// Delete from all tables where lot_name matches
-			storage.remove_all<db::Owner>(where(c(&db::Owner::lot_name) == lot_name));
-			storage.remove_all<db::Parent>(where(c(&db::Parent::lot_name) == lot_name));
-			storage.remove_all<db::Path>(where(c(&db::Path::lot_name) == lot_name));
-			storage.remove_all<db::ManagementPolicyAttributes>(
-				where(c(&db::ManagementPolicyAttributes::lot_name) == lot_name));
-			storage.remove_all<db::LotUsage>(where(c(&db::LotUsage::lot_name) == lot_name));
+		// Remove attributions where this lot is child or parent
+		storage.remove_all<db::ParentChildAttribution>(
+			where(c(&db::ParentChildAttribution::child_lot_name) == lot_name or
+				  c(&db::ParentChildAttribution::parent_lot_name) == lot_name));
 
-			return true; // Commit
-		});
+		// Remove dangling parent references from other lots that had this lot as a parent
+		storage.remove_all<db::Parent>(where(c(&db::Parent::parent) == lot_name));
 
 		return std::make_pair(true, "");
 	} catch (const std::exception &e) {
@@ -970,36 +980,45 @@ std::pair<bool, std::string> Lot::store_updates(const std::string &update_stmt,
 	}
 }
 
-std::pair<bool, std::string> Lot::store_new_paths(const std::vector<nlohmann::json> &new_paths) {
-	try {
-		auto &storage = db::StorageManager::get_storage();
+std::pair<bool, std::string> Lot::check_path_temporal_overlap(const std::string &lot_name,
+															  const std::string &normalized_path, int64_t creation_time,
+															  int64_t expiration_time) {
+	// Single JOIN query replaces the previous N+1 pattern (one SELECT for
+	// candidate lots, plus one get_pointer per candidate).
+	std::string query = "SELECT p.lot_name, mpa.creation_time, mpa.expiration_time "
+						"FROM paths p "
+						"JOIN management_policy_attributes mpa ON p.lot_name = mpa.lot_name "
+						"WHERE p.path = ?1 AND p.lot_name != ?2 AND p.exclude = 0 "
+						"AND ?3 < mpa.expiration_time AND mpa.creation_time < ?4 "
+						"LIMIT 1;";
+	std::map<std::string, std::vector<int>> str_map{{normalized_path, {1}}, {lot_name, {2}}};
+	std::map<int64_t, std::vector<int>> int_map{{creation_time, {3}}, {expiration_time, {4}}};
+	auto rp = db::SQL_get_matches_multi_col(query, 3, str_map, int_map);
 
-		// Use transaction for batch insert atomicity
-		storage.transaction([&] {
-			for (const auto &path : new_paths) {
-				storage.replace(db::create_path_record(lot_name, path));
-			}
-			return true; // Commit
-		});
-
-		return std::make_pair(true, "");
-	} catch (const std::exception &e) {
-		return std::make_pair(false, std::string("Failed to store new paths: ") + e.what());
+	if (!rp.second.empty()) {
+		return std::make_pair(false, "Temporal overlap check failed: " + rp.second);
 	}
+
+	if (!rp.first.empty()) {
+		const auto &row = rp.first[0];
+		return std::make_pair(false, "Path '" + normalized_path + "' has a temporal overlap with lot '" + row[0] +
+										 "'. Time ranges (treated as half-open intervals [start, end)) overlap: [" +
+										 std::to_string(creation_time) + ", " + std::to_string(expiration_time) +
+										 ") vs [" + row[1] + ", " + row[2] + ").");
+	}
+
+	return std::make_pair(true, "");
 }
 
 std::pair<bool, std::string> Lot::store_new_parents(const std::vector<Lot> &new_parents) {
+	// Note: caller (add_parents) must wrap this in a transaction.
 	try {
 		auto &storage = db::StorageManager::get_storage();
 
-		// Use transaction for batch insert atomicity
-		storage.transaction([&] {
-			for (const auto &parent : new_parents) {
-				db::Parent parent_record{lot_name, parent.lot_name};
-				storage.replace(parent_record);
-			}
-			return true; // Commit
-		});
+		for (const auto &parent : new_parents) {
+			db::Parent parent_record{lot_name, parent.lot_name};
+			storage.replace(parent_record);
+		}
 
 		return std::make_pair(true, "");
 	} catch (const std::exception &e) {
@@ -1008,18 +1027,15 @@ std::pair<bool, std::string> Lot::store_new_parents(const std::vector<Lot> &new_
 }
 
 std::pair<bool, std::string> Lot::remove_parents_from_db(const std::vector<std::string> &parents) {
+	// Note: caller (remove_parents) must wrap this in a transaction.
 	try {
 		auto &storage = db::StorageManager::get_storage();
 		using namespace sqlite_orm;
 
-		// Use transaction for batch delete atomicity
-		storage.transaction([&] {
-			for (const auto &parent : parents) {
-				storage.remove_all<db::Parent>(
-					where(c(&db::Parent::lot_name) == lot_name and c(&db::Parent::parent) == parent));
-			}
-			return true; // Commit
-		});
+		for (const auto &parent : parents) {
+			storage.remove_all<db::Parent>(
+				where(c(&db::Parent::lot_name) == lot_name and c(&db::Parent::parent) == parent));
+		}
 
 		return std::make_pair(true, "");
 	} catch (const std::exception &e) {
@@ -1037,8 +1053,9 @@ std::pair<bool, std::string> Lot::remove_paths_from_db(const std::vector<std::st
 			for (const auto &path : paths) {
 				// Normalize path with trailing slash to match stored format
 				std::string normalized_path = ensure_trailing_slash(path);
-				// Paths are unique, so we don't need lot_name in the condition
-				storage.remove_all<db::Path>(where(c(&db::Path::path) == normalized_path));
+				// Paths are keyed by composite (lot_name, path)
+				storage.remove_all<db::Path>(
+					where(c(&db::Path::lot_name) == lot_name and c(&db::Path::path) == normalized_path));
 			}
 			return true; // Commit
 		});

--- a/src/lotman_db.h
+++ b/src/lotman_db.h
@@ -118,6 +118,18 @@ struct SchemaVersion {
 };
 
 /**
+ * Tracks how a child lot's MPA values are attributed across its parents.
+ * Each row describes a (child, parent, MPA_key) triple and the fraction
+ * of the child's MPA that is counted against that parent.
+ */
+struct ParentChildAttribution {
+	std::string child_lot_name;
+	std::string parent_lot_name;
+	std::string mpa_key; // e.g. "dedicated_GB", "opportunistic_GB", "max_num_objects"
+	double fraction;	 // 0.0 to 1.0, how much of child's MPA is attributed to this parent
+};
+
+/**
  * Creates the sqlite_orm storage definition.
  * This defines the schema mapping between C++ structs and SQLite tables.
  */
@@ -132,9 +144,9 @@ inline auto create_storage(const std::string &db_path) {
 				   make_column("owner", &Owner::owner)),
 		make_table("parents", make_column("lot_name", &Parent::lot_name), make_column("parent", &Parent::parent),
 				   primary_key(&Parent::lot_name, &Parent::parent)),
-		make_table("paths", make_column("lot_name", &Path::lot_name), make_column("path", &Path::path, unique()),
-				   make_column("recursive", &Path::recursive),
-				   make_column("exclude", &Path::exclude, default_value(0))),
+		make_table("paths", make_column("lot_name", &Path::lot_name), make_column("path", &Path::path),
+				   make_column("recursive", &Path::recursive), make_column("exclude", &Path::exclude, default_value(0)),
+				   primary_key(&Path::lot_name, &Path::path)),
 		make_table("management_policy_attributes",
 				   make_column("lot_name", &ManagementPolicyAttributes::lot_name, primary_key()),
 				   make_column("dedicated_GB", &ManagementPolicyAttributes::dedicated_GB),
@@ -150,7 +162,13 @@ inline auto create_storage(const std::string &db_path) {
 				   make_column("self_GB_being_written", &LotUsage::self_GB_being_written),
 				   make_column("children_GB_being_written", &LotUsage::children_GB_being_written),
 				   make_column("self_objects_being_written", &LotUsage::self_objects_being_written),
-				   make_column("children_objects_being_written", &LotUsage::children_objects_being_written)));
+				   make_column("children_objects_being_written", &LotUsage::children_objects_being_written)),
+		make_table("parent_child_attributions", make_column("child_lot_name", &ParentChildAttribution::child_lot_name),
+				   make_column("parent_lot_name", &ParentChildAttribution::parent_lot_name),
+				   make_column("mpa_key", &ParentChildAttribution::mpa_key),
+				   make_column("fraction", &ParentChildAttribution::fraction),
+				   primary_key(&ParentChildAttribution::child_lot_name, &ParentChildAttribution::parent_lot_name,
+							   &ParentChildAttribution::mpa_key)));
 }
 
 // Type alias for the storage type

--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -2,12 +2,133 @@
 
 #include "lotman_db.h"
 
+#include <algorithm>
 #include <chrono>
+#include <cmath>
+#include <functional>
 #include <nlohmann/json.hpp>
+#include <set>
 #include <sys/stat.h>
 
 using json = nlohmann::json;
 using namespace lotman;
+
+namespace {
+
+// Sweep-line event representing a change in concurrent resource usage at a point in time.
+struct SweepEvent {
+	int64_t time;
+	double delta_ded;
+	double delta_opp;
+	double delta_obj;
+	bool is_start; // true=addition, false=removal (used for tie-breaking)
+};
+
+// Peak concurrent resource usage found by the sweep-line.
+struct SweepResult {
+	double peak_ded = 0.0;
+	double peak_opp = 0.0;
+	double peak_obj = 0.0;
+	double peak_total = 0.0; // peak of (ded + opp) at a single point in time
+};
+
+// Sort events and sweep to find peak concurrent usage.
+// Events are sorted by time, with removals before additions at the same time.
+SweepResult run_sweep_line(std::vector<SweepEvent> &events) {
+	std::sort(events.begin(), events.end(), [](const SweepEvent &a, const SweepEvent &b) {
+		if (a.time != b.time)
+			return a.time < b.time;
+		return a.is_start < b.is_start; // false (removal) < true (addition)
+	});
+
+	double cur_ded = 0.0, cur_opp = 0.0, cur_obj = 0.0;
+	SweepResult result;
+
+	for (const auto &ev : events) {
+		cur_ded += ev.delta_ded;
+		cur_opp += ev.delta_opp;
+		cur_obj += ev.delta_obj;
+
+		if (cur_ded > result.peak_ded)
+			result.peak_ded = cur_ded;
+		if (cur_opp > result.peak_opp)
+			result.peak_opp = cur_opp;
+		if (cur_obj > result.peak_obj)
+			result.peak_obj = cur_obj;
+
+		double cur_total = cur_ded + cur_opp;
+		if (cur_total > result.peak_total)
+			result.peak_total = cur_total;
+	}
+	return result;
+}
+
+// Helper to build sweep events from a parent's children's attributions.
+// If time window is specified (start_time < end_time), events are clipped to [start_time, end_time).
+// Returns events vector (may be empty if no children or none overlap window).
+std::vector<SweepEvent> build_attribution_events(const std::string &parent_lot_name, int64_t start_time = 0,
+												 int64_t end_time = 0) {
+	auto &storage = db::StorageManager::get_storage();
+	using namespace sqlite_orm;
+
+	std::vector<SweepEvent> events;
+	bool has_window = (start_time < end_time);
+
+	// Get all children of this parent (non-self)
+	auto child_names = storage.select(&db::Parent::lot_name, where(c(&db::Parent::parent) == parent_lot_name and
+																   c(&db::Parent::lot_name) != parent_lot_name));
+
+	for (const auto &child_name : child_names) {
+		auto child_mpa = storage.get_pointer<db::ManagementPolicyAttributes>(child_name);
+		if (!child_mpa)
+			continue;
+
+		// If window specified, skip children that don't overlap it
+		if (has_window && (child_mpa->creation_time >= end_time || child_mpa->expiration_time <= start_time))
+			continue;
+
+		// Get attributions from this parent to this child
+		auto attrs = storage.get_all<db::ParentChildAttribution>(
+			where(c(&db::ParentChildAttribution::parent_lot_name) == parent_lot_name and
+				  c(&db::ParentChildAttribution::child_lot_name) == child_name));
+
+		// Compute attributed fractions
+		std::map<std::string, double> fractions;
+		for (const auto &attr : attrs) {
+			fractions[attr.mpa_key] = attr.fraction;
+		}
+
+		// Fail fast if attribution rows are missing for an active child-parent edge
+		// when strict hierarchy is enabled
+		if (attrs.empty() && lotman::Context::get_strict_hierarchy()) {
+			throw std::runtime_error("Missing attribution rows for child '" + child_name + "' under parent '" +
+									 parent_lot_name + "'");
+		}
+
+		double attr_ded =
+			fractions.count("dedicated_GB") ? fractions.at("dedicated_GB") * child_mpa->dedicated_GB : 0.0;
+		double attr_opp =
+			fractions.count("opportunistic_GB") ? fractions.at("opportunistic_GB") * child_mpa->opportunistic_GB : 0.0;
+		double attr_obj = fractions.count("max_num_objects")
+							  ? std::round(fractions.at("max_num_objects") * child_mpa->max_num_objects)
+							  : 0.0;
+
+		// Determine event times: use child's full interval or clip to window
+		int64_t event_start = child_mpa->creation_time;
+		int64_t event_end = child_mpa->expiration_time;
+		if (has_window) {
+			event_start = std::max(event_start, start_time);
+			event_end = std::min(event_end, end_time);
+		}
+
+		events.push_back({event_start, attr_ded, attr_opp, attr_obj, true});
+		events.push_back({event_end, -attr_ded, -attr_opp, -attr_obj, false});
+	}
+
+	return events;
+}
+
+} // anonymous namespace
 
 // TODO: Go through and make things const where they should be declared as such
 // TODO: Optimize functions that instantiate a whole lot, when that isn't really needed
@@ -33,6 +154,12 @@ std::pair<bool, std::string> lotman::Lot::init_full(json lot_JSON) {
 	man_policy_attr.creation_time = lot_JSON["management_policy_attrs"]["creation_time"];
 	man_policy_attr.expiration_time = lot_JSON["management_policy_attrs"]["expiration_time"];
 	man_policy_attr.deletion_time = lot_JSON["management_policy_attrs"]["deletion_time"];
+
+	// Half-open interval [creation_time, expiration_time) must be non-empty
+	if (man_policy_attr.creation_time >= man_policy_attr.expiration_time) {
+		return std::make_pair(false, "creation_time must be strictly less than expiration_time (half-open interval "
+									 "[creation, expiration) must be non-empty)");
+	}
 
 	usage.self_GB = 0;
 	usage.children_GB = 0;
@@ -74,7 +201,7 @@ void lotman::Lot::init_self_usage() {
 	usage.children_objects_being_written = 0;
 }
 
-std::pair<bool, std::string> lotman::Lot::store_lot() {
+std::pair<bool, std::string> lotman::Lot::store_lot(const json &parent_attributions_json) {
 	if (!full_lot) {
 		return std::make_pair(false, "Lot was not fully initialized");
 	}
@@ -111,35 +238,60 @@ std::pair<bool, std::string> lotman::Lot::store_lot() {
 		}
 	}
 
-	// Store the lot, begin updating other lots after confirming the lot has been successfully stored
-	auto rp = this->write_new();
-	if (!rp.first) {
-		std::string int_err = rp.second;
-		std::string ext_err = "Failure to store new lot: ";
-		return std::make_pair(false, ext_err + int_err);
-	}
+	// Store lot, compute attributions, and validate in a single transaction.
+	// If any step fails, all DB changes are rolled back atomically.
+	{
+		auto &storage = db::StorageManager::get_storage();
+		std::string txn_error;
+		bool committed = storage.transaction([&] {
+			auto rp_inner = this->write_new();
+			if (!rp_inner.first) {
+				txn_error = "Failure to store new lot: " + rp_inner.second;
+				return false;
+			}
 
-	bool parent_updated = true;
-	for (auto &parents_iter : parents) {
-		for (auto &children_iter : children) {
-			if (lotman::Checks::insertion_check(lot_name, parents_iter, children_iter)) {
-				// Update child to have lot_name as a parent instead of parents_iter. Later, save LTBA with all its
-				// specified parents.
-				Lot child(children_iter);
+			if (lot_name != "default") {
+				rp_inner = compute_and_store_attributions(parent_attributions_json);
+				if (!rp_inner.first) {
+					txn_error = "Failed to compute attributions: " + rp_inner.second;
+					return false;
+				}
 
-				json update_arr = json::array();
-				update_arr.push_back({{"current", parents_iter}, {"new", lot_name}});
-
-				rp = child.update_parents(update_arr);
-				parent_updated = rp.first;
-				if (!parent_updated) {
-					std::string int_err = rp.second;
-					std::string ext_err = "Failure on call to child.update_parents: ";
-					return std::make_pair(false, ext_err + int_err);
+				auto vr = apply_validation_predicates(build_axiom_predicates(lot_name));
+				if (!vr.first) {
+					txn_error = vr.second;
+					return false;
 				}
 			}
+
+			// Insertion adjustment: if the new lot is being inserted between
+			// existing parent-child relationships, update children's parent pointers.
+			for (auto &parents_iter : parents) {
+				for (auto &children_iter : children) {
+					if (lotman::Checks::insertion_check(lot_name, parents_iter, children_iter)) {
+						Lot child(children_iter);
+						json update_arr = json::array();
+						update_arr.push_back({{"current", parents_iter}, {"new", lot_name}});
+						if (!child.update_parents_impl(update_arr, txn_error)) {
+							return false;
+						}
+						if (child.lot_name != "default") {
+							if (!child.reload_and_recompute_attributions(txn_error)) {
+								return false;
+							}
+						}
+					}
+				}
+			}
+
+			return true;
+		});
+
+		if (!committed) {
+			return std::make_pair(false, txn_error.empty() ? "Transaction failed" : txn_error);
 		}
 	}
+
 	return std::make_pair(true, "");
 }
 
@@ -197,6 +349,14 @@ std::pair<bool, std::string> lotman::Lot::destroy_lot() {
 		return std::make_pair(false, "The default lot cannot be deleted.");
 	}
 
+	// Contraction policy: deletion = contraction to zero
+	{
+		auto cp = check_contraction_for_deletion(lot_name);
+		if (!cp.first) {
+			return cp;
+		}
+	}
+
 	// Prechecks complete, get the children for LTBR
 	auto rp_lotvec_str = this->get_children();
 	if (!rp_lotvec_str.second.empty()) { // There is an error message
@@ -205,81 +365,77 @@ std::pair<bool, std::string> lotman::Lot::destroy_lot() {
 		return std::make_pair(false, ext_err + int_err);
 	}
 
-	// std::vector<Lot> children = rp_lotvec_str.first;
-	//  If there are no children, the lot can be deleted without issue
-	if (self_children.empty()) {
-		auto rp_bool_str = this->delete_lot_from_db();
-		if (!rp_bool_str.first) {
-			std::string int_err = rp_bool_str.second;
-			std::string ext_err = "Failed to delete the lot from the database: ";
-			return std::make_pair(false, ext_err + int_err);
-		}
-		return std::make_pair(true, "");
-	}
-
-	// Reaching this point means there are children --> Reassign them
-
+	// --- Read-only phase: determine which children need reparenting ---
+	std::vector<Lot *> children_to_reparent;
 	for (auto &child : self_children) {
-		if (lotman::Checks::will_be_orphaned(lot_name,
-											 child.lot_name)) { // Indicates whether LTBR is the only parent to child
-			if (reassignment_policy.assign_LTBR_parent_as_parent_to_orphans) {
-				auto rp_bool_str = this->check_if_root();
-				if (!rp_bool_str.second.empty()) {
-					std::string int_err = rp_bool_str.second;
-					std::string ext_err = "Function call to lotman::Lot::check_if_root failed: ";
-					return std::make_pair(false, ext_err + int_err);
-				}
-				if (is_root) {
-					return std::make_pair(
-						false, "The lot being removed is a root, and has no parents to assign to its children.");
-				}
-
-				// Since lots have only one explicit owner, we cannot reassign ownership.
-
-				// Generate parents of current lot for assignment to children -- only need immediate parents
-				this->get_parents();
-				// Now assign parents of LTBR to orphan children of LTBR
-				// No need to perform cycle check in this case
-				rp_bool_str = child.add_parents(self_parents);
-				if (!rp_bool_str.first) {
-					std::string int_err = rp_bool_str.second;
-					std::string ext_err = "Failure on call to lotman::Lot::add_parents for child lot: ";
-					return std::make_pair(false, ext_err + int_err);
-				}
-			} else {
-				return std::make_pair(false, "The operation cannot be completed as requested because deleting the lot "
-											 "would create an orphan that requires explicit assignment to the default "
-											 "lot. Set assign_LTBR_parent_as_parent_to_orphans=true.");
-			}
+		bool orphaned = lotman::Checks::will_be_orphaned(lot_name, child.lot_name);
+		if (orphaned && !reassignment_policy.assign_LTBR_parent_as_parent_to_orphans) {
+			return std::make_pair(false, "The operation cannot be completed as requested because deleting the lot "
+										 "would create an orphan that requires explicit assignment to the default "
+										 "lot. Set assign_LTBR_parent_as_parent_to_orphans=true.");
 		}
-		if (reassignment_policy.assign_LTBR_parent_as_parent_to_non_orphans) {
-			auto rp_bool_str = this->check_if_root();
-			if (!rp_bool_str.second.empty()) {
-				std::string int_err = rp_bool_str.second;
-				std::string ext_err = "Function call to lotman::Lot::check_if_root failed: ";
-				return std::make_pair(false, ext_err + int_err);
-			}
-			if (is_root) {
-				return std::make_pair(false,
-									  "The lot being removed is a root, and has no parents to assign to its children.");
-			}
-			this->get_parents();
-			// Now assign parents of LTBR to non-orphan children of LTBR
-			// No need to perform cycle check in this case
-			rp_bool_str = child.add_parents(self_parents);
-			if (!rp_bool_str.first) {
-				std::string int_err = rp_bool_str.second;
-				std::string ext_err = "Function call to lotman::Lot::add_parents for child lot failed: ";
-				return std::make_pair(false, ext_err + int_err);
-			}
+		if ((orphaned && reassignment_policy.assign_LTBR_parent_as_parent_to_orphans) ||
+			reassignment_policy.assign_LTBR_parent_as_parent_to_non_orphans) {
+			children_to_reparent.push_back(&child);
 		}
 	}
-	auto rp_bool_str = delete_lot_from_db();
-	if (!rp_bool_str.first) {
-		std::string int_err = rp_bool_str.second;
-		std::string ext_err = "Function call to lotman::Lot::delete_lot_from_db failed: ";
-		return std::make_pair(false, ext_err + int_err);
+
+	if (!children_to_reparent.empty()) {
+		auto rp_bool_str = this->check_if_root();
+		if (!rp_bool_str.second.empty()) {
+			return std::make_pair(false, "Function call to lotman::Lot::check_if_root failed: " + rp_bool_str.second);
+		}
+		if (is_root) {
+			return std::make_pair(false,
+								  "The lot being removed is a root, and has no parents to assign to its children.");
+		}
+		this->get_parents();
 	}
+
+	// --- Write phase: reparent children + delete LTBR in a single transaction ---
+	{
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+		std::string txn_error;
+		bool committed = storage.transaction([&] {
+			// Step 1: Add LTBR's parents to children that need reparenting
+			for (auto *child : children_to_reparent) {
+				auto rp = child->store_new_parents(self_parents);
+				if (!rp.first) {
+					txn_error = "Failed to add parents to child lot '" + child->lot_name + "': " + rp.second;
+					return false;
+				}
+			}
+
+			// Step 2: Delete LTBR (also cleans up reverse parent refs + attributions involving LTBR)
+			auto drp = delete_lot_from_db();
+			if (!drp.first) {
+				txn_error = "Failed to delete lot: " + drp.second;
+				return false;
+			}
+
+			// Step 3: Recompute attributions for ALL children that had LTBR as a parent.
+			// Reparented children had LTBR replaced by LTBR's parents; non-reparented
+			// children simply lost LTBR as a parent. In both cases the attribution
+			// rows referencing LTBR were deleted in Step 2, so the remaining
+			// attributions no longer sum correctly. Reload from DB and recompute.
+			for (auto &child : self_children) {
+				if (child.lot_name == "default")
+					continue;
+
+				if (!child.reload_and_recompute_attributions(txn_error)) {
+					return false;
+				}
+			}
+
+			return true;
+		});
+
+		if (!committed) {
+			return std::make_pair(false, txn_error.empty() ? "Transaction failed" : txn_error);
+		}
+	}
+
 	return std::make_pair(true, "");
 }
 
@@ -287,6 +443,14 @@ std::pair<bool, std::string> lotman::Lot::destroy_lot_recursive() {
 
 	if (lot_name == "default") {
 		return std::make_pair(false, "The default lot cannot be deleted.");
+	}
+
+	// Contraction policy: deletion = contraction to zero
+	{
+		auto cp = check_contraction_for_deletion(lot_name);
+		if (!cp.first) {
+			return cp;
+		}
 	}
 
 	// Prechecks complete, get the children for LTBR
@@ -297,15 +461,39 @@ std::pair<bool, std::string> lotman::Lot::destroy_lot_recursive() {
 		return std::make_pair(false, ext_err + int_err);
 	}
 
-	for (auto &child : recursive_children) {
-		auto rp_bool_str = child.delete_lot_from_db();
-		if (!rp_bool_str.first) {
-			std::string int_err = rp_bool_str.second;
-			std::string ext_err = "Failed to delete a lot from the database: ";
-			return std::make_pair(false, ext_err + int_err);
+	// Contraction policy must also be checked for every child in the subtree
+	for (const auto &child : recursive_children) {
+		auto cp = check_contraction_for_deletion(child.lot_name);
+		if (!cp.first) {
+			return cp;
 		}
 	}
-	this->delete_lot_from_db();
+
+	// Delete all children and self in a single atomic transaction.
+	{
+		auto &storage = db::StorageManager::get_storage();
+		std::string txn_error;
+		bool committed = storage.transaction([&] {
+			for (auto &child : recursive_children) {
+				auto rp_bool_str = child.delete_lot_from_db();
+				if (!rp_bool_str.first) {
+					txn_error = "Failed to delete child lot '" + child.lot_name + "': " + rp_bool_str.second;
+					return false;
+				}
+			}
+			auto rp_bool_str = this->delete_lot_from_db();
+			if (!rp_bool_str.first) {
+				txn_error = "Failed to delete lot '" + lot_name + "': " + rp_bool_str.second;
+				return false;
+			}
+			return true;
+		});
+
+		if (!committed) {
+			return std::make_pair(false, txn_error.empty() ? "Transaction failed" : txn_error);
+		}
+	}
+
 	return std::make_pair(true, "");
 }
 
@@ -592,19 +780,26 @@ std::pair<json, std::string> lotman::Lot::get_lot_dirs(const bool recursive) {
 	}
 }
 
-std::pair<std::string, std::string> lotman::Lot::get_lot_from_dir(const std::string &dir_path) {
+std::pair<std::string, std::string> lotman::Lot::get_lot_from_dir(const std::string &dir_path, int64_t query_time) {
 	try {
-		auto &storage = db::StorageManager::get_storage();
-		using namespace sqlite_orm;
-
 		// Normalize path with trailing slash to match stored format
 		std::string normalized_path = ensure_trailing_slash(dir_path);
-		auto lot_names = storage.select(&db::Path::lot_name, where(c(&db::Path::path) == normalized_path));
 
-		if (lot_names.empty()) {
-			return std::make_pair("", ""); // Nothing existed, and no error. Return empty strings!
+		std::string query = "SELECT p.lot_name FROM paths p "
+							"JOIN management_policy_attributes mpa ON p.lot_name = mpa.lot_name "
+							"WHERE p.path = ?1 AND mpa.creation_time <= ?2 AND mpa.expiration_time > ?2 "
+							"LIMIT 1;";
+		std::map<std::string, std::vector<int>> str_map{{normalized_path, {1}}};
+		std::map<int64_t, std::vector<int>> int_map{{query_time, {2}}};
+		auto rp = db::SQL_get_matches(query, str_map, int_map);
+
+		if (!rp.second.empty()) {
+			return std::make_pair("", std::string("get_lot_from_dir query failed: ") + rp.second);
 		}
-		return std::make_pair(lot_names[0], "");
+		if (rp.first.empty()) {
+			return std::make_pair("", "");
+		}
+		return std::make_pair(rp.first[0], "");
 	} catch (const std::exception &e) {
 		return std::make_pair("", std::string("get_lot_from_dir failed: ") + e.what());
 	}
@@ -927,7 +1122,87 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 	return std::make_pair(output_obj, "");
 }
 
+// Non-transactional helper: reloads parents and MPAs from DB, clears old attributions,
+// recomputes with equal split, and validates axioms. Caller MUST hold an active transaction.
+bool lotman::Lot::reload_and_recompute_attributions(std::string &txn_error) {
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+
+		// Reload parents from DB
+		auto parent_records = storage.select(&db::Parent::parent, where(c(&db::Parent::lot_name) == lot_name));
+		parents.clear();
+		for (const auto &p : parent_records) {
+			parents.push_back(p);
+		}
+
+		// Reload MPAs
+		auto mpa_ptr = storage.get_pointer<db::ManagementPolicyAttributes>(lot_name);
+		if (!mpa_ptr) {
+			txn_error = "Lot '" + lot_name + "' not found in management_policy_attributes";
+			return false;
+		}
+		man_policy_attr.dedicated_GB = mpa_ptr->dedicated_GB;
+		man_policy_attr.opportunistic_GB = mpa_ptr->opportunistic_GB;
+		man_policy_attr.max_num_objects = mpa_ptr->max_num_objects;
+
+		// Clear old attributions and recompute with equal split
+		storage.remove_all<db::ParentChildAttribution>(
+			where(c(&db::ParentChildAttribution::child_lot_name) == lot_name));
+		auto attr_rp = compute_and_store_attributions();
+		if (!attr_rp.first) {
+			txn_error = "Failed to recompute attributions for '" + lot_name + "': " + attr_rp.second;
+			return false;
+		}
+
+		auto vr = apply_validation_predicates(build_axiom_predicates(lot_name));
+		if (!vr.first) {
+			txn_error = "Hierarchy violation for '" + lot_name + "': " + vr.second;
+			return false;
+		}
+
+		return true;
+	} catch (const std::exception &e) {
+		txn_error = std::string("Failed to reload and recompute attributions: ") + e.what();
+		return false;
+	}
+}
+
+// Non-transactional helper: stores parents, reloads state, recomputes attributions, validates.
+// Caller MUST hold an active storage.transaction().
+bool lotman::Lot::add_parents_impl(const std::vector<Lot> &parents, std::string &txn_error) {
+	try {
+		auto rp = store_new_parents(parents);
+		if (!rp.first) {
+			txn_error = "Call to lotman::Lot::store_new_parents failed: " + rp.second;
+			return false;
+		}
+
+		if (lot_name != "default") {
+			if (!reload_and_recompute_attributions(txn_error)) {
+				return false;
+			}
+		}
+
+		return true;
+	} catch (const std::exception &e) {
+		txn_error = std::string("Failed to add parents: ") + e.what();
+		return false;
+	}
+}
+
 std::pair<bool, std::string> lotman::Lot::add_parents(const std::vector<Lot> &parents) {
+	auto &storage = db::StorageManager::get_storage();
+	std::string txn_error;
+	bool committed = storage.transaction([&] { return add_parents_in_txn(parents, txn_error); });
+
+	if (!committed) {
+		return std::make_pair(false, txn_error.empty() ? "Transaction failed" : txn_error);
+	}
+	return std::make_pair(true, "");
+}
+
+bool lotman::Lot::add_parents_in_txn(const std::vector<Lot> &parents, std::string &txn_error) {
 	// Perform a cycle check
 	// Build the list of all proposed parents
 	std::vector<std::string> parent_names;
@@ -948,28 +1223,57 @@ std::pair<bool, std::string> lotman::Lot::add_parents(const std::vector<Lot> &pa
 
 	// Perform the cycle check
 	if (Checks::cycle_check(lot_name, parent_names, children_names)) {
-		std::string err = "The requested parent addition would introduce a dependency cycle.";
-		return std::make_pair(false, err);
+		txn_error = "The requested parent addition would introduce a dependency cycle.";
+		return false;
 	}
 
-	// We've passed the cycle check, store the parents
-	auto rp = store_new_parents(parents);
-	if (!rp.first) {
-		std::string int_err = rp.second;
-		std::string ext_err = "Call to lotman::Lot::store_new_parents failed: ";
-		return std::make_pair(false, ext_err + int_err);
+	return add_parents_impl(parents, txn_error);
+}
+
+std::pair<bool, std::string> lotman::Lot::add_paths(const std::vector<json> &paths) {
+	auto &storage = db::StorageManager::get_storage();
+	std::string txn_error;
+	bool committed = storage.transaction([&] { return add_paths_in_txn(paths, txn_error); });
+	if (!committed) {
+		return std::make_pair(false, txn_error.empty() ? "Transaction failed" : txn_error);
 	}
 	return std::make_pair(true, "");
 }
 
-std::pair<bool, std::string> lotman::Lot::add_paths(const std::vector<json> &paths) {
-	auto rp = store_new_paths(paths);
-	if (!rp.first) {
-		std::string int_err = rp.second;
-		std::string ext_err = "Call to lotman::Lot::store_new_paths failed: ";
-		return std::make_pair(false, ext_err + int_err);
+bool lotman::Lot::add_paths_in_txn(const std::vector<json> &paths, std::string &txn_error) {
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+
+		auto this_mpa = storage.get_pointer<db::ManagementPolicyAttributes>(lot_name);
+		if (this_mpa) {
+			for (const auto &path_json : paths) {
+				std::string path_str = path_json.at("path").get<std::string>();
+				std::string normalized = ensure_trailing_slash(path_str);
+
+				bool exclude = path_json.contains("exclude") ? path_json["exclude"].get<bool>() : false;
+				if (!exclude) {
+					auto overlap = check_path_temporal_overlap(lot_name, normalized, this_mpa->creation_time,
+															   this_mpa->expiration_time);
+					if (!overlap.first) {
+						txn_error = overlap.second;
+						return false;
+					}
+				}
+			}
+		}
+
+		for (const auto &path : paths) {
+			std::string normalized = ensure_trailing_slash(path["path"].get<std::string>());
+			bool recursive = path["recursive"].get<bool>();
+			bool exclude = path.contains("exclude") ? path["exclude"].get<bool>() : false;
+			storage.replace(db::Path{lot_name, normalized, static_cast<int>(recursive), static_cast<int>(exclude)});
+		}
+		return true;
+	} catch (const std::exception &e) {
+		txn_error = std::string("Failed to add paths: ") + e.what();
+		return false;
 	}
-	return std::make_pair(true, "");
 }
 
 std::pair<bool, std::string> lotman::Lot::remove_parents(const std::vector<std::string> &parents_to_remove) {
@@ -1000,13 +1304,32 @@ std::pair<bool, std::string> lotman::Lot::remove_parents(const std::vector<std::
 		return std::make_pair(false, "Could not remove parents because doing so would orphan the lot.");
 	}
 
-	auto rp = remove_parents_from_db(parents_copy);
+	// Remove parents, recompute attributions, and validate in a single transaction.
+	// If any step fails, all DB changes are rolled back atomically.
+	{
+		auto &storage = db::StorageManager::get_storage();
+		std::string txn_error;
+		bool committed = storage.transaction([&] {
+			auto rp = remove_parents_from_db(parents_copy);
+			if (!rp.first) {
+				txn_error = "Call to lotman::Lot::remove_parents failed: " + rp.second;
+				return false;
+			}
 
-	if (!rp.first) {
-		std::string int_err = rp.second;
-		std::string ext_err = "Call to lotman::Lot::remove_parents failed: ";
-		return std::make_pair(false, ext_err + int_err);
+			if (lot_name != "default") {
+				if (!reload_and_recompute_attributions(txn_error)) {
+					return false;
+				}
+			}
+
+			return true;
+		});
+
+		if (!committed) {
+			return std::make_pair(false, txn_error.empty() ? "Transaction failed" : txn_error);
+		}
 	}
+
 	return std::make_pair(true, "");
 }
 
@@ -1021,39 +1344,87 @@ std::pair<bool, std::string> lotman::Lot::remove_paths(const std::vector<std::st
 }
 
 std::pair<bool, std::string> lotman::Lot::update_owner(const std::string &update_val) {
-	std::string owner_update_stmt = "UPDATE owners SET owner=? WHERE lot_name=?;";
-
-	std::map<std::string, std::vector<int>> owner_update_str_map{{lot_name, {2}}, {update_val, {1}}};
-	auto rp = store_updates(owner_update_stmt, owner_update_str_map);
-	if (!rp.first) {
-		std::string int_err = rp.second;
-		std::string ext_err = "Failure on call to lotman::Lot::store_updates when storing owner update: ";
-		return std::make_pair(false, ext_err + int_err);
+	auto &storage = db::StorageManager::get_storage();
+	std::string txn_error;
+	bool committed = storage.transaction([&] { return update_owner_in_txn(update_val, txn_error); });
+	if (!committed) {
+		return std::make_pair(false, txn_error.empty() ? "Transaction failed" : txn_error);
 	}
 	return std::make_pair(true, "");
 }
 
+bool lotman::Lot::update_owner_in_txn(const std::string &update_val, std::string &txn_error) {
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		// Owner has lot_name as primary key, so replace performs an in-place update.
+		storage.replace(db::Owner{lot_name, update_val});
+		return true;
+	} catch (const std::exception &e) {
+		txn_error = std::string("Failed to update owner: ") + e.what();
+		return false;
+	}
+}
+
+// Non-transactional helper: updates parent records using ORM.
+// Caller MUST hold an active storage.transaction().
+bool lotman::Lot::update_parents_impl(const json &update_arr, std::string &txn_error) {
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+
+		for (const auto &update_obj : update_arr) {
+			std::string current_parent = update_obj["current"].get<std::string>();
+			std::string new_parent = update_obj["new"].get<std::string>();
+
+			// Remove old parent record and insert the updated one.
+			// Parent table has composite PK (lot_name, parent), so we must
+			// remove + replace rather than update-in-place.
+			storage.remove_all<db::Parent>(
+				where(c(&db::Parent::lot_name) == lot_name and c(&db::Parent::parent) == current_parent));
+			storage.replace(db::Parent{lot_name, new_parent});
+		}
+
+		return true;
+	} catch (const std::exception &e) {
+		txn_error = std::string("Failed to update parents: ") + e.what();
+		return false;
+	}
+}
+
 std::pair<bool, std::string> lotman::Lot::update_parents(const json &update_arr) {
+	auto &storage = db::StorageManager::get_storage();
+	std::string txn_error;
+	bool committed = storage.transaction([&] { return update_parents_in_txn(update_arr, txn_error); });
+
+	if (!committed) {
+		return std::make_pair(false, txn_error.empty() ? "Transaction failed" : txn_error);
+	}
+
+	return std::make_pair(true, "");
+}
+
+bool lotman::Lot::update_parents_in_txn(const json &update_arr, std::string &txn_error) {
 	// First, perform a cycle check on the whole update arr, and fail if any introduce a cycle
 	// Cycle check takes in three arguments -- The start node (in this case, lot_name), and vectors of parents/children
 	// of the start node as strings
 
 	// Get all the existing parents
-	std::vector<std::string> parents;
+	std::vector<std::string> parent_list;
 	this->get_parents(
 		true, true); // get_self is true because either we need get_self to be true for get_parents or get_children.
 
 	for (const auto &parent_lot : recursive_parents) {
-		parents.push_back(parent_lot.lot_name);
+		parent_list.push_back(parent_lot.lot_name);
 	}
 	// for each existing parent, if it's being updated, swap it out with the new parent.
 	for (const auto &update : update_arr) {
-		auto parent_iter = std::find(parents.begin(), parents.end(), update["current"]);
-		if (parent_iter != parents.end()) {
+		auto parent_iter = std::find(parent_list.begin(), parent_list.end(), update["current"]);
+		if (parent_iter != parent_list.end()) {
 			*parent_iter = update["new"];
 		} else {
-			return std::make_pair(false, "One of the current parents, " + update["current"].get<std::string>() +
-											 ", to be updated is not actually a parent.");
+			txn_error = "One of the current parents, " + update["current"].get<std::string>() +
+						", to be updated is not actually a parent.";
+			return false;
 		}
 	}
 
@@ -1063,116 +1434,215 @@ std::pair<bool, std::string> lotman::Lot::update_parents(const json &update_arr)
 		children.push_back(child_lot.lot_name);
 	}
 
-	if (Checks::cycle_check(lot_name, parents, children)) {
-		std::string err = "The requested parent update would introduce a dependency cycle.";
-		return std::make_pair(false, err);
+	if (Checks::cycle_check(lot_name, parent_list, children)) {
+		txn_error = "The requested parent update would introduce a dependency cycle.";
+		return false;
 	}
 
-	std::string parents_update_stmt = "UPDATE parents SET parent=? WHERE lot_name=? AND parent=?";
-	// Need to store modifications per map entry
-	for (const auto &update_obj : update_arr) {
-		std::map<std::string, std::vector<int>> parents_update_str_map;
-		if (update_obj["current"] == lot_name) {
-			parents_update_str_map = {{update_obj["new"], {1}}, {update_obj["current"], {2, 3}}};
-		} else {
-			parents_update_str_map = {{update_obj["new"], {1}}, {lot_name, {2}}, {update_obj["current"], {3}}};
-		}
-		auto rp = store_updates(parents_update_stmt, parents_update_str_map);
-		if (!rp.first) {
-			std::string int_err = rp.second;
-			std::string ext_err = "Failure on call to lotman::Lot::store_updates when storing parents update: ";
-			return std::make_pair(false, ext_err + int_err);
+	if (!update_parents_impl(update_arr, txn_error)) {
+		return false;
+	}
+	if (lot_name != "default") {
+		if (!reload_and_recompute_attributions(txn_error)) {
+			return false;
 		}
 	}
-	return std::make_pair(true, "");
+	return true;
 }
 
 std::pair<bool, std::string> lotman::Lot::update_paths(const json &update_arr) {
-	// incoming update map looks like {"path1" --> {"path" : "path2", "recursive" : false, "exclude": false}}
-	std::string paths_update_stmt = "UPDATE paths SET path=? WHERE lot_name=? and path=?;";
-	std::string recursive_update_stmt = "UPDATE paths SET recursive=? WHERE lot_name=? and path=?;";
-	std::string exclude_update_stmt = "UPDATE paths SET exclude=? WHERE lot_name=? and path=?;";
-
-	// Iterate through updates, first perform recursive update, then exclude update, THEN path
-	for (const auto &update_obj : update_arr /*update_map*/) {
-		// Normalize paths with trailing slash
-		std::string current_path = ensure_trailing_slash(update_obj["current"].get<std::string>());
-		std::string new_path = ensure_trailing_slash(update_obj["new"].get<std::string>());
-
-		std::map<int64_t, std::vector<int>> recursive_update_int_map{
-			{update_obj["recursive"].get<int>(),
-			 {1}}}; // Unfortunately using int64_t for these bools to write less code
-		std::map<std::string, std::vector<int>> recursive_update_str_map{{lot_name, {2}}, {current_path, {3}}};
-		auto rp = store_updates(recursive_update_stmt, recursive_update_str_map, recursive_update_int_map);
-		if (!rp.first) {
-			std::string int_err = rp.second;
-			std::string ext_err = "Failure on call to lotman::Lot::store_updates when storing paths recursive update: ";
-			return std::make_pair(false, ext_err + int_err);
-		}
-
-		// Exclude update (if provided)
-		if (update_obj.contains("exclude")) {
-			std::map<int64_t, std::vector<int>> exclude_update_int_map{{update_obj["exclude"].get<int>(), {1}}};
-			std::map<std::string, std::vector<int>> exclude_update_str_map{{lot_name, {2}}, {current_path, {3}}};
-			rp = store_updates(exclude_update_stmt, exclude_update_str_map, exclude_update_int_map);
-			if (!rp.first) {
-				std::string int_err = rp.second;
-				std::string ext_err =
-					"Failure on call to lotman::Lot::store_updates when storing paths exclude update: ";
-				return std::make_pair(false, ext_err + int_err);
-			}
-		}
-
-		// Path update
-		std::map<std::string, std::vector<int>> paths_update_str_map{
-			{new_path, {1}}, {lot_name, {2}}, {current_path, {3}}};
-		rp = store_updates(paths_update_stmt, paths_update_str_map);
-		if (!rp.first) {
-			std::string int_err = rp.second;
-			std::string ext_err = "Failure on call to lotman::Lot::store_updates when storing paths path update: ";
-			return std::make_pair(false, ext_err + int_err);
-		}
+	auto &storage = db::StorageManager::get_storage();
+	std::string txn_error;
+	bool committed = storage.transaction([&] { return update_paths_in_txn(update_arr, txn_error); });
+	if (!committed) {
+		return std::make_pair(false, txn_error.empty() ? "Transaction failed" : txn_error);
 	}
 	return std::make_pair(true, "");
 }
 
+bool lotman::Lot::update_paths_in_txn(const json &update_arr, std::string &txn_error) {
+	auto &storage = db::StorageManager::get_storage();
+	using namespace sqlite_orm;
+	try {
+		for (const auto &update_obj : update_arr) {
+			std::string current_path = ensure_trailing_slash(update_obj["current"].get<std::string>());
+			std::string new_path = ensure_trailing_slash(update_obj["new"].get<std::string>());
+
+			// Read the current path record
+			auto rows = storage.get_all<db::Path>(
+				where(c(&db::Path::lot_name) == lot_name and c(&db::Path::path) == current_path));
+			if (rows.empty()) {
+				txn_error = "Path not found for update: " + current_path;
+				return false;
+			}
+			auto path_record = rows[0];
+
+			// Apply field updates
+			path_record.recursive = update_obj["recursive"].get<int>();
+			bool exclude_changed_to_false = false;
+			if (update_obj.contains("exclude")) {
+				int new_exclude = update_obj["exclude"].get<int>();
+				if (path_record.exclude && !new_exclude) {
+					exclude_changed_to_false = true;
+				}
+				path_record.exclude = new_exclude;
+			}
+
+			// Check temporal overlap if: (1) path changes, OR (2) exclude flips true→false
+			// In case (2), a previously-excluded path becomes active and might conflict
+			if (current_path != new_path || exclude_changed_to_false) {
+				// Check temporal overlap for the path (if not excluded)
+				if (!path_record.exclude) {
+					auto this_mpa = storage.get_pointer<db::ManagementPolicyAttributes>(lot_name);
+					if (this_mpa) {
+						// Use new_path for case (1), current_path for case (2)
+						std::string path_to_check = (current_path != new_path) ? new_path : current_path;
+						auto overlap = check_path_temporal_overlap(lot_name, path_to_check, this_mpa->creation_time,
+																   this_mpa->expiration_time);
+						if (!overlap.first) {
+							txn_error = overlap.second;
+							return false;
+						}
+					}
+				}
+			}
+
+			// If path itself changed, we must remove+replace since path is part of composite PK
+			if (current_path != new_path) {
+				storage.remove_all<db::Path>(
+					where(c(&db::Path::lot_name) == lot_name and c(&db::Path::path) == current_path));
+				path_record.path = new_path;
+			}
+			storage.replace(path_record);
+		}
+		return true;
+	} catch (const std::exception &e) {
+		txn_error = std::string("Failed to update paths: ") + e.what();
+		return false;
+	}
+}
+
 std::pair<bool, std::string> lotman::Lot::update_man_policy_attrs(const std::string &update_key, double update_val) {
-	std::string man_policy_attr_update_stmt_first_half = "UPDATE management_policy_attributes SET ";
-	std::string man_policy_attr_update_stmt_second_half = "=? WHERE lot_name=?;";
-
-	std::array<std::string, 2> dbl_keys = {"dedicated_GB", "opportunistic_GB"};
-	std::array<std::string, 4> int_keys = {"max_num_objects", "creation_time", "expiration_time", "deletion_time"};
-
-	if (std::find(dbl_keys.begin(), dbl_keys.end(), update_key) != dbl_keys.end()) {
-		std::string man_policy_attr_update_stmt =
-			man_policy_attr_update_stmt_first_half + update_key + man_policy_attr_update_stmt_second_half;
-		std::map<std::string, std::vector<int>> man_policy_attr_update_str_map{{lot_name, {2}}};
-		std::map<double, std::vector<int>> man_policy_attr_update_dbl_map{{update_val, {1}}};
-		auto rp = store_updates(man_policy_attr_update_stmt, man_policy_attr_update_str_map,
-								std::map<int64_t, std::vector<int>>(), man_policy_attr_update_dbl_map);
-		if (!rp.first) {
-			std::string int_err = rp.second;
-			std::string ext_err =
-				"Failure on call to lotman::Lot::store_updates when storing management policy attribute update: ";
-			return std::make_pair(false, ext_err + int_err);
-		}
-	} else if (std::find(int_keys.begin(), int_keys.end(), update_key) != int_keys.end()) {
-		std::string man_policy_attr_update_stmt =
-			man_policy_attr_update_stmt_first_half + update_key + man_policy_attr_update_stmt_second_half;
-		std::map<std::string, std::vector<int>> man_policy_attr_update_str_map{{lot_name, {2}}};
-		std::map<int64_t, std::vector<int>> man_policy_attr_update_int_map{{update_val, {1}}};
-		auto rp =
-			store_updates(man_policy_attr_update_stmt, man_policy_attr_update_str_map, man_policy_attr_update_int_map);
-		if (!rp.first) {
-			std::string int_err = rp.second;
-			std::string ext_err =
-				"Failure on call to lotman::Lot::store_updates when storing management policy attribute update: ";
-			return std::make_pair(false, ext_err + int_err);
-		}
-	} else {
-		return std::make_pair(false, "Update key not found or not recognized.");
+	auto &storage = db::StorageManager::get_storage();
+	std::string txn_error;
+	bool committed =
+		storage.transaction([&] { return update_man_policy_attrs_in_txn(update_key, update_val, txn_error); });
+	if (!committed) {
+		return std::make_pair(false, txn_error.empty() ? "Transaction failed" : txn_error);
 	}
 	return std::make_pair(true, "");
+}
+
+bool lotman::Lot::update_man_policy_attrs_in_txn(const std::string &update_key, double update_val,
+												 std::string &txn_error) {
+	auto &storage = db::StorageManager::get_storage();
+	using namespace sqlite_orm;
+	auto mpa_ptr = storage.get_pointer<db::ManagementPolicyAttributes>(lot_name);
+	if (!mpa_ptr) {
+		txn_error = "Lot '" + lot_name + "' not found in management_policy_attributes";
+		return false;
+	}
+	auto mpa = *mpa_ptr;
+
+	// Contraction policy enforcement (inside transaction for consistency).
+	// Floating-point comparisons use a small epsilon so trivial round-trip noise
+	// (e.g. JSON re-parse) is not flagged as a contraction; integer fields are
+	// compared exactly.
+	std::string contraction_policy = Context::get_contraction_policy();
+	if (contraction_policy != "none" && !Context::get_admin_override()) {
+		constexpr double kContractionEps = 1e-9;
+		bool is_contraction = false;
+		if (update_key == "dedicated_GB" && update_val < mpa.dedicated_GB - kContractionEps)
+			is_contraction = true;
+		if (update_key == "opportunistic_GB" && update_val < mpa.opportunistic_GB - kContractionEps)
+			is_contraction = true;
+		if (update_key == "max_num_objects" && update_val < mpa.max_num_objects)
+			is_contraction = true;
+		if (update_key == "creation_time" && update_val > mpa.creation_time)
+			is_contraction = true;
+		if (update_key == "expiration_time" && update_val < mpa.expiration_time)
+			is_contraction = true;
+		if (update_key == "deletion_time" && update_val < mpa.deletion_time)
+			is_contraction = true;
+
+		if (is_contraction) {
+			if (contraction_policy == "always") {
+				txn_error = "Contraction policy 'always' blocks reduction of '" + update_key + "' on lot '" + lot_name +
+							"'. Set admin_override to bypass.";
+				return false;
+			}
+			if (contraction_policy == "alive") {
+				auto alive_rp = is_lot_alive(lot_name);
+				if (!alive_rp.second.empty()) {
+					txn_error = "Failed contraction policy check: " + alive_rp.second;
+					return false;
+				}
+				if (alive_rp.first) {
+					txn_error = "Contraction policy 'alive' blocks reduction of '" + update_key +
+								"' on currently-alive lot '" + lot_name + "'. Set admin_override to bypass.";
+					return false;
+				}
+			}
+		}
+	}
+
+	// Update the appropriate field
+	if (update_key == "dedicated_GB")
+		mpa.dedicated_GB = update_val;
+	else if (update_key == "opportunistic_GB")
+		mpa.opportunistic_GB = update_val;
+	else if (update_key == "max_num_objects")
+		mpa.max_num_objects = static_cast<int64_t>(update_val);
+	else if (update_key == "creation_time")
+		mpa.creation_time = static_cast<int64_t>(update_val);
+	else if (update_key == "expiration_time")
+		mpa.expiration_time = static_cast<int64_t>(update_val);
+	else if (update_key == "deletion_time")
+		mpa.deletion_time = static_cast<int64_t>(update_val);
+	else {
+		txn_error = "Update key not found or not recognized.";
+		return false;
+	}
+
+	// After updating a timestamp, verify half-open interval invariant
+	if (update_key == "creation_time" || update_key == "expiration_time") {
+		if (mpa.creation_time >= mpa.expiration_time) {
+			txn_error = "Update would make creation_time >= expiration_time on lot '" + lot_name +
+						"' (half-open interval [creation, expiration) must be non-empty)";
+			return false;
+		}
+	}
+
+	try {
+		storage.replace(mpa);
+	} catch (const std::exception &e) {
+		txn_error = std::string("Failed to write MPA update: ") + e.what();
+		return false;
+	}
+
+	// If timestamps changed, re-check path temporal overlaps with other lots
+	if (update_key == "creation_time" || update_key == "expiration_time") {
+		auto lot_paths =
+			storage.get_all<db::Path>(where(c(&db::Path::lot_name) == lot_name and c(&db::Path::exclude) == false));
+		for (const auto &p : lot_paths) {
+			auto overlap = check_path_temporal_overlap(lot_name, p.path, mpa.creation_time, mpa.expiration_time);
+			if (!overlap.first) {
+				txn_error = "MPA update on '" + lot_name + "' would create path conflict: " + overlap.second;
+				return false;
+			}
+		}
+	}
+
+	// Re-validate axioms after MPA update
+	// check_children=true because changing this lot's MPAs can break axioms
+	// for children whose attributions reference this lot.
+	auto vr = apply_validation_predicates(build_axiom_predicates(lot_name, /*check_children=*/true));
+	if (!vr.first) {
+		txn_error = "MPA update on '" + lot_name + "' would violate hierarchy: " + vr.second;
+		return false;
+	}
+
+	return true;
 }
 
 std::pair<bool, std::string>
@@ -1203,6 +1673,12 @@ std::pair<bool, std::string> lotman::Lot::update_self_usage(const std::string &k
 
 	std::array<std::string, 2> allowed_int_keys = {"self_objects", "self_objects_being_written"};
 	std::array<std::string, 2> allowed_double_keys = {"self_GB", "self_GB_being_written"};
+
+	// Validate key before any SQL construction (defense-in-depth against column-name injection)
+	if (std::find(allowed_int_keys.begin(), allowed_int_keys.end(), key) == allowed_int_keys.end() &&
+		std::find(allowed_double_keys.begin(), allowed_double_keys.end(), key) == allowed_double_keys.end()) {
+		return std::make_pair(false, "Unrecognized usage key: " + key);
+	}
 
 	std::string children_key =
 		"children" + key.substr(4); // here, we strip out the "self" from the key to target the children col
@@ -1546,12 +2022,14 @@ std::pair<bool, std::string> lotman::Lot::recalculate_children_usage() {
 
 // END SECTION
 
-std::pair<bool, std::string> lotman::Lot::update_usage_by_dirs(const json &update_JSON, bool deltaMode) {
+std::pair<bool, std::string> lotman::Lot::update_usage_by_dirs(const json &update_JSON, bool deltaMode,
+															   int64_t query_time) {
 	// TODO: Should lots who don't show up when connecting lots to dirs be reset to have
 	//       0 usage, or should the be kept the way they are?
 	// --> kept the way they are, probably.
 
 	DirUsageUpdate dirUpdate;
+	dirUpdate.m_query_time = query_time;
 	std::vector<Lot> return_lots;
 	auto rp = dirUpdate.JSON_math(update_JSON, &return_lots);
 	if (!rp.first) {
@@ -1884,6 +2362,171 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_obj(
 	return std::make_pair(lots_past_obj, "");
 }
 
+// Helper: sort lot names by depth descending (deepest/leaf first).
+// Uses a single recursive CTE instead of N+1 individual queries.
+static void sort_by_depth_descending(std::vector<std::string> &lots) {
+	if (lots.empty())
+		return;
+
+	std::string depth_query = "WITH RECURSIVE depth_cte(lot_name, depth) AS ("
+							  "  SELECT lot_name, 0 FROM parents WHERE lot_name = parent "
+							  "  UNION ALL "
+							  "  SELECT p.lot_name, d.depth + 1 "
+							  "  FROM parents p JOIN depth_cte d ON p.parent = d.lot_name "
+							  "  WHERE p.lot_name != p.parent"
+							  ") "
+							  "SELECT lot_name, MAX(depth) FROM depth_cte GROUP BY lot_name ORDER BY MAX(depth) DESC;";
+
+	auto rp = lotman::db::SQL_get_matches_multi_col(depth_query, 2);
+	if (!rp.second.empty() || rp.first.empty())
+		return; // On error, leave unsorted
+
+	// Build lot_name → depth map
+	std::map<std::string, int> depth_map;
+	for (const auto &row : rp.first) {
+		if (row.size() >= 2) {
+			try {
+				depth_map[row[0]] = std::stoi(row[1]);
+			} catch (...) {
+				depth_map[row[0]] = 0;
+			}
+		}
+	}
+
+	std::sort(lots.begin(), lots.end(), [&depth_map](const std::string &a, const std::string &b) {
+		int da = depth_map.count(a) ? depth_map.at(a) : 0;
+		int db = depth_map.count(b) ? depth_map.at(b) : 0;
+		return da > db;
+	});
+}
+
+// Parameterized helper for hierarchical lot-threshold queries.
+// Builds an "adjusted usage" query that accounts for children's overage,
+// executes it, and returns results sorted by depth (deepest first).
+//
+// Parameters:
+//   self_usage_col: the lot_usage column for the lot's own usage (e.g. "self_GB")
+//   child_usage_expr: aggregate expression for a child's total usage
+//                     (e.g. "c_usage.self_GB + c_usage.children_GB")
+//   child_threshold_expr: the child's MPA threshold expression
+//                         (e.g. "c_mpa.dedicated_GB" or "c_mpa.dedicated_GB + c_mpa.opportunistic_GB")
+//   parent_threshold_expr: the parent's MPA threshold to compare against
+//                          (e.g. "p_mpa.dedicated_GB" or "p_mpa.dedicated_GB + p_mpa.opportunistic_GB")
+//   error_context: string for error messages
+static std::pair<std::vector<std::string>, std::string>
+get_lots_past_threshold_hierarchical(const std::string &self_usage_col, const std::string &child_usage_expr,
+									 const std::string &child_threshold_expr, const std::string &parent_threshold_expr,
+									 const std::string &error_context) {
+
+	// Defense-in-depth: validate all SQL fragments against known-good values.
+	// All callers pass compile-time constants, but this prevents future misuse.
+	static const std::set<std::string> allowed_usage_cols = {"self_GB", "self_objects"};
+	static const std::set<std::string> allowed_exprs = {"c_usage.self_GB + c_usage.children_GB",
+														"c_usage.self_objects + c_usage.children_objects",
+														"c_mpa.dedicated_GB",
+														"c_mpa.dedicated_GB + c_mpa.opportunistic_GB",
+														"c_mpa.max_num_objects",
+														"p_mpa.dedicated_GB",
+														"p_mpa.dedicated_GB + p_mpa.opportunistic_GB",
+														"p_mpa.max_num_objects"};
+
+	if (allowed_usage_cols.find(self_usage_col) == allowed_usage_cols.end() ||
+		allowed_exprs.find(child_usage_expr) == allowed_exprs.end() ||
+		allowed_exprs.find(child_threshold_expr) == allowed_exprs.end() ||
+		allowed_exprs.find(parent_threshold_expr) == allowed_exprs.end()) {
+		return std::make_pair(std::vector<std::string>(),
+							  "Internal error: unrecognized SQL fragment in hierarchical query");
+	}
+
+	std::string query = "SELECT p_usage.lot_name "
+						"FROM lot_usage p_usage "
+						"JOIN management_policy_attributes p_mpa ON p_usage.lot_name = p_mpa.lot_name "
+						"WHERE p_usage." +
+						self_usage_col +
+						" + COALESCE("
+						"    (SELECT SUM(MAX(0, (" +
+						child_usage_expr + ") - (" + child_threshold_expr +
+						"))) "
+						"     FROM parents c_par "
+						"     JOIN lot_usage c_usage ON c_par.lot_name = c_usage.lot_name "
+						"     JOIN management_policy_attributes c_mpa ON c_par.lot_name = c_mpa.lot_name "
+						"     WHERE c_par.parent = p_usage.lot_name AND c_par.lot_name != c_par.parent), 0"
+						") >= " +
+						parent_threshold_expr + ";";
+
+	auto rp = lotman::db::SQL_get_matches(query);
+	if (!rp.second.empty()) {
+		return std::make_pair(std::vector<std::string>(), "Failure on " + error_context + ": " + rp.second);
+	}
+
+	auto lots = rp.first;
+	sort_by_depth_descending(lots);
+	return std::make_pair(lots, "");
+}
+
+std::pair<std::vector<std::string>, std::string>
+lotman::Lot::get_lots_past_ded(const bool recursive_quota, const bool recursive_children, const bool hierarchical) {
+	if (!hierarchical) {
+		return get_lots_past_ded(recursive_quota, recursive_children);
+	}
+	return get_lots_past_threshold_hierarchical("self_GB", "c_usage.self_GB + c_usage.children_GB",
+												"c_mpa.dedicated_GB", "p_mpa.dedicated_GB", "adjusted dedicated query");
+}
+
+std::pair<std::vector<std::string>, std::string>
+lotman::Lot::get_lots_past_opp(const bool recursive_quota, const bool recursive_children, const bool hierarchical) {
+	if (!hierarchical) {
+		return get_lots_past_opp(recursive_quota, recursive_children);
+	}
+	return get_lots_past_threshold_hierarchical(
+		"self_GB", "c_usage.self_GB + c_usage.children_GB", "c_mpa.dedicated_GB + c_mpa.opportunistic_GB",
+		"p_mpa.dedicated_GB + p_mpa.opportunistic_GB", "adjusted opportunistic query");
+}
+
+std::pair<std::vector<std::string>, std::string>
+lotman::Lot::get_lots_past_obj(const bool recursive_quota, const bool recursive_children, const bool hierarchical) {
+	if (!hierarchical) {
+		return get_lots_past_obj(recursive_quota, recursive_children);
+	}
+	return get_lots_past_threshold_hierarchical("self_objects", "c_usage.self_objects + c_usage.children_objects",
+												"c_mpa.max_num_objects", "p_mpa.max_num_objects",
+												"adjusted objects query");
+}
+
+std::pair<json, std::string> lotman::Lot::get_available_capacity(const std::string &parent_lot_name, int64_t start_time,
+																 int64_t end_time) {
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+
+		// Get parent's MPAs
+		auto parent_mpa = storage.get_pointer<db::ManagementPolicyAttributes>(parent_lot_name);
+		if (!parent_mpa) {
+			return std::make_pair(json(), "Parent lot '" + parent_lot_name + "' not found");
+		}
+
+		// Build sweep-line events from children's attributions, clipped to query window
+		auto events = build_attribution_events(parent_lot_name, start_time, end_time);
+		auto peak = run_sweep_line(events);
+
+		json result;
+		result["available_dedicated_GB"] = parent_mpa->dedicated_GB - peak.peak_ded;
+		result["available_opportunistic_GB"] = parent_mpa->opportunistic_GB - peak.peak_opp;
+		result["available_max_num_objects"] = parent_mpa->max_num_objects - static_cast<int64_t>(peak.peak_obj);
+		result["peak_dedicated_GB"] = peak.peak_ded;
+		result["peak_opportunistic_GB"] = peak.peak_opp;
+		result["peak_max_num_objects"] = static_cast<int64_t>(peak.peak_obj);
+		// peak_total is the true max of (ded+opp) at a single point in time
+		double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
+		result["available_total_GB"] = parent_total - peak.peak_total;
+		result["peak_total_GB"] = peak.peak_total;
+
+		return std::make_pair(result, "");
+	} catch (const std::exception &e) {
+		return std::make_pair(json(), std::string("get_available_capacity failed: ") + e.what());
+	}
+}
+
 std::pair<std::vector<std::string>, std::string> lotman::Lot::list_all_lots() {
 	try {
 		auto &storage = db::StorageManager::get_storage();
@@ -1895,8 +2538,8 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::list_all_lots() {
 	}
 }
 
-std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_from_dir(const std::string &dir_input,
-																				const bool recursive) {
+std::pair<std::vector<std::string>, std::string>
+lotman::Lot::get_lots_from_dir(const std::string &dir_input, const bool recursive, int64_t query_time) {
 	// Normalize: ensure input dir has trailing slash for consistent comparison
 	// Database paths always have trailing slashes (e.g., "/foo/bar/")
 	std::string dir = ensure_trailing_slash(dir_input);
@@ -1929,14 +2572,17 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_from_dir(
 	//
 	// We select the longest non-excluded path that doesn't have a longer exclusion overriding it
 	std::string lots_from_dir_query =
-		"SELECT lot_name FROM paths p "
+		"SELECT p.lot_name FROM paths p "
+		"JOIN management_policy_attributes mpa ON p.lot_name = mpa.lot_name "
 		"WHERE "
 		"(p.path = ?1 OR ?2 LIKE p.path || '%') " // Exact match or subdirectory of stored path
 		"AND "
 		"(p.recursive OR p.path = ?3) " // If not recursive, only match exact path
 		"AND "
-		"p.exclude = 0 "	// Only consider inclusion paths
-		"AND NOT EXISTS ( " // Ensure no longer exclusion overrides this inclusion
+		"p.exclude = 0 "				// Only consider inclusion paths
+		"AND mpa.creation_time <= ?4 "	// Lot must have started
+		"AND mpa.expiration_time > ?4 " // Lot must not have expired
+		"AND NOT EXISTS ( "				// Ensure no longer exclusion overrides this inclusion
 		"    SELECT 1 FROM paths e "
 		"    WHERE e.lot_name = p.lot_name "			  // Same lot
 		"    AND e.exclude = 1 "						  // Is an exclusion
@@ -1946,7 +2592,8 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_from_dir(
 		") "
 		"ORDER BY LENGTH(p.path) DESC LIMIT 1;"; // Prefer longest matching inclusion
 	std::map<std::string, std::vector<int>> dir_str_map{{dir, {1, 3}}, {dir_for_like, {2}}};
-	auto rp = lotman::db::SQL_get_matches(lots_from_dir_query, dir_str_map);
+	std::map<int64_t, std::vector<int>> dir_int_map{{query_time, {4}}};
+	auto rp = lotman::db::SQL_get_matches(lots_from_dir_query, dir_str_map, dir_int_map);
 	if (!rp.second.empty()) {
 		std::string int_err = rp.second;
 		std::string ext_err = "Failure on call to SQL_get_matches: ";
@@ -2162,6 +2809,515 @@ std::pair<bool, std::string> lotman::Lot::check_context_for_children(const std::
 }
 
 /**
+ * Strict Hierarchy Enforcement Methods
+ */
+
+std::pair<bool, std::string> lotman::Lot::compute_and_store_attributions(const json &parent_attributions_json) {
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+
+		// Get non-self parents
+		std::vector<std::string> non_self_parents;
+		for (const auto &p : parents) {
+			if (p != lot_name) {
+				non_self_parents.push_back(p);
+			}
+		}
+
+		// If no non-self parents (root lot), nothing to attribute
+		if (non_self_parents.empty()) {
+			return std::make_pair(true, "");
+		}
+
+		// Validate that parent_attributions_json contains only known parent keys
+		if (!parent_attributions_json.is_null() && parent_attributions_json.is_object()) {
+			for (auto it = parent_attributions_json.begin(); it != parent_attributions_json.end(); ++it) {
+				const auto &key = it.key();
+				if (std::find(non_self_parents.begin(), non_self_parents.end(), key) == non_self_parents.end()) {
+					return std::make_pair(false, "Attribution JSON contains unknown parent '" + key +
+													 "' which is not a current non-self parent of lot '" + lot_name +
+													 "'");
+				}
+			}
+		}
+
+		// Remove any existing attributions for this child
+		storage.remove_all<db::ParentChildAttribution>(
+			where(c(&db::ParentChildAttribution::child_lot_name) == lot_name));
+
+		// The three MPA keys we track attributions for
+		const std::vector<std::string> mpa_keys = {"dedicated_GB", "opportunistic_GB", "max_num_objects"};
+		const std::map<std::string, double> child_mpas = {
+			{"dedicated_GB", man_policy_attr.dedicated_GB},
+			{"opportunistic_GB", man_policy_attr.opportunistic_GB},
+			{"max_num_objects", static_cast<double>(man_policy_attr.max_num_objects)}};
+
+		for (const auto &mpa_key : mpa_keys) {
+			double total_child_value = child_mpas.at(mpa_key);
+			double explicitly_attributed = 0.0;
+			std::vector<std::string> unspecified_parents;
+
+			// Process explicit attributions
+			for (const auto &parent_name : non_self_parents) {
+				if (!parent_attributions_json.is_null() && parent_attributions_json.contains(parent_name) &&
+					parent_attributions_json[parent_name].contains(mpa_key)) {
+
+					double explicit_value = parent_attributions_json[parent_name][mpa_key].get<double>();
+					double fraction = (total_child_value > 0) ? explicit_value / total_child_value : 0.0;
+
+					db::ParentChildAttribution attr;
+					attr.child_lot_name = lot_name;
+					attr.parent_lot_name = parent_name;
+					attr.mpa_key = mpa_key;
+					attr.fraction = fraction;
+					storage.replace(attr);
+
+					explicitly_attributed += explicit_value;
+				} else {
+					unspecified_parents.push_back(parent_name);
+				}
+			}
+
+			// If all parents were explicitly attributed, verify the sum matches the total
+			// (no shortfall and no overage). An overage would mean the child's MPA is being
+			// double-counted across parents, which violates the attribution invariant.
+			if (unspecified_parents.empty() && total_child_value > 0) {
+				double shortfall = total_child_value - explicitly_attributed;
+				if (shortfall > 1e-9) {
+					return std::make_pair(
+						false, "Explicit attributions for '" + mpa_key + "' sum to " +
+								   std::to_string(explicitly_attributed) + " but child's total is " +
+								   std::to_string(total_child_value) +
+								   "; all parents are explicitly attributed so remainder cannot be distributed");
+				}
+				double overage = explicitly_attributed - total_child_value;
+				if (overage > 1e-9) {
+					return std::make_pair(
+						false, "Explicit attributions for '" + mpa_key + "' sum to " +
+								   std::to_string(explicitly_attributed) + " which exceeds child's total of " +
+								   std::to_string(total_child_value) +
+								   "; attributions cannot exceed the child's allocation (would double-count).");
+				}
+			}
+
+			// Distribute remainder equally among unspecified parents
+			if (!unspecified_parents.empty()) {
+				double remainder = total_child_value - explicitly_attributed;
+				if (remainder < -1e-9) {
+					return std::make_pair(false, "Explicit attributions for '" + mpa_key +
+													 "' exceed the child's total allocation");
+				}
+				if (remainder < 0)
+					remainder = 0; // floating point tolerance
+
+				double per_parent = remainder / unspecified_parents.size();
+				// For max_num_objects, handle integer remainder
+				int64_t int_per_parent = 0;
+				int64_t int_remainder_extra = 0;
+				if (mpa_key == "max_num_objects") {
+					int64_t int_remainder = static_cast<int64_t>(remainder);
+					int_per_parent = int_remainder / static_cast<int64_t>(unspecified_parents.size());
+					int_remainder_extra = int_remainder % static_cast<int64_t>(unspecified_parents.size());
+				}
+
+				for (size_t i = 0; i < unspecified_parents.size(); ++i) {
+					double value;
+					if (mpa_key == "max_num_objects") {
+						value = static_cast<double>(int_per_parent +
+													(static_cast<int64_t>(i) < int_remainder_extra ? 1 : 0));
+					} else {
+						value = per_parent;
+					}
+
+					double fraction = (total_child_value > 0) ? value / total_child_value : 0.0;
+
+					db::ParentChildAttribution attr;
+					attr.child_lot_name = lot_name;
+					attr.parent_lot_name = unspecified_parents[i];
+					attr.mpa_key = mpa_key;
+					attr.fraction = fraction;
+					storage.replace(attr);
+				}
+			}
+		}
+
+		return std::make_pair(true, "");
+	} catch (const std::exception &e) {
+		return std::make_pair(false, std::string("Failed to compute attributions: ") + e.what());
+	}
+}
+
+std::pair<bool, std::string> lotman::Lot::update_attributions(const json &parent_attributions_json) {
+	auto &storage = db::StorageManager::get_storage();
+	std::string txn_error;
+	bool committed =
+		storage.transaction([&] { return update_attributions_in_txn(parent_attributions_json, txn_error); });
+	if (!committed) {
+		return std::make_pair(false, txn_error.empty() ? "Transaction failed" : txn_error);
+	}
+	return std::make_pair(true, "");
+}
+
+bool lotman::Lot::update_attributions_in_txn(const json &parent_attributions_json, std::string &txn_error) {
+	try {
+		// Load the lot's current MPAs and parents from DB
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+
+		auto mpa_ptr = storage.get_pointer<db::ManagementPolicyAttributes>(lot_name);
+		if (!mpa_ptr) {
+			txn_error = "Lot '" + lot_name + "' not found in management_policy_attributes";
+			return false;
+		}
+		man_policy_attr.dedicated_GB = mpa_ptr->dedicated_GB;
+		man_policy_attr.opportunistic_GB = mpa_ptr->opportunistic_GB;
+		man_policy_attr.max_num_objects = mpa_ptr->max_num_objects;
+
+		// Load parents
+		auto parent_records = storage.select(&db::Parent::parent, where(c(&db::Parent::lot_name) == lot_name));
+		parents.clear();
+		for (const auto &p : parent_records) {
+			parents.push_back(p);
+		}
+
+		auto rp = compute_and_store_attributions(parent_attributions_json);
+		if (!rp.first) {
+			txn_error = rp.second;
+			return false;
+		}
+
+		// Re-validate axioms 1 and 2 (not 3 — timestamps are unchanged)
+		if (Context::get_strict_hierarchy()) {
+			const std::string &name = lot_name;
+			std::vector<ValidationPredicate> predicates = {[name]() { return validate_axiom1(name); },
+														   [name]() { return validate_axiom2_for_parents_of(name); }};
+			auto vr = apply_validation_predicates(predicates);
+			if (!vr.first) {
+				txn_error = vr.second;
+				return false;
+			}
+		}
+
+		return true;
+	} catch (const std::exception &e) {
+		txn_error = std::string("Failed to update attributions: ") + e.what();
+		return false;
+	}
+}
+
+std::pair<bool, std::string> lotman::Lot::is_lot_alive(const std::string &lot_name) {
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+		auto mpa = storage.get_pointer<db::ManagementPolicyAttributes>(lot_name);
+		if (!mpa) {
+			return std::make_pair(false, "");
+		}
+		auto now =
+			std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+				.count();
+		return std::make_pair(mpa->creation_time <= now && now < mpa->expiration_time, "");
+	} catch (const std::exception &e) {
+		return std::make_pair(false, std::string("Failed to check lot alive status: ") + e.what());
+	}
+}
+
+std::pair<bool, std::string> lotman::Lot::check_contraction_for_deletion(const std::string &lot_name) {
+	std::string contraction_policy = Context::get_contraction_policy();
+	if (contraction_policy == "none" || Context::get_admin_override()) {
+		return std::make_pair(true, "");
+	}
+
+	if (contraction_policy == "always") {
+		return std::make_pair(false,
+							  "Contraction policy 'always' blocks deletion of lot '" + lot_name +
+								  "'. Deletion is treated as contraction to zero. Set admin_override to bypass.");
+	}
+
+	if (contraction_policy == "alive") {
+		auto alive_rp = is_lot_alive(lot_name);
+		if (!alive_rp.second.empty()) {
+			return std::make_pair(false,
+								  std::string("Failed contraction policy check for deletion: ") + alive_rp.second);
+		}
+		if (alive_rp.first) {
+			return std::make_pair(false, "Contraction policy 'alive' blocks deletion of currently-alive lot '" +
+											 lot_name + "'. Set admin_override to bypass.");
+		}
+	}
+
+	return std::make_pair(true, "");
+}
+
+std::pair<bool, std::string>
+lotman::Lot::apply_validation_predicates(const std::vector<ValidationPredicate> &predicates) {
+	for (const auto &pred : predicates) {
+		auto result = pred();
+		if (!result.first) {
+			return result;
+		}
+	}
+	return std::make_pair(true, "");
+}
+
+std::vector<lotman::Lot::ValidationPredicate> lotman::Lot::build_axiom_predicates(const std::string &lot_name,
+																				  bool check_children) {
+	std::vector<ValidationPredicate> predicates;
+
+	if (!Context::get_strict_hierarchy()) {
+		return predicates;
+	}
+
+	predicates.push_back([lot_name]() { return validate_axiom1(lot_name); });
+	predicates.push_back([lot_name]() { return validate_axiom2_for_parents_of(lot_name); });
+	predicates.push_back([lot_name]() { return validate_axiom3(lot_name); });
+
+	if (check_children) {
+		predicates.push_back([lot_name]() -> std::pair<bool, std::string> {
+			Lot lot(lot_name);
+			auto children_rp = lot.get_children(false);
+			if (!children_rp.second.empty()) {
+				return std::make_pair(false, "Failed to get children for '" + lot_name + "': " + children_rp.second);
+			}
+			for (const auto &child : lot.self_children) {
+				auto a1 = validate_axiom1(child.lot_name);
+				if (!a1.first)
+					return a1;
+				auto a2 = validate_axiom2_for_parents_of(child.lot_name);
+				if (!a2.first)
+					return a2;
+				auto a3 = validate_axiom3(child.lot_name);
+				if (!a3.first)
+					return a3;
+			}
+			return std::make_pair(true, "");
+		});
+	}
+
+	return predicates;
+}
+
+std::pair<bool, std::string> lotman::Lot::validate_axiom1(const std::string &child_lot_name) {
+	// Axiom 1: For each parent P of child C, the attributed amount from C to P
+	// must not exceed P's own MPAs.
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+
+		// Get child's MPAs
+		auto child_mpa = storage.get_pointer<db::ManagementPolicyAttributes>(child_lot_name);
+		if (!child_mpa) {
+			return std::make_pair(false, "Child lot '" + child_lot_name + "' not found");
+		}
+
+		// Get non-self parents from the parents table (authoritative source)
+		auto parent_records = storage.select(&db::Parent::parent, where(c(&db::Parent::lot_name) == child_lot_name));
+
+		// Get all attributions for this child
+		auto attributions = storage.get_all<db::ParentChildAttribution>(
+			where(c(&db::ParentChildAttribution::child_lot_name) == child_lot_name));
+
+		// Group by parent
+		std::map<std::string, std::map<std::string, double>> parent_attributed; // parent -> {mpa_key -> fraction}
+		for (const auto &attr : attributions) {
+			parent_attributed[attr.parent_lot_name][attr.mpa_key] = attr.fraction;
+		}
+
+		// Iterate over actual parents from the parents table, not just attribution rows
+		for (const auto &parent_name : parent_records) {
+			if (parent_name == child_lot_name)
+				continue; // skip self-parent
+
+			// Ensure this parent has attribution rows
+			if (parent_attributed.find(parent_name) == parent_attributed.end()) {
+				return std::make_pair(false, "Hierarchy attribution error: parent lot '" + parent_name +
+												 "' has no attribution rows for child lot '" + child_lot_name +
+												 "'; attribution data may be missing or stale.");
+			}
+
+			const auto &fractions = parent_attributed.at(parent_name);
+			auto parent_mpa = storage.get_pointer<db::ManagementPolicyAttributes>(parent_name);
+			if (!parent_mpa) {
+				return std::make_pair(false, "Parent lot '" + parent_name + "' not found");
+			}
+
+			// Compute attributed values
+			double attr_ded =
+				fractions.count("dedicated_GB") ? fractions.at("dedicated_GB") * child_mpa->dedicated_GB : 0.0;
+			double attr_opp = fractions.count("opportunistic_GB")
+								  ? fractions.at("opportunistic_GB") * child_mpa->opportunistic_GB
+								  : 0.0;
+			double attr_obj = fractions.count("max_num_objects")
+								  ? std::round(fractions.at("max_num_objects") * child_mpa->max_num_objects)
+								  : 0.0;
+
+			// Check: attributed dedicated ≤ parent dedicated
+			if (attr_ded > parent_mpa->dedicated_GB + 1e-9) {
+				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
+												 std::to_string(attr_ded) + " dedicated_GB to parent lot '" +
+												 parent_name +
+												 "', which exceeds the parent's dedicated_GB allocation of " +
+												 std::to_string(parent_mpa->dedicated_GB) +
+												 ". A child lot's allocation may not exceed any parent's.");
+			}
+
+			// Check: attributed (ded+opp) ≤ parent (ded+opp)
+			double attr_total = attr_ded + attr_opp;
+			double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
+			if (attr_total > parent_total + 1e-9) {
+				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
+												 std::to_string(attr_total) +
+												 " total GB (dedicated + opportunistic) to parent lot '" + parent_name +
+												 "', which exceeds the parent's combined allocation of " +
+												 std::to_string(parent_total) +
+												 " GB. A child lot's allocation may not exceed any parent's.");
+			}
+
+			// Check: attributed objects ≤ parent objects
+			if (attr_obj > parent_mpa->max_num_objects) {
+				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
+												 std::to_string(static_cast<int64_t>(attr_obj)) +
+												 " max_num_objects to parent lot '" + parent_name +
+												 "', which exceeds the parent's max_num_objects allocation of " +
+												 std::to_string(parent_mpa->max_num_objects) +
+												 ". A child lot's allocation may not exceed any parent's.");
+			}
+		}
+
+		return std::make_pair(true, "");
+	} catch (const std::exception &e) {
+		return std::make_pair(false,
+							  std::string("Hierarchy validation (per-parent allocation check) failed: ") + e.what());
+	}
+}
+
+std::pair<bool, std::string> lotman::Lot::validate_axiom2_for_parents_of(const std::string &child_lot_name) {
+	// Axiom 2 (time-aware): For each parent P, at no point in time may the sum of
+	// concurrently-active children's attributed MPAs exceed P's own MPAs.
+	// Uses a sweep-line over children's [creation_time, expiration_time) intervals.
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+
+		// Get the parents of this child (non-self)
+		auto parent_records = storage.select(&db::Parent::parent, where(c(&db::Parent::lot_name) == child_lot_name));
+
+		for (const auto &parent_name : parent_records) {
+			if (parent_name == child_lot_name)
+				continue; // skip self-parent
+
+			auto parent_mpa = storage.get_pointer<db::ManagementPolicyAttributes>(parent_name);
+			if (!parent_mpa) {
+				return std::make_pair(false, "Parent lot '" + parent_name + "' not found");
+			}
+
+			// Build sweep-line events from children's attributions
+			auto events = build_attribution_events(parent_name);
+			auto peak = run_sweep_line(events);
+
+			// Check: peak dedicated ≤ parent dedicated
+			if (peak.peak_ded > parent_mpa->dedicated_GB + 1e-9) {
+				return std::make_pair(
+					false, "Hierarchy violation: peak concurrent dedicated_GB across children of parent lot '" +
+							   parent_name + "' is " + std::to_string(peak.peak_ded) +
+							   ", which exceeds the parent's dedicated_GB allocation of " +
+							   std::to_string(parent_mpa->dedicated_GB) +
+							   ". The combined allocations of children active at the same time may not exceed the "
+							   "parent's capacity.");
+			}
+
+			// Check: peak (ded+opp) ≤ parent (ded+opp)
+			// Use peak_total which is the true max of (ded+opp) at a single point in time,
+			// not the sum of independent peaks which can occur at different times.
+			double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
+			if (peak.peak_total > parent_total + 1e-9) {
+				return std::make_pair(false, "Hierarchy violation: peak concurrent total GB (dedicated + "
+											 "opportunistic) across children of parent lot '" +
+												 parent_name + "' is " + std::to_string(peak.peak_total) +
+												 ", which exceeds the parent's combined allocation of " +
+												 std::to_string(parent_total) +
+												 " GB. The combined allocations of children active at the same time "
+												 "may not exceed the parent's capacity.");
+			}
+
+			// Check: peak objects ≤ parent objects
+			if (std::round(peak.peak_obj) > parent_mpa->max_num_objects) {
+				return std::make_pair(
+					false, "Hierarchy violation: peak concurrent max_num_objects across children of parent lot '" +
+							   parent_name + "' is " + std::to_string(static_cast<int64_t>(peak.peak_obj)) +
+							   ", which exceeds the parent's max_num_objects allocation of " +
+							   std::to_string(parent_mpa->max_num_objects) +
+							   ". The combined allocations of children active at the same time may not exceed the "
+							   "parent's capacity.");
+			}
+		}
+
+		return std::make_pair(true, "");
+	} catch (const std::exception &e) {
+		return std::make_pair(false, std::string("Hierarchy validation (concurrent children capacity check) failed: ") +
+										 e.what());
+	}
+}
+
+std::pair<bool, std::string> lotman::Lot::validate_axiom3(const std::string &child_lot_name) {
+	// Axiom 3: A child lot's timestamps must fit within all parents' timestamps:
+	// child.creation_time ≥ parent.creation_time
+	// child.expiration_time ≤ parent.expiration_time
+	// child.deletion_time ≤ parent.deletion_time
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+
+		auto child_mpa = storage.get_pointer<db::ManagementPolicyAttributes>(child_lot_name);
+		if (!child_mpa) {
+			return std::make_pair(false, "Child lot '" + child_lot_name + "' not found");
+		}
+
+		auto parent_records = storage.select(&db::Parent::parent, where(c(&db::Parent::lot_name) == child_lot_name));
+
+		for (const auto &parent_name : parent_records) {
+			if (parent_name == child_lot_name)
+				continue; // skip self-parent
+
+			auto parent_mpa = storage.get_pointer<db::ManagementPolicyAttributes>(parent_name);
+			if (!parent_mpa) {
+				return std::make_pair(false, "Parent lot '" + parent_name + "' not found");
+			}
+
+			if (child_mpa->creation_time < parent_mpa->creation_time) {
+				return std::make_pair(
+					false, "Hierarchy violation: child lot '" + child_lot_name + "' has a creation_time (" +
+							   std::to_string(child_mpa->creation_time) + ") earlier than parent lot '" + parent_name +
+							   "' creation_time (" + std::to_string(parent_mpa->creation_time) +
+							   "). A child lot's time window must be contained within every parent's time window.");
+			}
+
+			if (child_mpa->expiration_time > parent_mpa->expiration_time) {
+				return std::make_pair(
+					false, "Hierarchy violation: child lot '" + child_lot_name + "' has an expiration_time (" +
+							   std::to_string(child_mpa->expiration_time) + ") later than parent lot '" + parent_name +
+							   "' expiration_time (" + std::to_string(parent_mpa->expiration_time) +
+							   "). A child lot's time window must be contained within every parent's time window.");
+			}
+
+			if (child_mpa->deletion_time > parent_mpa->deletion_time) {
+				return std::make_pair(
+					false, "Hierarchy violation: child lot '" + child_lot_name + "' has a deletion_time (" +
+							   std::to_string(child_mpa->deletion_time) + ") later than parent lot '" + parent_name +
+							   "' deletion_time (" + std::to_string(parent_mpa->deletion_time) +
+							   "). A child lot's time window must be contained within every parent's time window.");
+			}
+		}
+
+		return std::make_pair(true, "");
+	} catch (const std::exception &e) {
+		return std::make_pair(false,
+							  std::string("Hierarchy validation (time window containment check) failed: ") + e.what());
+	}
+}
+
+/**
  * Functions specific to Checks class
  */
 
@@ -2267,6 +3423,22 @@ bool lotman::Checks::will_be_orphaned(const std::string &LTBR, const std::string
 
 void lotman::Context::set_caller(const std::string caller) {
 	m_caller = std::make_shared<std::string>(caller);
+}
+
+void lotman::Context::set_strict_hierarchy(bool enabled) {
+	m_strict_hierarchy = enabled;
+}
+
+std::pair<bool, std::string> lotman::Context::set_contraction_policy(const std::string &policy) {
+	if (policy != "none" && policy != "alive" && policy != "always") {
+		return std::make_pair(false, "Contraction policy must be one of: 'none', 'alive', 'always'. Got: " + policy);
+	}
+	m_contraction_policy = policy;
+	return std::make_pair(true, "");
+}
+
+void lotman::Context::set_admin_override(bool enabled) {
+	m_admin_override = enabled;
 }
 
 std::pair<bool, std::string> lotman::Context::set_lot_home(const std::string dir_path) {

--- a/src/lotman_internal.h
+++ b/src/lotman_internal.h
@@ -1,6 +1,7 @@
 // #include <algorithm>
 // #include <stdio.h>
 // #include <string>
+#include <functional>
 #include <nlohmann/json.hpp>
 #include <vector>
 
@@ -168,7 +169,7 @@ class Lot {
 	void init_self_usage();
 	static std::pair<bool, std::string> lot_exists(const std::string &lot_name);
 	std::pair<bool, std::string> check_if_root();
-	std::pair<bool, std::string> store_lot();
+	std::pair<bool, std::string> store_lot(const json &parent_attributions_json = json());
 	std::pair<bool, std::string> destroy_lot();
 	std::pair<bool, std::string> destroy_lot_recursive();
 
@@ -181,7 +182,7 @@ class Lot {
 	std::pair<json, std::string> get_restricting_attribute(const std::string &key, const bool recursive);
 
 	std::pair<json, std::string> get_lot_dirs(const bool recursive);
-	static std::pair<std::string, std::string> get_lot_from_dir(const std::string &dir_path);
+	static std::pair<std::string, std::string> get_lot_from_dir(const std::string &dir_path, int64_t query_time);
 
 	std::pair<json, std::string> get_lot_usage(const std::string &key, const bool recursive);
 
@@ -204,7 +205,8 @@ class Lot {
 		const std::map<std::string, std::vector<int>> &update_str_map = std::map<std::string, std::vector<int>>(),
 		const std::map<int64_t, std::vector<int>> &update_int_map = std::map<int64_t, std::vector<int>>(),
 		const std::map<double, std::vector<int>> &update_dbl_map = std::map<double, std::vector<int>>());
-	static std::pair<bool, std::string> update_usage_by_dirs(const json &update_JSON, bool deltaMode);
+	static std::pair<bool, std::string> update_usage_by_dirs(const json &update_JSON, bool deltaMode,
+															 int64_t query_time);
 	std::pair<bool, std::string> check_context_for_parents(const std::vector<std::string> &parents,
 														   bool include_self = false, bool new_lot = false);
 	std::pair<bool, std::string> check_context_for_parents(const std::vector<Lot> &parents, bool include_self = false,
@@ -222,14 +224,79 @@ class Lot {
 																			  const bool recursive_children);
 	static std::pair<std::vector<std::string>, std::string> get_lots_past_obj(const bool recursive_quota,
 																			  const bool recursive_children);
+
+	// Hierarchical-aware overloads: when hierarchical=true, uses adjusted usage
+	// and returns depth-ordered results (deepest/leaf lots first).
+	// NOTE: When hierarchical=true, recursive_quota and recursive_children are
+	// not used — the hierarchical SQL query has its own built-in logic.
+	// They are only forwarded to the non-hierarchical path when hierarchical=false.
+	static std::pair<std::vector<std::string>, std::string>
+	get_lots_past_opp(const bool recursive_quota, const bool recursive_children, const bool hierarchical);
+	static std::pair<std::vector<std::string>, std::string>
+	get_lots_past_ded(const bool recursive_quota, const bool recursive_children, const bool hierarchical);
+	static std::pair<std::vector<std::string>, std::string>
+	get_lots_past_obj(const bool recursive_quota, const bool recursive_children, const bool hierarchical);
+
+	// Strict hierarchy validation methods
+	static std::pair<bool, std::string> validate_axiom1(const std::string &child_lot_name);
+	static std::pair<bool, std::string> validate_axiom2_for_parents_of(const std::string &child_lot_name);
+	static std::pair<bool, std::string> validate_axiom3(const std::string &child_lot_name);
+
+	// Validation predicate: returns (success, error_message)
+	using ValidationPredicate = std::function<std::pair<bool, std::string>()>;
+
+	// Apply predicates sequentially; return first failure or (true, "")
+	static std::pair<bool, std::string> apply_validation_predicates(const std::vector<ValidationPredicate> &predicates);
+
+	// Build axiom predicates for a lot. If check_children is true, also validates
+	// each direct child against the lot. Returns empty vector if strict hierarchy is off.
+	static std::vector<ValidationPredicate> build_axiom_predicates(const std::string &lot_name,
+																   bool check_children = false);
+
+	// Attribution computation: compute how a child's MPAs are split across its parents,
+	// then store into parent_child_attributions table.
+	// parent_attributions_json is optional; missing parents get equal split of remainder.
+	std::pair<bool, std::string> compute_and_store_attributions(const json &parent_attributions_json = json());
+
+	// Update existing attributions for this lot
+	std::pair<bool, std::string> update_attributions(const json &parent_attributions_json);
+
+	// Contraction policy check for lot deletion. Returns (false, reason) if blocked.
+	static std::pair<bool, std::string> check_contraction_for_deletion(const std::string &lot_name);
+
+	// Check whether a lot is currently "alive" (creation_time <= now < expiration_time;
+	// i.e. the active interval is half-open).
+	// Returns (true, "") if alive, (false, "") if not alive, or (false, error) on failure.
+	static std::pair<bool, std::string> is_lot_alive(const std::string &lot_name);
 	static std::pair<std::vector<std::string>, std::string> list_all_lots();
 	static std::pair<std::vector<std::string>, std::string> get_lots_from_dir(const std::string &dir,
-																			  const bool recursive);
+																			  const bool recursive, int64_t query_time);
+
+	// Advisory: compute available capacity under a parent lot during a time window.
+	// Returns JSON with available and peak values for each resource type.
+	// WARNING: This is NOT the reservation mechanism. Capacity enforcement is
+	// performed atomically by validate_axiom2_for_parents_of inside the lot creation transaction.
+	// Use this method only for informational/monitoring purposes.
+	static std::pair<json, std::string> get_available_capacity(const std::string &parent_lot_name, int64_t start_time,
+															   int64_t end_time);
+
+	// Non-transactional update helpers used by the C-API dispatchers
+	// (lotman_update_lot / lotman_add_to_lot) so the entire dispatch can
+	// run inside a single outer storage.transaction(). Each *_in_txn helper
+	// performs the same work as its public counterpart (including any
+	// per-step axiom revalidation), but does NOT open its own transaction.
+	// Returns false and sets txn_error on failure to trigger rollback.
+	bool update_owner_in_txn(const std::string &update_val, std::string &txn_error);
+	bool update_parents_in_txn(const json &update_arr, std::string &txn_error);
+	bool update_paths_in_txn(const json &update_arr, std::string &txn_error);
+	bool update_man_policy_attrs_in_txn(const std::string &update_key, double update_val, std::string &txn_error);
+	bool update_attributions_in_txn(const json &parent_attributions_json, std::string &txn_error);
+	bool add_paths_in_txn(const std::vector<json> &paths, std::string &txn_error);
+	bool add_parents_in_txn(const std::vector<Lot> &parents, std::string &txn_error);
 
   private:
 	std::pair<bool, std::string> write_new();
 	std::pair<bool, std::string> delete_lot_from_db();
-	std::pair<bool, std::string> store_new_paths(const std::vector<json> &new_paths);
 	std::pair<bool, std::string> store_new_parents(const std::vector<Lot> &new_parents);
 	std::pair<bool, std::string> store_updates(
 		const std::string &update_query,
@@ -238,6 +305,22 @@ class Lot {
 		const std::map<double, std::vector<int>> &update_dbl_map = std::map<double, std::vector<int>>());
 	std::pair<bool, std::string> remove_parents_from_db(const std::vector<std::string> &parents);
 	std::pair<bool, std::string> remove_paths_from_db(const std::vector<std::string> &paths);
+
+	// Check whether a path conflicts with another lot's claim during overlapping time ranges.
+	// Caller MUST be inside an active storage.transaction().
+	static std::pair<bool, std::string> check_path_temporal_overlap(const std::string &lot_name,
+																	const std::string &normalized_path,
+																	int64_t creation_time, int64_t expiration_time);
+
+	// Non-transactional helpers for composing inside an outer transaction.
+	// Callers MUST hold an active storage.transaction().
+	bool add_parents_impl(const std::vector<Lot> &parents, std::string &txn_error);
+	bool update_parents_impl(const json &update_arr, std::string &txn_error);
+
+	// Reload parents + MPAs from DB, clear old attributions, recompute with equal split,
+	// and validate axioms. Caller MUST hold an active storage.transaction().
+	// Returns false and sets txn_error on failure.
+	bool reload_and_recompute_attributions(std::string &txn_error);
 };
 
 class DirUsageUpdate : public Lot {
@@ -246,8 +329,11 @@ class DirUsageUpdate : public Lot {
 	std::string m_current_path;
 	std::string m_parent_prefix;
 
-	DirUsageUpdate() : m_depth{0}, m_current_path{}, m_parent_prefix{} {}
-	DirUsageUpdate(int depth, std::string path) : m_depth{depth}, m_current_path{}, m_parent_prefix{path} {}
+	int64_t m_query_time;
+
+	DirUsageUpdate() : m_depth{0}, m_current_path{}, m_parent_prefix{}, m_query_time{0} {}
+	DirUsageUpdate(int depth, std::string path, int64_t query_time)
+		: m_depth{depth}, m_current_path{}, m_parent_prefix{path}, m_query_time{query_time} {}
 
 	std::pair<bool, std::string> JSON_math(json update_JSON, std::vector<Lot> *return_lots) {
 		std::map<std::string, double> size_updates;
@@ -284,7 +370,7 @@ class DirUsageUpdate : public Lot {
 			}
 
 			// Figure out which lot to associate with the dir
-			auto rp_vec_str = get_lots_from_dir(m_current_path, false);
+			auto rp_vec_str = get_lots_from_dir(m_current_path, false, m_query_time);
 			if (!rp_vec_str.second.empty()) { // There was an error
 				std::string int_err = rp_vec_str.second;
 				std::string ext_err = "Failure on call to get_lots_from_dir: ";
@@ -355,7 +441,7 @@ class DirUsageUpdate : public Lot {
 						subdir_path = m_current_path + subdir["path"].get<std::string>();
 					}
 
-					auto subdir_lot_rp = get_lots_from_dir(subdir_path, false);
+					auto subdir_lot_rp = get_lots_from_dir(subdir_path, false, m_query_time);
 					if (subdir_lot_rp.second.empty() && !subdir_lot_rp.first.empty() &&
 						subdir_lot_rp.first[0] != lot.lot_name) {
 						// Subdir belongs to a different lot (e.g., due to exclusion)
@@ -371,7 +457,7 @@ class DirUsageUpdate : public Lot {
 					for (const auto &subdir : update["subdirs"]) {
 						subtract_subdir_values(subdir);
 					}
-					DirUsageUpdate dirUpdate(m_depth + 1, m_current_path);
+					DirUsageUpdate dirUpdate(m_depth + 1, m_current_path, m_query_time);
 					dirUpdate.JSON_math(update["subdirs"], return_lots);
 				} else if (!other_lot_subdirs.empty()) {
 					// Recursive path but some subdirs are excluded - subtract only those
@@ -379,7 +465,7 @@ class DirUsageUpdate : public Lot {
 						subtract_subdir_values(subdir);
 					}
 					// Process only the subdirs that belong to other lots
-					DirUsageUpdate dirUpdate(m_depth + 1, m_current_path);
+					DirUsageUpdate dirUpdate(m_depth + 1, m_current_path, m_query_time);
 					dirUpdate.JSON_math(other_lot_subdirs, return_lots);
 				}
 				// If recursive and all subdirs belong to same lot, do nothing extra -
@@ -432,6 +518,12 @@ class DirUsageUpdate : public Lot {
 	}
 };
 
+// NOTE: Context is NOT thread-safe. All static members (m_caller, m_home,
+// m_strict_hierarchy, m_contraction_policy, m_admin_override) are accessed
+// without synchronization. Callers must ensure Context is configured from
+// a single thread before invoking LotMan operations. This is a pre-existing
+// design constraint — the PooledConnection pool handles DB-level concurrency,
+// but Context state must be set up front.
 class Context {
   public:
 	Context() {}
@@ -445,9 +537,37 @@ class Context {
 		return *m_home;
 	}
 
+	// Strict hierarchy enforcement: when true, lot creation/updates must satisfy
+	// Axioms 1-3 (child MPAs within parent bounds, aggregate children within parent,
+	// timestamp containment)
+	static void set_strict_hierarchy(bool enabled);
+	static bool get_strict_hierarchy() {
+		return m_strict_hierarchy;
+	}
+
+	// Contraction policy: controls whether lot MPA reductions (and deletions) are allowed.
+	// "none" (default): no restrictions on MPA reductions
+	// "alive": block reductions on lots where creation_time <= now <= expiration_time
+	// "always": block any MPA reduction regardless of time
+	static std::pair<bool, std::string> set_contraction_policy(const std::string &policy);
+	static std::string get_contraction_policy() {
+		return m_contraction_policy;
+	}
+
+	// Admin override: when true, bypasses contraction policy checks.
+	// The calling library is responsible for verifying the caller is a root lot owner
+	// before setting this.
+	static void set_admin_override(bool enabled);
+	static bool get_admin_override() {
+		return m_admin_override;
+	}
+
   private:
 	static std::shared_ptr<std::string> m_caller;
 	static std::shared_ptr<std::string> m_home;
+	static bool m_strict_hierarchy;
+	static std::string m_contraction_policy;
+	static bool m_admin_override;
 
 	static std::vector<std::string> path_split(const std::string dir_path);
 	static std::pair<bool, std::string> mkdir_and_parents_if_needed(const std::string dir_path);

--- a/src/schemas.h
+++ b/src/schemas.h
@@ -5,7 +5,34 @@ using json_validator = nlohmann::json_schema::json_validator;
 
 namespace lotman_schemas {
 
-json new_lot_schema = R"(
+// Shared schema fragment for parent_attributions, used by new_lot_schema,
+// lot_update_schema, and lot_additions_schema.
+const json parent_attributions_def = R"({
+    "description": "How the child's MPAs are attributed across its parents. Keys are parent lot names.",
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "dedicated_GB": {
+                "type": "number",
+                "minimum": 0
+            },
+            "opportunistic_GB": {
+                "type": "number",
+                "minimum": 0
+            },
+            "max_num_objects": {
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 1
+            }
+        }
+    }
+})"_json;
+
+inline json new_lot_schema = []() {
+	json s = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -106,8 +133,12 @@ json new_lot_schema = R"(
     "required": ["lot_name", "owner", "parents", "management_policy_attrs"]
 }
 )"_json;
+	s["properties"]["parent_attributions"] = parent_attributions_def;
+	return s;
+}();
 
-json lot_update_schema = R"(
+inline json lot_update_schema = []() {
+	json s = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -217,8 +248,15 @@ json lot_update_schema = R"(
     "required": ["lot_name"]
 }
 )"_json;
+	// `parent_attributions` is accepted in the same envelope as the rest of the
+	// update payload (see lotman_update_lot). Wholesale-replace semantics: any
+	// parent omitted from this object gets the equal-split remainder of the
+	// child's MPAs.
+	s["properties"]["parent_attributions"] = parent_attributions_def;
+	return s;
+}();
 
-json lot_rm_parents_schema = R"(
+inline json lot_rm_parents_schema = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -244,7 +282,7 @@ json lot_rm_parents_schema = R"(
 }
 )"_json;
 
-json lot_rm_paths_schema = R"(
+inline json lot_rm_paths_schema = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -264,7 +302,8 @@ json lot_rm_paths_schema = R"(
 }
 )"_json;
 
-json lot_additions_schema = R"(
+inline json lot_additions_schema = []() {
+	json s = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -314,8 +353,13 @@ json lot_additions_schema = R"(
     "required": ["lot_name"]
 }
 )"_json;
+	// Allow callers to specify per-parent shares for the post-addition lot;
+	// any parent omitted from this object gets the equal-split remainder.
+	s["properties"]["parent_attributions"] = parent_attributions_def;
+	return s;
+}();
 
-json get_policy_attrs_schema = R"(
+inline json get_policy_attrs_schema = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -362,7 +406,7 @@ json get_policy_attrs_schema = R"(
 }
 )"_json;
 
-json get_usage_schema = R"(
+inline json get_usage_schema = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -409,7 +453,7 @@ json get_usage_schema = R"(
 }
 )"_json;
 
-json update_usage_schema = R"(
+inline json update_usage_schema = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -448,7 +492,7 @@ json update_usage_schema = R"(
 }
 )"_json;
 
-json update_usage_delta_schema = R"(
+inline json update_usage_delta_schema = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -490,7 +534,7 @@ NOTE: This schema only validates a single top level object, but does get the arr
 TODO: Fix this so it validates the top level array instead of validating each individualobject
 	  in the array
 */
-json update_usage_by_dir_schema = R"(
+inline json update_usage_by_dir_schema = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -529,7 +573,7 @@ json update_usage_by_dir_schema = R"(
 }
 )"_json;
 
-json update_usage_by_dir_delta_schema = R"(
+inline json update_usage_by_dir_delta_schema = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(lotman-gtest main.cpp orm_tests.cpp migration_tests.cpp ../src/lotman.cpp ../src/lotman_db.cpp ../src/lotman_internal.cpp)
+add_executable(lotman-gtest main.cpp orm_tests.cpp migration_tests.cpp strict_hierarchy_tests.cpp ../src/lotman.cpp ../src/lotman_db.cpp ../src/lotman_internal.cpp)
 if( NOT LOTMAN_EXTERNAL_GTEST )
     add_dependencies(lotman-gtest gtest)
     include_directories("${PROJECT_SOURCE_DIR}/vendor/gtest/googletest/include")

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -861,7 +861,7 @@ TEST_F(LotManTest, SetGetUsageTest) {
 		}
 	])";
 	raw_err = nullptr;
-	rv = lotman_update_lot_usage_by_dir(update_JSON_str, deltaMode, &raw_err);
+	rv = lotman_update_lot_usage_by_dir(update_JSON_str, deltaMode, 150, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 
@@ -922,7 +922,7 @@ TEST_F(LotManTest, SetGetUsageTest) {
 		"subdirs": []
 	}])";
 	raw_err = nullptr;
-	rv = lotman_update_lot_usage_by_dir(update2_JSON_str, deltaMode, &raw_err);
+	rv = lotman_update_lot_usage_by_dir(update2_JSON_str, deltaMode, 150, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 
@@ -946,7 +946,7 @@ TEST_F(LotManTest, SetGetUsageTest) {
 		"subdirs": []
 	}])";
 	raw_err = nullptr;
-	rv = lotman_update_lot_usage_by_dir(update3_JSON_str, deltaMode, &raw_err);
+	rv = lotman_update_lot_usage_by_dir(update3_JSON_str, deltaMode, 150, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_NE(rv, 0) << err_msg.get();
 }
@@ -1297,7 +1297,7 @@ TEST_F(LotManTest, LotsQueryTest) {
 	// Check for lots past opportunistic storage limit
 	raw_output = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_opp(true, true, &raw_output, &raw_err);
+	rv = lotman_get_lots_past_opp(true, true, &raw_output, false, &raw_err);
 	err_msg.reset(raw_err);
 	UniqueStringList output3(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();
@@ -1313,7 +1313,7 @@ TEST_F(LotManTest, LotsQueryTest) {
 	// Check for lots past dedicated storage limit
 	raw_output = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_ded(true, true, &raw_output, &raw_err);
+	rv = lotman_get_lots_past_ded(true, true, &raw_output, false, &raw_err);
 	err_msg.reset(raw_err);
 	UniqueStringList output4(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();
@@ -1329,7 +1329,7 @@ TEST_F(LotManTest, LotsQueryTest) {
 	// Check for lots past object storage limit
 	raw_output = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_obj(true, true, &raw_output, &raw_err);
+	rv = lotman_get_lots_past_obj(true, true, &raw_output, false, &raw_err);
 	err_msg.reset(raw_err);
 	UniqueStringList output5(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();
@@ -1433,7 +1433,7 @@ TEST_F(LotManTest, GetLotJSONTest) {
 		"subdirs": []
 	}])";
 	raw_err = nullptr;
-	rv = lotman_update_lot_usage_by_dir(update_JSON_str, false, &raw_err);
+	rv = lotman_update_lot_usage_by_dir(update_JSON_str, false, 150, &raw_err);
 	setup_err.reset(raw_err);
 	ASSERT_EQ(rv, 0) << setup_err.get();
 
@@ -1446,7 +1446,7 @@ TEST_F(LotManTest, GetLotJSONTest) {
 		"subdirs": []
 	}])";
 	raw_err = nullptr;
-	rv = lotman_update_lot_usage_by_dir(update2_JSON_str, true, &raw_err);
+	rv = lotman_update_lot_usage_by_dir(update2_JSON_str, true, 150, &raw_err);
 	setup_err.reset(raw_err);
 	ASSERT_EQ(rv, 0) << setup_err.get();
 
@@ -1491,14 +1491,14 @@ TEST_F(LotManTest, GetLotJSONTest) {
 			{
 				"exclude": false,
 				"lot_name": "lot3",
-				"path": "/updated/path/",
-				"recursive": false
+				"path": "/foo/barr/",
+				"recursive": true
 			},
 			{
 				"exclude": false,
 				"lot_name": "lot3",
-				"path": "/foo/barr/",
-				"recursive": true
+				"path": "/updated/path/",
+				"recursive": false
 			}
 		],
 		"usage": {
@@ -1552,14 +1552,14 @@ TEST_F(LotManTest, GetLotJSONTest) {
 			{
 				"exclude": false,
 				"lot_name": "lot3",
-				"path": "/updated/path/",
-				"recursive": false
+				"path": "/foo/barr/",
+				"recursive": true
 			},
 			{
 				"exclude": false,
 				"lot_name": "lot3",
-				"path": "/foo/barr/",
-				"recursive": true
+				"path": "/updated/path/",
+				"recursive": false
 			},
 			{
 				"exclude": false,
@@ -1675,7 +1675,7 @@ TEST_F(LotManTest, LotsFromDirTest) {
 	char **raw_output = nullptr;
 	raw_err = nullptr;
 	const char *dir = "/1/2/3/4"; // Get a path
-	rv = lotman_get_lots_from_dir(dir, true, &raw_output, &raw_err);
+	rv = lotman_get_lots_from_dir(dir, true, 150, &raw_output, &raw_err);
 	UniqueCString err_msg(raw_err);
 	UniqueStringList output(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();
@@ -1692,7 +1692,7 @@ TEST_F(LotManTest, LotsFromDirTest) {
 	raw_output = nullptr;
 	raw_err = nullptr;
 	const char *dir2 = "/foo/barr"; // Make sure parsing doesn't grab lot associated with /foo/bar
-	rv = lotman_get_lots_from_dir(dir2, false, &raw_output, &raw_err);
+	rv = lotman_get_lots_from_dir(dir2, false, 150, &raw_output, &raw_err);
 	err_msg.reset(raw_err);
 	UniqueStringList output2(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();
@@ -1932,7 +1932,7 @@ TEST_F(LotManTest, PathTrailingSlashNormalizationTest) {
 
 	// Verify lookup works WITHOUT trailing slash
 	char **lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/no/slash/here", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/no/slash/here", false, 1750000000, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -1941,7 +1941,7 @@ TEST_F(LotManTest, PathTrailingSlashNormalizationTest) {
 
 	// Verify lookup works WITH trailing slash
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/no/slash/here/", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/no/slash/here/", false, 1750000000, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -1950,7 +1950,7 @@ TEST_F(LotManTest, PathTrailingSlashNormalizationTest) {
 
 	// Verify subdirectory lookup works (for recursive path)
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/no/slash/here/subdir/deeper", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/no/slash/here/subdir/deeper", false, 1750000000, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2051,7 +2051,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 
 	// Test get_lots_from_dir: /data/storage should return the lot
 	char **lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/storage", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/data/storage", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2060,7 +2060,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 
 	// Test get_lots_from_dir: /data/storage/subdir should return the lot (recursive, not excluded)
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/storage/subdir", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/data/storage/subdir", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2070,7 +2070,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 	// Test get_lots_from_dir: /data/storage/cache itself should NOT return exclusion_lot (excluded)
 	// It should return "default" since the path is excluded from exclusion_lot
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/storage/cache", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/data/storage/cache", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2080,7 +2080,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 	// Test get_lots_from_dir: /data/storage/cache/subdir should NOT return exclusion_lot (excluded recursively)
 	// It should return "default" since the subdir is under a RECURSIVE exclusion
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/storage/cache/subdir", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/data/storage/cache/subdir", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2089,7 +2089,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 
 	// Test get_lots_from_dir: /data/storage/cache/deep/nested/path should also be excluded (recursive exclusion)
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/storage/cache/deep/nested/path", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/data/storage/cache/deep/nested/path", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2098,7 +2098,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 
 	// Test NON-RECURSIVE exclusion: /data/storage/stuff itself should be excluded
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/storage/stuff", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/data/storage/stuff", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2108,7 +2108,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 	// Test NON-RECURSIVE exclusion: /data/storage/stuff/foo should be INCLUDED
 	// Because the exclusion is non-recursive, subdirs fall back to the parent inclusion /data/storage
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/storage/stuff/foo", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/data/storage/stuff/foo", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2118,7 +2118,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 
 	// Test NON-RECURSIVE exclusion: /data/storage/stuff/foo/bar/baz should also be INCLUDED
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/storage/stuff/foo/bar/baz", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/data/storage/stuff/foo/bar/baz", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2188,7 +2188,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 
 	// Test that /test/path/subdir still returns the lot (not excluded)
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/test/path/subdir", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/test/path/subdir", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2197,7 +2197,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 
 	// Test that /test/path/excluded returns "default" (excluded from default_exclude_lot)
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/test/path/excluded", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/test/path/excluded", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2249,7 +2249,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 
 	// /data/cache should be excluded
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/cache", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/data/cache", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	EXPECT_STREQ(lots_output[0], "default") << "/data/cache should be excluded";
@@ -2257,7 +2257,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 
 	// /data/cachedata should NOT be excluded (different path, just happens to have "cache" prefix)
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/cachedata", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/data/cachedata", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	EXPECT_STREQ(lots_output[0], "prefix_test_lot") << "/data/cachedata should NOT be excluded (different path)";
@@ -2265,7 +2265,7 @@ TEST_F(LotManTest, PathExclusionTest) {
 
 	// /data/cache/subdir should be excluded (under recursive exclusion)
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/cache/subdir", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/data/cache/subdir", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	EXPECT_STREQ(lots_output[0], "default") << "/data/cache/subdir should be excluded";
@@ -2325,7 +2325,7 @@ TEST_F(LotManTest, PathExclusionUpdateTest) {
 
 	// Verify get_lots_from_dir respects the update - should return "default" now
 	char **lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/update/test", false, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/update/test", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
 	ASSERT_NE(lots_output, nullptr);
@@ -2427,7 +2427,7 @@ TEST_F(LotManTest, UpdateUsageByDirWithExclusionsTest) {
 		}
 	])";
 
-	rv = lotman_update_lot_usage_by_dir(usage_update, false, &raw_err);
+	rv = lotman_update_lot_usage_by_dir(usage_update, false, 150, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << "Failed to update usage by dir: " << err_msg.get();
 
@@ -2481,7 +2481,7 @@ TEST_F(LotManTest, UpdateUsageByDirWithExclusionsTest) {
 		}
 	])";
 
-	rv = lotman_update_lot_usage_by_dir(delta_update, true, &raw_err);
+	rv = lotman_update_lot_usage_by_dir(delta_update, true, 150, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << "Failed delta update: " << err_msg.get();
 
@@ -2573,7 +2573,7 @@ TEST_F(LotManTest, UpdateUsageByDirNestedExclusionsTest) {
 		}
 	])";
 
-	rv = lotman_update_lot_usage_by_dir(nested_update, false, &raw_err);
+	rv = lotman_update_lot_usage_by_dir(nested_update, false, 150, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << "Failed nested update: " << err_msg.get();
 
@@ -2723,7 +2723,7 @@ TEST_F(LotManTest, UpdateUsageByDirIncludesSubdirsWithExclusionsTest) {
 		}
 	])";
 
-	rv = lotman_update_lot_usage_by_dir(usage_update, false, &raw_err);
+	rv = lotman_update_lot_usage_by_dir(usage_update, false, 150, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << "Failed usage update: " << err_msg.get();
 

--- a/test/migration_tests.cpp
+++ b/test/migration_tests.cpp
@@ -439,7 +439,7 @@ TEST_F(MigrationTest, TestPathLookupWithoutTrailingSlash) {
 
 	// Test lookup WITHOUT trailing slash
 	char **output = nullptr;
-	rv = lotman_get_lots_from_dir("/test/path", false, &output, &raw_err);
+	rv = lotman_get_lots_from_dir("/test/path", false, 1750000000, &output, &raw_err);
 	UniqueCString err5(raw_err);
 	ASSERT_EQ(rv, 0) << "Failed to get lots from dir: " << (err5.get() ? err5.get() : "unknown error");
 	ASSERT_NE(output, nullptr);
@@ -448,7 +448,7 @@ TEST_F(MigrationTest, TestPathLookupWithoutTrailingSlash) {
 
 	// Test lookup WITH trailing slash
 	output = nullptr;
-	rv = lotman_get_lots_from_dir("/test/path/", false, &output, &raw_err);
+	rv = lotman_get_lots_from_dir("/test/path/", false, 1750000000, &output, &raw_err);
 	UniqueCString err6(raw_err);
 	ASSERT_EQ(rv, 0) << "Failed to get lots from dir: " << (err6.get() ? err6.get() : "unknown error");
 	ASSERT_NE(output, nullptr);
@@ -457,7 +457,7 @@ TEST_F(MigrationTest, TestPathLookupWithoutTrailingSlash) {
 
 	// Test subdirectory lookup (recursive path)
 	output = nullptr;
-	rv = lotman_get_lots_from_dir("/test/path/subdir", false, &output, &raw_err);
+	rv = lotman_get_lots_from_dir("/test/path/subdir", false, 1750000000, &output, &raw_err);
 	UniqueCString err7(raw_err);
 	ASSERT_EQ(rv, 0) << "Failed to get lots from dir: " << (err7.get() ? err7.get() : "unknown error");
 	ASSERT_NE(output, nullptr);

--- a/test/strict_hierarchy_tests.cpp
+++ b/test/strict_hierarchy_tests.cpp
@@ -1,0 +1,6018 @@
+#include "../src/lotman.h"
+#include "../src/lotman_db.h"
+#include "../src/lotman_internal.h"
+#include "test_utils.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+// Test fixture for strict hierarchy tests
+class StrictHierarchyTest : public ::testing::Test {
+  protected:
+	std::string tmp_dir;
+
+	void SetUp() override {
+		tmp_dir = create_temp_directory("lotman_strict_test");
+		char *raw_err = nullptr;
+		int rv = lotman_set_context_str("lot_home", tmp_dir.c_str(), &raw_err);
+		UniqueCString err(raw_err);
+		ASSERT_EQ(rv, 0) << err.get();
+		rv = lotman_set_context_str("caller", "owner1", &raw_err);
+		err.reset(raw_err);
+		ASSERT_EQ(rv, 0) << err.get();
+		// Reset all context to defaults at the start of each test
+		rv = lotman_set_context_str("strict_hierarchy", "false", &raw_err);
+		err.reset(raw_err);
+		ASSERT_EQ(rv, 0) << err.get();
+		rv = lotman_set_context_str("contraction_policy", "none", &raw_err);
+		err.reset(raw_err);
+		ASSERT_EQ(rv, 0) << err.get();
+		rv = lotman_set_context_str("admin_override", "false", &raw_err);
+		err.reset(raw_err);
+		ASSERT_EQ(rv, 0) << err.get();
+	}
+
+	void TearDown() override {
+		// Reset context so other tests aren't affected
+		char *raw_err = nullptr;
+		lotman_set_context_str("strict_hierarchy", "false", &raw_err);
+		free(raw_err);
+		raw_err = nullptr;
+		lotman_set_context_str("contraction_policy", "none", &raw_err);
+		free(raw_err);
+		raw_err = nullptr;
+		lotman_set_context_str("admin_override", "false", &raw_err);
+		free(raw_err);
+		std::filesystem::remove_all(tmp_dir);
+	}
+
+	void addLot(const char *lot_json) {
+		char *raw_err = nullptr;
+		int rv = lotman_add_lot(lot_json, &raw_err);
+		UniqueCString err_msg(raw_err);
+		ASSERT_EQ(rv, 0) << "Failed to add lot: " << (err_msg.get() ? err_msg.get() : "unknown");
+	}
+
+	void addDefaultLot() {
+		addLot(R"({
+			"lot_name": "default",
+			"owner": "owner1",
+			"parents": ["default"],
+			"paths": [{"path": "/default", "recursive": true}],
+			"management_policy_attrs": {
+				"dedicated_GB": 1000,
+				"opportunistic_GB": 500,
+				"max_num_objects": 10000,
+				"creation_time": 100,
+				"expiration_time": 9999,
+				"deletion_time": 99999
+			}
+		})");
+	}
+
+	// A root lot with generous resources
+	void addRootLot() {
+		addLot(R"({
+			"lot_name": "root",
+			"owner": "owner1",
+			"parents": ["root"],
+			"paths": [{"path": "/root/data", "recursive": true}],
+			"management_policy_attrs": {
+				"dedicated_GB": 100,
+				"opportunistic_GB": 50,
+				"max_num_objects": 1000,
+				"creation_time": 100,
+				"expiration_time": 9000,
+				"deletion_time": 9500
+			}
+		})");
+	}
+};
+
+namespace {
+
+// ============================================================================
+// Context string set/get tests
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, ContextSetGetStrictHierarchy) {
+	char *raw_err = nullptr;
+	char *raw_output = nullptr;
+
+	// Default should be false
+	int rv = lotman_get_context_str("strict_hierarchy", &raw_output, &raw_err);
+	UniqueCString err(raw_err);
+	UniqueCString output(raw_output);
+	ASSERT_EQ(rv, 0) << err.get();
+	EXPECT_STREQ(output.get(), "false");
+
+	// Set to true via "true"
+	rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	rv = lotman_get_context_str("strict_hierarchy", &raw_output, &raw_err);
+	err.reset(raw_err);
+	output.reset(raw_output);
+	ASSERT_EQ(rv, 0) << err.get();
+	EXPECT_STREQ(output.get(), "true");
+
+	// Set to false via "0"
+	rv = lotman_set_context_str("strict_hierarchy", "0", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	rv = lotman_get_context_str("strict_hierarchy", &raw_output, &raw_err);
+	err.reset(raw_err);
+	output.reset(raw_output);
+	ASSERT_EQ(rv, 0) << err.get();
+	EXPECT_STREQ(output.get(), "false");
+
+	// Set to true via "1"
+	rv = lotman_set_context_str("strict_hierarchy", "1", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	rv = lotman_get_context_str("strict_hierarchy", &raw_output, &raw_err);
+	err.reset(raw_err);
+	output.reset(raw_output);
+	ASSERT_EQ(rv, 0) << err.get();
+	EXPECT_STREQ(output.get(), "true");
+
+	// Invalid value should fail
+	rv = lotman_set_context_str("strict_hierarchy", "yes", &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(err.get(), nullptr);
+}
+
+TEST_F(StrictHierarchyTest, ContextSetGetContractionPolicy) {
+	char *raw_err = nullptr;
+	char *raw_output = nullptr;
+
+	// Default should be "none"
+	int rv = lotman_get_context_str("contraction_policy", &raw_output, &raw_err);
+	UniqueCString err(raw_err);
+	UniqueCString output(raw_output);
+	ASSERT_EQ(rv, 0) << err.get();
+	EXPECT_STREQ(output.get(), "none");
+
+	// Set to "alive"
+	rv = lotman_set_context_str("contraction_policy", "alive", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	rv = lotman_get_context_str("contraction_policy", &raw_output, &raw_err);
+	err.reset(raw_err);
+	output.reset(raw_output);
+	ASSERT_EQ(rv, 0) << err.get();
+	EXPECT_STREQ(output.get(), "alive");
+
+	// Set to "always"
+	rv = lotman_set_context_str("contraction_policy", "always", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	rv = lotman_get_context_str("contraction_policy", &raw_output, &raw_err);
+	err.reset(raw_err);
+	output.reset(raw_output);
+	ASSERT_EQ(rv, 0) << err.get();
+	EXPECT_STREQ(output.get(), "always");
+
+	// Set back to "none"
+	rv = lotman_set_context_str("contraction_policy", "none", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	rv = lotman_get_context_str("contraction_policy", &raw_output, &raw_err);
+	err.reset(raw_err);
+	output.reset(raw_output);
+	ASSERT_EQ(rv, 0) << err.get();
+	EXPECT_STREQ(output.get(), "none");
+
+	// Invalid value
+	rv = lotman_set_context_str("contraction_policy", "invalid", &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(err.get(), nullptr);
+}
+
+TEST_F(StrictHierarchyTest, ContextSetGetAdminOverride) {
+	char *raw_err = nullptr;
+	char *raw_output = nullptr;
+
+	// Default should be false
+	int rv = lotman_get_context_str("admin_override", &raw_output, &raw_err);
+	UniqueCString err(raw_err);
+	UniqueCString output(raw_output);
+	ASSERT_EQ(rv, 0) << err.get();
+	EXPECT_STREQ(output.get(), "false");
+
+	// Set to true
+	rv = lotman_set_context_str("admin_override", "true", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	rv = lotman_get_context_str("admin_override", &raw_output, &raw_err);
+	err.reset(raw_err);
+	output.reset(raw_output);
+	ASSERT_EQ(rv, 0) << err.get();
+	EXPECT_STREQ(output.get(), "true");
+
+	// Invalid value
+	rv = lotman_set_context_str("admin_override", "maybe", &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0);
+}
+
+// ============================================================================
+// Axiom 1: child's attributed portion must not exceed parent's MPAs
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, Axiom1ViolationDedicatedGB) {
+	addDefaultLot();
+
+	// Root lot with 10 GB dedicated
+	addLot(R"({
+		"lot_name": "parent_a1",
+		"owner": "owner1",
+		"parents": ["parent_a1"],
+		"paths": [{"path": "/a1/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Enable strict hierarchy
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Try to create a child that attributes MORE dedicated_GB to parent than parent has.
+	// Child claims 20 dedicated_GB, and attributes all 20 to parent_a1 (which only has 10).
+	const char *child_json = R"({
+		"lot_name": "child_a1",
+		"owner": "owner1",
+		"parents": ["parent_a1"],
+		"paths": [{"path": "/a1/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})";
+	// With equal-split default attribution, all 20 GB goes to parent_a1 (only parent).
+	// parent_a1 only has 10 GB. This should violate Axiom 1.
+	rv = lotman_add_lot(child_json, &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Adding a child that exceeds parent's dedicated_GB should fail under strict hierarchy";
+	EXPECT_NE(err.get(), nullptr);
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("exceeds the parent's") != std::string::npos)
+		<< "Error should report that the child's allocation exceeds the parent's, got: " << err_str;
+}
+
+TEST_F(StrictHierarchyTest, Axiom1ViolationMaxObjects) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "parent_obj",
+		"owner": "owner1",
+		"parents": ["parent_obj"],
+		"paths": [{"path": "/obj/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child with 200 max_num_objects, parent only has 50
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_obj",
+		"owner": "owner1",
+		"parents": ["parent_obj"],
+		"paths": [{"path": "/obj/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 200,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Child with more objects than parent should fail";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("exceeds the parent's") != std::string::npos)
+		<< "Error should report that the child's allocation exceeds the parent's, got: " << err_str;
+}
+
+TEST_F(StrictHierarchyTest, Axiom1PassesWhenChildFitsInParent) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "parent_fit",
+		"owner": "owner1",
+		"parents": ["parent_fit"],
+		"paths": [{"path": "/fit/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child well within parent's limits
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_fit",
+		"owner": "owner1",
+		"parents": ["parent_fit"],
+		"paths": [{"path": "/fit/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Child within parent's limits should succeed: " << (err.get() ? err.get() : "");
+}
+
+// ============================================================================
+// Axiom 2: sum of all children's attributions must not exceed parent's MPAs
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, Axiom2ViolationSumExceedsParent) {
+	addDefaultLot();
+
+	// Parent with 10 GB dedicated
+	addLot(R"({
+		"lot_name": "parent_a2",
+		"owner": "owner1",
+		"parents": ["parent_a2"],
+		"paths": [{"path": "/a2/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// First child: 6 dedicated_GB (fits within 10)
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a2_1",
+		"owner": "owner1",
+		"parents": ["parent_a2"],
+		"paths": [{"path": "/a2/child1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 6,
+			"opportunistic_GB": 2,
+			"max_num_objects": 40,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << "First child should succeed: " << (err.get() ? err.get() : "");
+
+	// Second child: 6 dedicated_GB. Now total attributed = 6 + 6 = 12 > 10. Should fail.
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a2_2",
+		"owner": "owner1",
+		"parents": ["parent_a2"],
+		"paths": [{"path": "/a2/child2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 6,
+			"opportunistic_GB": 2,
+			"max_num_objects": 40,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Second child should fail — sum of children exceeds parent's dedicated_GB";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("peak concurrent") != std::string::npos)
+		<< "Error should report that combined concurrent children exceed the parent's capacity, got: " << err_str;
+}
+
+TEST_F(StrictHierarchyTest, Axiom2PassesSumWithinParent) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "parent_a2p",
+		"owner": "owner1",
+		"parents": ["parent_a2p"],
+		"paths": [{"path": "/a2p/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Two children each with 8 dedicated_GB. Sum=16, fits within 20.
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a2p_1",
+		"owner": "owner1",
+		"parents": ["parent_a2p"],
+		"paths": [{"path": "/a2p/child1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 8,
+			"opportunistic_GB": 4,
+			"max_num_objects": 80,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a2p_2",
+		"owner": "owner1",
+		"parents": ["parent_a2p"],
+		"paths": [{"path": "/a2p/child2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 8,
+			"opportunistic_GB": 4,
+			"max_num_objects": 80,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Sum 16 <= 20 should pass: " << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, Axiom2ViolationSumDedOppExceedsParentTotal) {
+	// Axiom 2 checks BOTH:
+	//   (a) sum(ded) <= parent.ded
+	//   (b) sum(ded + opp) <= parent.(ded + opp)
+	// This test exercises check (b) by keeping each child's dedicated_GB
+	// within the parent's dedicated_GB, but making the combined ded+opp
+	// exceed the parent's total.
+	addDefaultLot();
+
+	// Parent: ded=20, opp=5 → total=25
+	addLot(R"({
+		"lot_name": "parent_a2do",
+		"owner": "owner1",
+		"parents": ["parent_a2do"],
+		"paths": [{"path": "/a2do/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 5,
+			"max_num_objects": 500,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child 1: ded=9, opp=5 → attributed ded=9 ≤ parent ded=20 ✓
+	//          attributed total=14 ≤ parent total=25 ✓
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a2do_1",
+		"owner": "owner1",
+		"parents": ["parent_a2do"],
+		"paths": [{"path": "/a2do/child1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 9,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	UniqueCString err1(raw_err);
+	ASSERT_EQ(rv, 0) << "First child should succeed: " << (err1.get() ? err1.get() : "");
+
+	// Child 2: ded=9, opp=5 → attributed ded=9+9=18 ≤ parent ded=20 ✓
+	//          attributed total=(9+5)+(9+5)=28, parent total=25 ✗
+	// This should fail on the sum(ded+opp) check.
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a2do_2",
+		"owner": "owner1",
+		"parents": ["parent_a2do"],
+		"paths": [{"path": "/a2do/child2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 9,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	EXPECT_NE(rv, 0) << "Second child should fail — sum of ded+opp exceeds parent total";
+	std::string err_str(err2.get() ? err2.get() : "");
+	EXPECT_TRUE(err_str.find("peak concurrent") != std::string::npos)
+		<< "Error should report that combined concurrent children exceed the parent's capacity, got: " << err_str;
+	EXPECT_TRUE(err_str.find("total GB") != std::string::npos)
+		<< "Error should mention total GB (ded+opp), got: " << err_str;
+}
+
+TEST_F(StrictHierarchyTest, Axiom2PassesDedOppWithinParentTotal) {
+	// Complement to the above: two children whose combined ded+opp fits.
+	addDefaultLot();
+
+	// Parent: ded=20, opp=10 → total=30
+	addLot(R"({
+		"lot_name": "parent_a2dop",
+		"owner": "owner1",
+		"parents": ["parent_a2dop"],
+		"paths": [{"path": "/a2dop/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 10,
+			"max_num_objects": 500,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child 1: ded=9, opp=5 → total attributed so far = 14
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a2dop_1",
+		"owner": "owner1",
+		"parents": ["parent_a2dop"],
+		"paths": [{"path": "/a2dop/child1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 9,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	UniqueCString err1(raw_err);
+	ASSERT_EQ(rv, 0) << (err1.get() ? err1.get() : "");
+
+	// Child 2: ded=9, opp=5 → total attributed = 14+14=28 ≤ 30 ✓
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a2dop_2",
+		"owner": "owner1",
+		"parents": ["parent_a2dop"],
+		"paths": [{"path": "/a2dop/child2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 9,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	EXPECT_EQ(rv, 0) << "Sum ded+opp within parent total should pass: " << (err2.get() ? err2.get() : "");
+}
+
+// ============================================================================
+// Axiom 3: child timestamps must fit within parent's timestamps
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, Axiom3ViolationCreationTimeTooEarly) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "parent_a3",
+		"owner": "owner1",
+		"parents": ["parent_a3"],
+		"paths": [{"path": "/a3/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 500,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child creation_time (100) < parent creation_time (500) → violation
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a3_early",
+		"owner": "owner1",
+		"parents": ["parent_a3"],
+		"paths": [{"path": "/a3/child_early", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Child with earlier creation_time than parent should fail";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("time window") != std::string::npos)
+		<< "Error should report that the child's time window is not contained within the parent's, got: " << err_str;
+}
+
+TEST_F(StrictHierarchyTest, Axiom3ViolationExpirationTimeTooLate) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "parent_a3e",
+		"owner": "owner1",
+		"parents": ["parent_a3e"],
+		"paths": [{"path": "/a3e/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 5000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child expiration_time (8000) > parent expiration_time (5000) → violation
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a3_late",
+		"owner": "owner1",
+		"parents": ["parent_a3e"],
+		"paths": [{"path": "/a3e/child_late", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Child with later expiration_time than parent should fail";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("time window") != std::string::npos)
+		<< "Error should report that the child's time window is not contained within the parent's, got: " << err_str;
+}
+
+TEST_F(StrictHierarchyTest, Axiom3ViolationDeletionTimeTooLate) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "parent_a3d",
+		"owner": "owner1",
+		"parents": ["parent_a3d"],
+		"paths": [{"path": "/a3d/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 5000,
+			"deletion_time": 6000
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child deletion_time (9000) > parent deletion_time (6000) → violation
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a3_del",
+		"owner": "owner1",
+		"parents": ["parent_a3d"],
+		"paths": [{"path": "/a3d/child_del", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 200,
+			"expiration_time": 4000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Child with later deletion_time than parent should fail";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("time window") != std::string::npos)
+		<< "Error should report that the child's time window is not contained within the parent's, got: " << err_str;
+}
+
+TEST_F(StrictHierarchyTest, Axiom3PassesTimestampsWithinParent) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "parent_a3ok",
+		"owner": "owner1",
+		"parents": ["parent_a3ok"],
+		"paths": [{"path": "/a3ok/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child timestamps strictly within parent's
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_a3_ok",
+		"owner": "owner1",
+		"parents": ["parent_a3ok"],
+		"paths": [{"path": "/a3ok/child_ok", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Child within parent timestamps should pass: " << (err.get() ? err.get() : "");
+}
+
+// ============================================================================
+// Attribution logic: joint child lot sharing quotas from two parents
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, AttributionJointChildEqualSplit) {
+	addDefaultLot();
+
+	// Two root lots, each with 20 dedicated_GB
+	addLot(R"({
+		"lot_name": "parent_A",
+		"owner": "owner1",
+		"parents": ["parent_A"],
+		"paths": [{"path": "/attr/parentA", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "parent_B",
+		"owner": "owner1",
+		"parents": ["parent_B"],
+		"paths": [{"path": "/attr/parentB", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Joint child with 30 dedicated_GB, parents=["parent_A", "parent_B"].
+	// With equal-split (no explicit attributions), each parent gets 15 GB attributed.
+	// Each parent has 20 GB, so 15 <= 20 → Axiom 1 passes.
+	// Each parent has only this child, so sum = 15 <= 20 → Axiom 2 passes.
+	rv = lotman_add_lot(R"({
+		"lot_name": "joint_child",
+		"owner": "owner1",
+		"parents": ["parent_A", "parent_B"],
+		"paths": [{"path": "/attr/joint", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 10,
+			"max_num_objects": 300,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Joint child with equal split across two parents should succeed: "
+					 << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, AttributionJointChildExplicitSplit) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "pA_explicit",
+		"owner": "owner1",
+		"parents": ["pA_explicit"],
+		"paths": [{"path": "/attr_ex/parentA", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "pB_explicit",
+		"owner": "owner1",
+		"parents": ["pB_explicit"],
+		"paths": [{"path": "/attr_ex/parentB", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child with 20 dedicated_GB, explicit attribution: 15 to pA, 5 to pB.
+	// pA has 30, so 15 <= 30 ✓. pB has 10, so 5 <= 10 ✓.
+	rv = lotman_add_lot(R"({
+		"lot_name": "joint_explicit",
+		"owner": "owner1",
+		"parents": ["pA_explicit", "pB_explicit"],
+		"paths": [{"path": "/attr_ex/joint", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		},
+		"parent_attributions": {
+			"pA_explicit": {
+				"dedicated_GB": 15,
+				"opportunistic_GB": 7,
+				"max_num_objects": 70
+			},
+			"pB_explicit": {
+				"dedicated_GB": 5,
+				"opportunistic_GB": 3,
+				"max_num_objects": 30
+			}
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Explicit attribution within limits should succeed: " << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, AttributionJointChildExplicitExceedsOneParent) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "pA_exceed",
+		"owner": "owner1",
+		"parents": ["pA_exceed"],
+		"paths": [{"path": "/attr_exc/parentA", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "pB_exceed",
+		"owner": "owner1",
+		"parents": ["pB_exceed"],
+		"paths": [{"path": "/attr_exc/parentB", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child with 20 dedicated_GB, explicit: 5 to pA, 15 to pB.
+	// pB only has 10 → Axiom 1 violation for pB.
+	rv = lotman_add_lot(R"({
+		"lot_name": "joint_exceed",
+		"owner": "owner1",
+		"parents": ["pA_exceed", "pB_exceed"],
+		"paths": [{"path": "/attr_exc/joint", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		},
+		"parent_attributions": {
+			"pA_exceed": {
+				"dedicated_GB": 5,
+				"opportunistic_GB": 3,
+				"max_num_objects": 30
+			},
+			"pB_exceed": {
+				"dedicated_GB": 15,
+				"opportunistic_GB": 7,
+				"max_num_objects": 70
+			}
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Explicit attribution exceeding one parent should fail";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("exceeds the parent's") != std::string::npos)
+		<< "Error should report that the child's allocation exceeds the parent's, got: " << err_str;
+}
+
+TEST_F(StrictHierarchyTest, AttributionThreeParentsMixedExplicitAndSplit) {
+	// One child with 3 parents. Attribution to parent A is explicit;
+	// the remainder is equal-split across parents B and C.
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "mp_A",
+		"owner": "owner1",
+		"parents": ["mp_A"],
+		"paths": [{"path": "/mp/parentA", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 20,
+			"max_num_objects": 400,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "mp_B",
+		"owner": "owner1",
+		"parents": ["mp_B"],
+		"paths": [{"path": "/mp/parentB", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 15,
+			"max_num_objects": 300,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "mp_C",
+		"owner": "owner1",
+		"parents": ["mp_C"],
+		"paths": [{"path": "/mp/parentC", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 15,
+			"max_num_objects": 300,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child: ded=30, opp=12, obj=300
+	// Explicit: mp_A gets ded=10, opp=4, obj=100
+	// Remainder: ded=20, opp=8, obj=200 → split equally between mp_B and mp_C
+	//   mp_B gets ded=10, opp=4, obj=100
+	//   mp_C gets ded=10, opp=4, obj=100
+	// All fit: mp_A(40) >= 10, mp_B(30) >= 10, mp_C(30) >= 10
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "mp_child",
+		"owner": "owner1",
+		"parents": ["mp_A", "mp_B", "mp_C"],
+		"paths": [{"path": "/mp/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 12,
+			"max_num_objects": 300,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		},
+		"parent_attributions": {
+			"mp_A": {
+				"dedicated_GB": 10,
+				"opportunistic_GB": 4,
+				"max_num_objects": 100
+			}
+		}
+	})",
+						&raw_err);
+	UniqueCString err1(raw_err);
+	EXPECT_EQ(rv, 0) << "Mixed explicit + equal-split across 3 parents should succeed: "
+					 << (err1.get() ? err1.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, AttributionThreeParentsMixedExplicitOverloadsOneParent) {
+	// Same 3-parent layout, but the equal-split remainder overloads one parent.
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "mpo_A",
+		"owner": "owner1",
+		"parents": ["mpo_A"],
+		"paths": [{"path": "/mpo/parentA", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 20,
+			"max_num_objects": 400,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "mpo_B",
+		"owner": "owner1",
+		"parents": ["mpo_B"],
+		"paths": [{"path": "/mpo/parentB", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 5,
+			"opportunistic_GB": 3,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "mpo_C",
+		"owner": "owner1",
+		"parents": ["mpo_C"],
+		"paths": [{"path": "/mpo/parentC", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 20,
+			"max_num_objects": 400,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child: ded=30, opp=12, obj=300
+	// Explicit: mpo_A gets ded=10, opp=4, obj=100
+	// Remainder: ded=20, opp=8, obj=200 → split equally between mpo_B and mpo_C
+	//   mpo_B gets ded=10, opp=4, obj=100
+	//   mpo_C gets ded=10, opp=4, obj=100
+	// mpo_B only has ded=5 → Axiom 1 violation (10 > 5)
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "mpo_child",
+		"owner": "owner1",
+		"parents": ["mpo_A", "mpo_B", "mpo_C"],
+		"paths": [{"path": "/mpo/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 12,
+			"max_num_objects": 300,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		},
+		"parent_attributions": {
+			"mpo_A": {
+				"dedicated_GB": 10,
+				"opportunistic_GB": 4,
+				"max_num_objects": 100
+			}
+		}
+	})",
+						&raw_err);
+	UniqueCString err1(raw_err);
+	EXPECT_NE(rv, 0) << "Equal-split remainder overloading mpo_B should fail";
+	std::string err_str(err1.get() ? err1.get() : "");
+	EXPECT_TRUE(err_str.find("exceeds the parent's") != std::string::npos)
+		<< "Error should report that the child's allocation exceeds the parent's, got: " << err_str;
+}
+
+// ============================================================================
+// Contraction policy tests: non-strict mode (no contraction_policy)
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, ContractionAllowedInNonStrictMode) {
+	// With default settings (contraction_policy="none"), all contractions should work.
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "contract_lot",
+		"owner": "owner1",
+		"parents": ["contract_lot"],
+		"paths": [{"path": "/contract/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+
+	// Shrink dedicated_GB: 50 → 10
+	const char *up1 = R"({"lot_name": "contract_lot", "management_policy_attrs": {"dedicated_GB": 10}})";
+	int rv = lotman_update_lot(up1, &raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Dedicated_GB contraction should be allowed: " << (err.get() ? err.get() : "");
+
+	// Shrink opportunistic_GB: 25 → 5
+	rv = lotman_update_lot(R"({"lot_name": "contract_lot", "management_policy_attrs": {"opportunistic_GB": 5}})",
+						   &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Opportunistic_GB contraction should be allowed: " << (err.get() ? err.get() : "");
+
+	// Shrink max_num_objects: 500 → 50
+	rv = lotman_update_lot(R"({"lot_name": "contract_lot", "management_policy_attrs": {"max_num_objects": 50}})",
+						   &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Max_num_objects contraction should be allowed: " << (err.get() ? err.get() : "");
+
+	// Shrink expiration_time: 9000 → 5000 (ending sooner = contraction)
+	rv = lotman_update_lot(R"({"lot_name": "contract_lot", "management_policy_attrs": {"expiration_time": 5000}})",
+						   &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Expiration_time contraction should be allowed: " << (err.get() ? err.get() : "");
+
+	// Shrink deletion_time: 9500 → 6000
+	rv = lotman_update_lot(R"({"lot_name": "contract_lot", "management_policy_attrs": {"deletion_time": 6000}})",
+						   &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Deletion_time contraction should be allowed: " << (err.get() ? err.get() : "");
+}
+
+// ============================================================================
+// Contraction policy "always": all contractions blocked
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, ContractionBlockedAlwaysPolicy) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "always_lot",
+		"owner": "owner1",
+		"parents": ["always_lot"],
+		"paths": [{"path": "/always/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("contraction_policy", "always", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Each contraction should be blocked
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "always_lot", "management_policy_attrs": {"dedicated_GB": 10}})", &raw_err);
+	UniqueCString err1(raw_err);
+	EXPECT_NE(rv, 0) << "Dedicated_GB contraction should be blocked by 'always' policy";
+	{
+		std::string err_str(err1.get() ? err1.get() : "");
+		EXPECT_TRUE(err_str.find("always") != std::string::npos) << "Error: " << err_str;
+	}
+
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "always_lot", "management_policy_attrs": {"opportunistic_GB": 5}})",
+						   &raw_err);
+	UniqueCString err2(raw_err);
+	EXPECT_NE(rv, 0) << "Opportunistic_GB contraction should be blocked";
+
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "always_lot", "management_policy_attrs": {"max_num_objects": 50}})",
+						   &raw_err);
+	UniqueCString err3(raw_err);
+	EXPECT_NE(rv, 0) << "Max_num_objects contraction should be blocked";
+
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "always_lot", "management_policy_attrs": {"expiration_time": 5000}})",
+						   &raw_err);
+	UniqueCString err4(raw_err);
+	EXPECT_NE(rv, 0) << "Expiration_time contraction should be blocked";
+
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "always_lot", "management_policy_attrs": {"deletion_time": 6000}})",
+						   &raw_err);
+	UniqueCString err5(raw_err);
+	EXPECT_NE(rv, 0) << "Deletion_time contraction should be blocked";
+
+	// But expansions should still work
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "always_lot", "management_policy_attrs": {"dedicated_GB": 100}})", &raw_err);
+	UniqueCString err6(raw_err);
+	EXPECT_EQ(rv, 0) << "Dedicated_GB expansion should be allowed: " << (err6.get() ? err6.get() : "");
+}
+
+// ============================================================================
+// Contraction policy "alive": blocks only for currently-alive lots
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, ContractionBlockedAlivePolicy) {
+	addDefaultLot();
+	// Create a lot that is currently alive (creation far in the past, expiration far in the future)
+	addLot(R"({
+		"lot_name": "alive_lot",
+		"owner": "owner1",
+		"parents": ["alive_lot"],
+		"paths": [{"path": "/alive/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 1,
+			"expiration_time": 99999999999999,
+			"deletion_time": 99999999999999
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("contraction_policy", "alive", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// This lot is currently alive, so contraction should be blocked
+	rv = lotman_update_lot(R"({"lot_name": "alive_lot", "management_policy_attrs": {"dedicated_GB": 10}})", &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Contraction on alive lot should be blocked by 'alive' policy";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("alive") != std::string::npos) << "Error: " << err_str;
+}
+
+TEST_F(StrictHierarchyTest, ContractionAllowedForExpiredLotUnderAlivePolicy) {
+	addDefaultLot();
+	// Create a lot that expired long ago
+	addLot(R"({
+		"lot_name": "expired_lot",
+		"owner": "owner1",
+		"parents": ["expired_lot"],
+		"paths": [{"path": "/expired/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 1,
+			"expiration_time": 2,
+			"deletion_time": 3
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("contraction_policy", "alive", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Lot is expired (expiration_time=2), so contraction should be allowed
+	rv = lotman_update_lot(R"({"lot_name": "expired_lot", "management_policy_attrs": {"dedicated_GB": 10}})", &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Contraction on expired lot should be allowed under 'alive' policy: "
+					 << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, ContractionBypassedWithAdminOverride) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "override_lot",
+		"owner": "owner1",
+		"parents": ["override_lot"],
+		"paths": [{"path": "/override/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("contraction_policy", "always", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	rv = lotman_set_context_str("admin_override", "true", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// With admin_override, contraction should be allowed even with "always" policy
+	rv =
+		lotman_update_lot(R"({"lot_name": "override_lot", "management_policy_attrs": {"dedicated_GB": 10}})", &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Admin override should bypass contraction policy: " << (err.get() ? err.get() : "");
+}
+
+// ============================================================================
+// Contraction in delete: "always" policy blocks lot deletion
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, ContractionBlocksDeletionAlwaysPolicy) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "del_always",
+		"owner": "owner1",
+		"parents": ["del_always"],
+		"paths": [{"path": "/del_always/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("contraction_policy", "always", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	rv = lotman_remove_lots_recursive("del_always", &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Lot deletion should be blocked by 'always' contraction policy";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("always") != std::string::npos) << "Error: " << err_str;
+}
+
+// ============================================================================
+// Parent shrink that would break hierarchy for children
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, ParentShrinkBlockedByChildRevalidation) {
+	// C1 fix: Axiom re-validation now runs on children when updating a parent's MPAs.
+	// Shrinking a parent below a child's attributed value is correctly blocked.
+	addDefaultLot();
+
+	// Parent with 20 dedicated_GB
+	addLot(R"({
+		"lot_name": "shrink_parent",
+		"owner": "owner1",
+		"parents": ["shrink_parent"],
+		"paths": [{"path": "/shrink/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child with 15 dedicated_GB (fits within 20)
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "shrink_child",
+		"owner": "owner1",
+		"parents": ["shrink_parent"],
+		"paths": [{"path": "/shrink/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 15,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	ASSERT_EQ(rv, 0) << "Child should be created: " << (err2.get() ? err2.get() : "");
+
+	// Shrink parent to 10 dedicated_GB — this is now blocked because child
+	// re-validation detects that the child's attribution (15) exceeds the
+	// parent's new dedicated_GB (10).
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "shrink_parent", "management_policy_attrs": {"dedicated_GB": 10}})",
+						   &raw_err);
+	UniqueCString err3(raw_err);
+	EXPECT_NE(rv, 0) << "Parent shrink should be blocked by child re-validation";
+	EXPECT_NE(err3.get(), nullptr);
+}
+
+TEST_F(StrictHierarchyTest, ParentShrinkExpirationBlockedByChildRevalidation) {
+	// C1 fix: Timestamp changes now re-validate Axiom 3 for children.
+	// Shrinking a parent's expiration below a child's expiration is blocked.
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "tshrink_parent",
+		"owner": "owner1",
+		"parents": ["tshrink_parent"],
+		"paths": [{"path": "/tshrink/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child with expiration_time=8000 (within parent's 9000)
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "tshrink_child",
+		"owner": "owner1",
+		"parents": ["tshrink_parent"],
+		"paths": [{"path": "/tshrink/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	ASSERT_EQ(rv, 0) << (err2.get() ? err2.get() : "");
+
+	// Shrink parent's expiration to 7000. Child's expiration (8000) > 7000.
+	// This is now blocked because child re-validation detects the Axiom 3
+	// violation (child expiration exceeds parent expiration).
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "tshrink_parent", "management_policy_attrs": {"expiration_time": 7000}})",
+						   &raw_err);
+	UniqueCString err3(raw_err);
+	EXPECT_NE(rv, 0) << "Parent timestamp shrink should be blocked by child re-validation";
+	EXPECT_NE(err3.get(), nullptr);
+}
+
+// ============================================================================
+// Temporal path querying: multiple lots on same path at different times
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, TemporalPathQueryCorrectLotReturned) {
+	addDefaultLot();
+
+	// Lot A: owns /temporal/data from time 1000 to 2000
+	addLot(R"({
+		"lot_name": "temporal_A",
+		"owner": "owner1",
+		"parents": ["temporal_A"],
+		"paths": [{"path": "/temporal/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 1000,
+			"expiration_time": 2000,
+			"deletion_time": 3000
+		}
+	})");
+
+	// Lot B: owns /temporal/data from time 3000 to 4000 (no overlap)
+	addLot(R"({
+		"lot_name": "temporal_B",
+		"owner": "owner1",
+		"parents": ["temporal_B"],
+		"paths": [{"path": "/temporal/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 3000,
+			"expiration_time": 4000,
+			"deletion_time": 5000
+		}
+	})");
+
+	char *raw_err = nullptr;
+	char **lots_output = nullptr;
+
+	// Query BEFORE either lot's time (t=500): should return "default"
+	int rv = lotman_get_lots_from_dir("/temporal/data", false, 500, &lots_output, &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	ASSERT_NE(lots_output, nullptr);
+	EXPECT_STREQ(lots_output[0], "default") << "Before either lot's time, should return default";
+	lotman_free_string_list(lots_output);
+
+	// Query DURING lot A (t=1500): should return "temporal_A"
+	rv = lotman_get_lots_from_dir("/temporal/data", false, 1500, &lots_output, &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	ASSERT_NE(lots_output, nullptr);
+	EXPECT_STREQ(lots_output[0], "temporal_A") << "During lot A's time, should return temporal_A";
+	lotman_free_string_list(lots_output);
+
+	// Query BETWEEN lots (t=2500): should return "default"
+	rv = lotman_get_lots_from_dir("/temporal/data", false, 2500, &lots_output, &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	ASSERT_NE(lots_output, nullptr);
+	EXPECT_STREQ(lots_output[0], "default") << "Between lots' times, should return default";
+	lotman_free_string_list(lots_output);
+
+	// Query DURING lot B (t=3500): should return "temporal_B"
+	rv = lotman_get_lots_from_dir("/temporal/data", false, 3500, &lots_output, &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	ASSERT_NE(lots_output, nullptr);
+	EXPECT_STREQ(lots_output[0], "temporal_B") << "During lot B's time, should return temporal_B";
+	lotman_free_string_list(lots_output);
+
+	// Query AFTER both lots (t=5000): should return "default"
+	rv = lotman_get_lots_from_dir("/temporal/data", false, 5000, &lots_output, &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	ASSERT_NE(lots_output, nullptr);
+	EXPECT_STREQ(lots_output[0], "default") << "After both lots' times, should return default";
+	lotman_free_string_list(lots_output);
+}
+
+// ============================================================================
+// Temporal overlap: two lots with same path overlapping in time should fail
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, TemporalOverlapFailsWhenAddingPath) {
+	addDefaultLot();
+
+	// Lot A: owns /overlap/data from 1000 to 3000
+	addLot(R"({
+		"lot_name": "overlap_A",
+		"owner": "owner1",
+		"parents": ["overlap_A"],
+		"paths": [{"path": "/overlap/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 1000,
+			"expiration_time": 3000,
+			"deletion_time": 4000
+		}
+	})");
+
+	// Lot B: created WITHOUT the overlapping path initially
+	addLot(R"({
+		"lot_name": "overlap_B",
+		"owner": "owner1",
+		"parents": ["overlap_B"],
+		"paths": [{"path": "/overlap/other", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 2500,
+			"expiration_time": 4000,
+			"deletion_time": 5000
+		}
+	})");
+
+	// Now try to ADD the conflicting path to lot B via lotman_add_to_lot.
+	// This goes through store_new_paths which has the temporal overlap check.
+	char *raw_err = nullptr;
+	int rv = lotman_add_to_lot(R"({
+		"lot_name": "overlap_B",
+		"paths": [{"path": "/overlap/data", "recursive": true}]
+	})",
+							   &raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0) << "Adding a path with temporal overlap should fail";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("temporal overlap") != std::string::npos || err_str.find("overlap") != std::string::npos)
+		<< "Error should mention temporal overlap, got: " << err_str;
+}
+
+TEST_F(StrictHierarchyTest, TemporalOverlapFailsWhenCreatingLot) {
+	addDefaultLot();
+
+	// Lot A: owns /create_overlap/data from 1000 to 3000
+	addLot(R"({
+		"lot_name": "create_overlap_A",
+		"owner": "owner1",
+		"parents": ["create_overlap_A"],
+		"paths": [{"path": "/create_overlap/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 1000,
+			"expiration_time": 3000,
+			"deletion_time": 4000
+		}
+	})");
+
+	// Try to CREATE Lot B with the same path and overlapping time range.
+	// This goes through write_new() which should now have the temporal overlap check.
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "create_overlap_B",
+		"owner": "owner1",
+		"parents": ["create_overlap_B"],
+		"paths": [{"path": "/create_overlap/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 2500,
+			"expiration_time": 4000,
+			"deletion_time": 5000
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0) << "Creating a lot with a temporally overlapping path should fail";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("temporal overlap") != std::string::npos || err_str.find("overlap") != std::string::npos)
+		<< "Error should mention temporal overlap, got: " << err_str;
+
+	// Verify the failed lot doesn't exist
+	char *lot_json_str = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lot_as_json("create_overlap_B", false, &lot_json_str, &raw_err);
+	UniqueCString err2(raw_err);
+	UniqueCString lotStr(lot_json_str);
+	EXPECT_NE(rv, 0) << "Failed lot should not exist in database";
+}
+
+TEST_F(StrictHierarchyTest, TemporalNoOverlapSucceeds) {
+	addDefaultLot();
+
+	// Lot A: owns /nooverlap/data from 1000 to 2000
+	addLot(R"({
+		"lot_name": "nooverlap_A",
+		"owner": "owner1",
+		"parents": ["nooverlap_A"],
+		"paths": [{"path": "/nooverlap/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 1000,
+			"expiration_time": 2000,
+			"deletion_time": 3000
+		}
+	})");
+
+	// Lot B: owns same path from 3000 to 4000 (no overlap — gap between 2000 and 3000)
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "nooverlap_B",
+		"owner": "owner1",
+		"parents": ["nooverlap_B"],
+		"paths": [{"path": "/nooverlap/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 3000,
+			"expiration_time": 4000,
+			"deletion_time": 5000
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Non-overlapping temporal ranges on same path should succeed: " << (err.get() ? err.get() : "");
+}
+
+// ============================================================================
+// Hierarchical mode: depth-ordered lot lists
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, HierarchicalDepthOrderedResults) {
+	addDefaultLot();
+
+	// Create a 3-level hierarchy: root → mid → leaf
+	// Each lot has progressively usage that exceeds its dedicated_GB.
+	addLot(R"({
+		"lot_name": "h_root",
+		"owner": "owner1",
+		"parents": ["h_root"],
+		"paths": [{"path": "/hier/root", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 5,
+			"opportunistic_GB": 3,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "h_mid",
+		"owner": "owner1",
+		"parents": ["h_root"],
+		"paths": [{"path": "/hier/mid", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 3,
+			"opportunistic_GB": 2,
+			"max_num_objects": 30,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "h_leaf",
+		"owner": "owner1",
+		"parents": ["h_mid"],
+		"paths": [{"path": "/hier/leaf", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 1,
+			"opportunistic_GB": 1,
+			"max_num_objects": 10,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Set usage on all lots so they all exceed their dedicated_GB:
+	// h_leaf: 2 GB self (exceeds 1 GB ded)
+	// h_mid: 4 GB self (exceeds 3 GB ded)
+	// h_root: 6 GB self (exceeds 5 GB ded)
+	char *raw_err = nullptr;
+	const char *usage_leaf = R"({"lot_name": "h_leaf", "self_GB": 2})";
+	int rv = lotman_update_lot_usage(usage_leaf, false, &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+
+	const char *usage_mid = R"({"lot_name": "h_mid", "self_GB": 4})";
+	rv = lotman_update_lot_usage(usage_mid, false, &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+
+	const char *usage_root = R"({"lot_name": "h_root", "self_GB": 6})";
+	rv = lotman_update_lot_usage(usage_root, false, &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+
+	// Query lots_past_ded in hierarchical mode
+	// All three lots are past their dedicated quota.
+	// Results should be depth-ordered: deepest (leaf) first.
+	char **raw_output = nullptr;
+	rv = lotman_get_lots_past_ded(false, false, &raw_output, true, &raw_err);
+	err.reset(raw_err);
+	UniqueStringList output(raw_output);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	ASSERT_NE(output.get(), nullptr);
+
+	// Collect the results
+	std::vector<std::string> results;
+	for (int i = 0; output.get()[i]; i++) {
+		results.push_back(output.get()[i]);
+	}
+
+	// At minimum, h_leaf, h_mid, h_root should all be present
+	EXPECT_GE(results.size(), 3u) << "Should have at least 3 lots past dedicated";
+
+	// Find positions of our lots
+	auto leaf_pos = std::find(results.begin(), results.end(), "h_leaf");
+	auto mid_pos = std::find(results.begin(), results.end(), "h_mid");
+	auto root_pos = std::find(results.begin(), results.end(), "h_root");
+
+	ASSERT_NE(leaf_pos, results.end()) << "h_leaf should be in results";
+	ASSERT_NE(mid_pos, results.end()) << "h_mid should be in results";
+	ASSERT_NE(root_pos, results.end()) << "h_root should be in results";
+
+	// Depth-descending order: leaf (depth 2) before mid (depth 1) before root (depth 0)
+	EXPECT_LT(leaf_pos, mid_pos) << "h_leaf (deepest) should come before h_mid";
+	EXPECT_LT(mid_pos, root_pos) << "h_mid should come before h_root (shallowest)";
+}
+
+TEST_F(StrictHierarchyTest, HierarchicalVsNonHierarchical) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "nh_root",
+		"owner": "owner1",
+		"parents": ["nh_root"],
+		"paths": [{"path": "/nh/root", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 5,
+			"opportunistic_GB": 3,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "nh_child",
+		"owner": "owner1",
+		"parents": ["nh_root"],
+		"paths": [{"path": "/nh/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 2,
+			"opportunistic_GB": 1,
+			"max_num_objects": 20,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Give nh_child usage that exceeds dedicated
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot_usage(R"({"lot_name": "nh_child", "self_GB": 3})", false, &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+
+	// Non-hierarchical: just check raw self_GB vs dedicated_GB
+	char **raw_output = nullptr;
+	rv = lotman_get_lots_past_ded(false, false, &raw_output, false, &raw_err);
+	err.reset(raw_err);
+	UniqueStringList output_nonhier(raw_output);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+
+	std::vector<std::string> nonhier_results;
+	if (output_nonhier.get()) {
+		for (int i = 0; output_nonhier.get()[i]; i++) {
+			nonhier_results.push_back(output_nonhier.get()[i]);
+		}
+	}
+
+	// nh_child should be in non-hierarchical results (3 > 2)
+	EXPECT_NE(std::find(nonhier_results.begin(), nonhier_results.end(), "nh_child"), nonhier_results.end())
+		<< "nh_child should appear in non-hierarchical results";
+}
+
+// ============================================================================
+// Context functionality: strict_hierarchy enforces axioms on lot creation
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, StrictHierarchyOffAllowsViolation) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "nostrict_parent",
+		"owner": "owner1",
+		"parents": ["nostrict_parent"],
+		"paths": [{"path": "/nostrict/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// strict_hierarchy is OFF (default). Creating a child that would violate Axiom 1
+	// should succeed because axioms are not enforced.
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "nostrict_child",
+		"owner": "owner1",
+		"parents": ["nostrict_parent"],
+		"paths": [{"path": "/nostrict/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 999,
+			"opportunistic_GB": 999,
+			"max_num_objects": 9999,
+			"creation_time": 1,
+			"expiration_time": 99999,
+			"deletion_time": 99999
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Without strict hierarchy, axiom violations should be allowed: "
+					 << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, StrictHierarchyOnEnforcesAllAxioms) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "strict_parent",
+		"owner": "owner1",
+		"parents": ["strict_parent"],
+		"paths": [{"path": "/strict/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 500,
+			"expiration_time": 5000,
+			"deletion_time": 6000
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// This child violates ALL three axioms:
+	// - dedicated_GB=999 > parent's 10 (Axiom 1)
+	// - creation_time=1 < parent's 500 (Axiom 3 — only checked if Axiom 1 passes)
+	// The check should fail on the first axiom violation it encounters.
+	rv = lotman_add_lot(R"({
+		"lot_name": "strict_child",
+		"owner": "owner1",
+		"parents": ["strict_parent"],
+		"paths": [{"path": "/strict/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 999,
+			"opportunistic_GB": 999,
+			"max_num_objects": 9999,
+			"creation_time": 1,
+			"expiration_time": 99999,
+			"deletion_time": 99999
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Strict hierarchy should block axiom-violating lot creation";
+	EXPECT_NE(err.get(), nullptr);
+}
+
+// ============================================================================
+// Update attributions API test
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, UpdateAttributionsRebalances) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "ua_parent1",
+		"owner": "owner1",
+		"parents": ["ua_parent1"],
+		"paths": [{"path": "/ua/p1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "ua_parent2",
+		"owner": "owner1",
+		"parents": ["ua_parent2"],
+		"paths": [{"path": "/ua/p2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Child with 20 dedicated_GB, equal split across two parents (10 each by default)
+	addLot(R"({
+		"lot_name": "ua_child",
+		"owner": "owner1",
+		"parents": ["ua_parent1", "ua_parent2"],
+		"paths": [{"path": "/ua/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Now update attributions to assign 15 to parent1 and 5 to parent2
+	char *raw_err = nullptr;
+	const char *update_json = R"({
+		"lot_name": "ua_child",
+		"parent_attributions": {
+			"ua_parent1": {
+				"dedicated_GB": 15,
+				"opportunistic_GB": 8,
+				"max_num_objects": 150
+			},
+			"ua_parent2": {
+				"dedicated_GB": 5,
+				"opportunistic_GB": 2,
+				"max_num_objects": 50
+			}
+		}
+	})";
+
+	int rv = lotman_update_lot(update_json, &raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Updating attributions should succeed: " << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, UpdateAttributionsViolatesAxiomInStrictMode) {
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "uav_parent1",
+		"owner": "owner1",
+		"parents": ["uav_parent1"],
+		"paths": [{"path": "/uav/p1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "uav_parent2",
+		"owner": "owner1",
+		"parents": ["uav_parent2"],
+		"paths": [{"path": "/uav/p2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 5,
+			"opportunistic_GB": 2,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Child with 20 dedicated_GB
+	addLot(R"({
+		"lot_name": "uav_child",
+		"owner": "owner1",
+		"parents": ["uav_parent1", "uav_parent2"],
+		"paths": [{"path": "/uav/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Enable strict hierarchy
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Try to attribute 2 to parent1 and 18 to parent2. But parent2 only has 5.
+	const char *update_json = R"({
+		"lot_name": "uav_child",
+		"parent_attributions": {
+			"uav_parent1": {
+				"dedicated_GB": 2,
+				"opportunistic_GB": 1,
+				"max_num_objects": 20
+			},
+			"uav_parent2": {
+				"dedicated_GB": 18,
+				"opportunistic_GB": 9,
+				"max_num_objects": 180
+			}
+		}
+	})";
+
+	rv = lotman_update_lot(update_json, &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Attribution update exceeding parent capacity should fail in strict mode";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("exceeds the parent's") != std::string::npos)
+		<< "Error should report that the child's allocation exceeds the parent's, got: " << err_str;
+}
+
+// ============================================================================
+// Migration test: v0→v1 adds parent_child_attributions table
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, MigrationCreatesAttributionTable) {
+	// The DB has already been initialized by SetUp (setting lot_home).
+	// Verify the parent_child_attributions table exists by creating a lot
+	// with attributions.
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "migrate_parent",
+		"owner": "owner1",
+		"parents": ["migrate_parent"],
+		"paths": [{"path": "/migrate/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Creating a child lot triggers compute_and_store_attributions which writes
+	// to parent_child_attributions. If the table doesn't exist, this will crash.
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "migrate_child",
+		"owner": "owner1",
+		"parents": ["migrate_parent"],
+		"paths": [{"path": "/migrate/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		},
+		"parent_attributions": {
+			"migrate_parent": {
+				"dedicated_GB": 10,
+				"opportunistic_GB": 5,
+				"max_num_objects": 50
+			}
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Creating lot with attributions should work on fresh DB: " << (err.get() ? err.get() : "");
+}
+
+// ============================================================================
+// C6: Non-root lot MPA updates with strict hierarchy
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, NonRootMPAUpdateAllowed) {
+	// Updating a non-root (child) lot's MPAs should succeed when the change
+	// still satisfies all axioms.
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "nrm_parent",
+		"owner": "owner1",
+		"parents": ["nrm_parent"],
+		"paths": [{"path": "/nrm/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child with dedicated_GB=10 (<<< parent's 100)
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "nrm_child",
+		"owner": "owner1",
+		"parents": ["nrm_parent"],
+		"paths": [{"path": "/nrm/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	ASSERT_EQ(rv, 0) << "Child creation: " << (err2.get() ? err2.get() : "");
+
+	// Increase child's dedicated_GB to 20 — still fits within parent's 100
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "nrm_child", "management_policy_attrs": {"dedicated_GB": 20}})", &raw_err);
+	UniqueCString err3(raw_err);
+	EXPECT_EQ(rv, 0) << "Non-root MPA increase should succeed: " << (err3.get() ? err3.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, NonRootMPAUpdateBlockedByAxiom1) {
+	// Increasing a child's dedicated_GB beyond its attributed portion to the
+	// parent should fail Axiom 1 validation.
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "nra1_parent",
+		"owner": "owner1",
+		"parents": ["nra1_parent"],
+		"paths": [{"path": "/nra1/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child with dedicated_GB=10, default attributions will set dedicated_GB=10
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "nra1_child",
+		"owner": "owner1",
+		"parents": ["nra1_parent"],
+		"paths": [{"path": "/nra1/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	ASSERT_EQ(rv, 0) << (err2.get() ? err2.get() : "");
+
+	// Now try to increase child's dedicated_GB to 50. Even though parent has 30
+	// total, the child's attribution to the parent was set to 10 at creation,
+	// so 50 > 10 = Axiom 1 violation (child MPA exceeds attributed amount).
+	// Note: Axiom 1 checks that each child→parent attribution covers the child's MPAs.
+	// The attribution was 10, but now the child's MPA is 50 — the attribution
+	// no longer covers the child.
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "nra1_child", "management_policy_attrs": {"dedicated_GB": 50}})", &raw_err);
+	UniqueCString err3(raw_err);
+	EXPECT_NE(rv, 0) << "Non-root MPA update should be blocked by Axiom 1 (attribution too small)";
+	EXPECT_NE(err3.get(), nullptr);
+}
+
+TEST_F(StrictHierarchyTest, NonRootTimestampShrinkBlockedByAxiom3) {
+	// Narrowing a non-root child's timestamps outside its parent's range
+	// should fail Axiom 3.
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "nrt_parent",
+		"owner": "owner1",
+		"parents": ["nrt_parent"],
+		"paths": [{"path": "/nrt/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 1000,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child with creation_time=1000, expiration_time=8000
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "nrt_child",
+		"owner": "owner1",
+		"parents": ["nrt_parent"],
+		"paths": [{"path": "/nrt/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 1000,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	ASSERT_EQ(rv, 0) << (err2.get() ? err2.get() : "");
+
+	// Try to push child's expiration_time past parent's (9000 → 9500).
+	// Axiom 3: child.expiration_time must <= parent.expiration_time.
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "nrt_child", "management_policy_attrs": {"expiration_time": 9500}})",
+						   &raw_err);
+	UniqueCString err3(raw_err);
+	EXPECT_NE(rv, 0) << "Child timestamp expansion beyond parent should be blocked by Axiom 3";
+	EXPECT_NE(err3.get(), nullptr);
+}
+
+// ============================================================================
+// C7: DB cleanliness after failed lot creation
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, FailedLotCreationLeavesNoDBResidue) {
+	// When lot creation fails axiom validation, the lot should be completely
+	// removed from the database (rolled back via delete_lot_from_db).
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "clean_parent",
+		"owner": "owner1",
+		"parents": ["clean_parent"],
+		"paths": [{"path": "/clean/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Try to create child with dedicated_GB=50, exceeding parent's 10.
+	// This should fail axiom validation.
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "clean_child_fail",
+		"owner": "owner1",
+		"parents": ["clean_parent"],
+		"paths": [{"path": "/clean/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	EXPECT_NE(rv, 0) << "Lot creation should fail with axiom violation";
+
+	// Verify the lot does not exist in the database
+	raw_err = nullptr;
+	char *lot_json_str = nullptr;
+	rv = lotman_get_lot_as_json("clean_child_fail", false, &lot_json_str, &raw_err);
+	UniqueCString err3(raw_err);
+	UniqueCString lotStr(lot_json_str);
+	EXPECT_NE(rv, 0) << "Failed lot should not exist in database";
+}
+
+// ============================================================================
+// C5: Schema validation for update_attributions
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, UpdateAttributionsRejectsInvalidSchema) {
+	// update_attributions should reject JSON that doesn't match the schema.
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "schema_parent",
+		"owner": "owner1",
+		"parents": ["schema_parent"],
+		"paths": [{"path": "/schema/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "schema_child",
+		"owner": "owner1",
+		"parents": ["schema_parent"],
+		"paths": [{"path": "/schema/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	ASSERT_EQ(rv, 0) << (err2.get() ? err2.get() : "");
+
+	// Pass invalid attributions: dedicated_GB should be a number, not a string
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({
+		"lot_name": "schema_child",
+		"parent_attributions": {
+			"schema_parent": {
+				"dedicated_GB": "not_a_number"
+			}
+		}
+	})",
+						   &raw_err);
+	UniqueCString err3(raw_err);
+	EXPECT_NE(rv, 0) << "Should reject invalid schema (string instead of number)";
+	EXPECT_NE(err3.get(), nullptr);
+}
+
+TEST_F(StrictHierarchyTest, UpdateAttributionsRejectsNegativeValues) {
+	// Negative values should be rejected by the schema (minimum: 0).
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "neg_parent",
+		"owner": "owner1",
+		"parents": ["neg_parent"],
+		"paths": [{"path": "/neg/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "neg_child",
+		"owner": "owner1",
+		"parents": ["neg_parent"],
+		"paths": [{"path": "/neg/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	ASSERT_EQ(rv, 0) << (err2.get() ? err2.get() : "");
+
+	// Pass attributions with negative dedicated_GB
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({
+		"lot_name": "neg_child",
+		"parent_attributions": {
+			"neg_parent": {
+				"dedicated_GB": -5
+			}
+		}
+	})",
+						   &raw_err);
+	UniqueCString err3(raw_err);
+	EXPECT_NE(rv, 0) << "Should reject negative attribution values";
+	EXPECT_NE(err3.get(), nullptr);
+}
+
+// ============================================================================
+// Bug fix: attributions recomputed correctly after add/remove parents
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, AddParentRecomputesAttributions) {
+	// Regression test: add_parents must reload parents & MPAs from DB
+	// before calling compute_and_store_attributions.
+	addDefaultLot();
+
+	// Create two root lots that will be parents
+	addLot(R"({
+		"lot_name": "ap_parent1",
+		"owner": "owner1",
+		"parents": ["ap_parent1"],
+		"paths": [{"path": "/ap/p1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "ap_parent2",
+		"owner": "owner1",
+		"parents": ["ap_parent2"],
+		"paths": [{"path": "/ap/p2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Create child under parent1 only (strict mode on)
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "ap_child",
+		"owner": "owner1",
+		"parents": ["ap_parent1"],
+		"paths": [{"path": "/ap/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	ASSERT_EQ(rv, 0) << (err2.get() ? err2.get() : "");
+
+	// Add parent2 as a second parent
+	raw_err = nullptr;
+	rv = lotman_add_to_lot(R"({"lot_name": "ap_child", "parents": ["ap_parent2"]})", &raw_err);
+	UniqueCString err3(raw_err);
+	ASSERT_EQ(rv, 0) << "add_parents should succeed: " << (err3.get() ? err3.get() : "");
+
+	// Verify attribution records exist for both parents by querying DB directly
+	{
+		using namespace sqlite_orm;
+		auto &storage = lotman::db::StorageManager::get_storage();
+		auto attrs = storage.get_all<lotman::db::ParentChildAttribution>(
+			where(c(&lotman::db::ParentChildAttribution::child_lot_name) == "ap_child"));
+
+		// Should have attributions for both parents (3 MPA keys × 2 parents = 6 records)
+		EXPECT_EQ(attrs.size(), 6u) << "Expected 6 attribution records (3 keys × 2 parents), got " << attrs.size();
+
+		// Verify each parent has attributions
+		int p1_count = 0, p2_count = 0;
+		for (const auto &a : attrs) {
+			if (a.parent_lot_name == "ap_parent1")
+				p1_count++;
+			if (a.parent_lot_name == "ap_parent2")
+				p2_count++;
+			// Equal split: each fraction should be 0.5
+			EXPECT_NEAR(a.fraction, 0.5, 0.01)
+				<< "Attribution for " << a.parent_lot_name << "/" << a.mpa_key << " should be 0.5, got " << a.fraction;
+		}
+		EXPECT_EQ(p1_count, 3) << "parent1 should have 3 attribution records";
+		EXPECT_EQ(p2_count, 3) << "parent2 should have 3 attribution records";
+	}
+}
+
+TEST_F(StrictHierarchyTest, RemoveParentRecomputesAttributions) {
+	// Regression test: remove_parents must reload parents & MPAs from DB
+	// before calling compute_and_store_attributions.
+	addDefaultLot();
+
+	addLot(R"({
+		"lot_name": "rp_parent1",
+		"owner": "owner1",
+		"parents": ["rp_parent1"],
+		"paths": [{"path": "/rp/p1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "rp_parent2",
+		"owner": "owner1",
+		"parents": ["rp_parent2"],
+		"paths": [{"path": "/rp/p2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Create child under both parents
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "rp_child",
+		"owner": "owner1",
+		"parents": ["rp_parent1", "rp_parent2"],
+		"paths": [{"path": "/rp/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	ASSERT_EQ(rv, 0) << (err2.get() ? err2.get() : "");
+
+	// Remove parent2
+	raw_err = nullptr;
+	rv = lotman_rm_parents_from_lot(R"({"lot_name": "rp_child", "parents": ["rp_parent2"]})", &raw_err);
+	UniqueCString err3(raw_err);
+	ASSERT_EQ(rv, 0) << "remove_parents should succeed: " << (err3.get() ? err3.get() : "");
+
+	// Verify attribution records: should only have parent1 with fraction=1.0
+	{
+		using namespace sqlite_orm;
+		auto &storage = lotman::db::StorageManager::get_storage();
+		auto attrs = storage.get_all<lotman::db::ParentChildAttribution>(
+			where(c(&lotman::db::ParentChildAttribution::child_lot_name) == "rp_child"));
+
+		// Should have 3 records (3 MPA keys × 1 remaining parent)
+		EXPECT_EQ(attrs.size(), 3u) << "Expected 3 attribution records (3 keys × 1 parent), got " << attrs.size();
+
+		for (const auto &a : attrs) {
+			EXPECT_EQ(a.parent_lot_name, "rp_parent1")
+				<< "All attributions should be to parent1 after removing parent2";
+			// Sole parent: fraction should be 1.0
+			EXPECT_NEAR(a.fraction, 1.0, 0.01)
+				<< "Attribution fraction for sole parent should be 1.0, got " << a.fraction;
+		}
+	}
+}
+
+// ============================================================================
+// Time-aware Axiom 2 tests (sweep-line)
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, Axiom2NonOverlappingChildrenAllowed) {
+	// Two non-overlapping children whose combined allocation exceeds parent,
+	// but since they don't overlap temporally, peak is within limits → PASS
+	addDefaultLot();
+	addRootLot(); // 100 ded, 50 opp, 1000 obj, [100, 9000]
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child A: 60 ded, active [200, 3000) — exceeds half of parent's 100
+	addLot(R"({
+		"lot_name": "child_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 20,
+			"max_num_objects": 500,
+			"creation_time": 200,
+			"expiration_time": 3000,
+			"deletion_time": 3500
+		}
+	})");
+
+	// Child B: 60 ded, active [3000, 8000) — non-overlapping with child_a
+	// Combined 60+60=120 > 100, but peak at any moment is 60 ≤ 100
+	addLot(R"({
+		"lot_name": "child_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 20,
+			"max_num_objects": 500,
+			"creation_time": 3000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+	// If we get here, both lots were created — no axiom violation
+}
+
+TEST_F(StrictHierarchyTest, Axiom2OverlappingChildrenBlocked) {
+	// Two overlapping children whose combined allocation exceeds parent → FAIL
+	addDefaultLot();
+	addRootLot(); // 100 ded, [100, 9000]
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child A: 60 ded, active [200, 5000)
+	addLot(R"({
+		"lot_name": "child_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 20,
+			"max_num_objects": 500,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	// Child B: 60 ded, active [4000, 8000) — overlaps child_a during [4000, 5000)
+	// Peak = 60+60=120 > 100 → should fail
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 20,
+			"max_num_objects": 500,
+			"creation_time": 4000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Expected axiom 2 violation for overlapping children exceeding parent capacity";
+	EXPECT_NE(std::string(err.get()).find("peak concurrent"), std::string::npos) << "Error: " << err.get();
+}
+
+TEST_F(StrictHierarchyTest, Axiom2BoundaryExactNoOverlap) {
+	// Child A ends exactly when child B starts → no overlap → PASS
+	addDefaultLot();
+	addRootLot(); // 100 ded, [100, 9000]
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child A: 80 ded, active [200, 4000)
+	addLot(R"({
+		"lot_name": "child_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 80,
+			"opportunistic_GB": 10,
+			"max_num_objects": 500,
+			"creation_time": 200,
+			"expiration_time": 4000,
+			"deletion_time": 4500
+		}
+	})");
+
+	// Child B: 80 ded, active [4000, 8000) — starts exactly when A expires
+	// At time 4000: A's removal event fires before B's addition (tie-break)
+	// so peak remains 80 ≤ 100 → should pass
+	addLot(R"({
+		"lot_name": "child_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 80,
+			"opportunistic_GB": 10,
+			"max_num_objects": 500,
+			"creation_time": 4000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+}
+
+TEST_F(StrictHierarchyTest, Axiom2ExtendExpirationCausesOverlap) {
+	// Two children that don't overlap initially, then extending child A's
+	// expiration makes them overlap → should fail on MPA update
+	addDefaultLot();
+	addRootLot(); // 100 ded, [100, 9000]
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child A: 60 ded, active [200, 3000)
+	addLot(R"({
+		"lot_name": "child_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 20,
+			"max_num_objects": 500,
+			"creation_time": 200,
+			"expiration_time": 3000,
+			"deletion_time": 3500
+		}
+	})");
+
+	// Child B: 60 ded, active [3000, 8000) — no overlap
+	addLot(R"({
+		"lot_name": "child_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 20,
+			"max_num_objects": 500,
+			"creation_time": 3000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Now extend child A's expiration to 5000 → overlaps B during [3000, 5000)
+	// Peak = 120 > 100 → should fail
+	rv =
+		lotman_update_lot(R"({"lot_name": "child_a", "management_policy_attrs": {"expiration_time": 5000}})", &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Expected axiom 2 violation when extending expiration creates overlap";
+	EXPECT_NE(std::string(err.get()).find("peak concurrent"), std::string::npos) << "Error: " << err.get();
+}
+
+TEST_F(StrictHierarchyTest, Axiom2ThreeChildrenPartialOverlapUnderLimit) {
+	// Three children with partial overlaps but peak at any moment ≤ parent → PASS
+	addDefaultLot();
+	addRootLot(); // 100 ded, 50 opp, 1000 obj, [100, 9000]
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// A: 40 ded, [200, 3000)
+	addLot(R"({
+		"lot_name": "child_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 10,
+			"max_num_objects": 300,
+			"creation_time": 200,
+			"expiration_time": 3000,
+			"deletion_time": 3500
+		}
+	})");
+
+	// B: 40 ded, [2000, 5000) — overlaps A during [2000, 3000), peak=80 ≤ 100
+	addLot(R"({
+		"lot_name": "child_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 10,
+			"max_num_objects": 300,
+			"creation_time": 2000,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	// C: 40 ded, [4000, 8000) — overlaps B during [4000, 5000), peak=80 ≤ 100
+	// No triple overlap; max concurrent at any time is 80 ≤ 100
+	addLot(R"({
+		"lot_name": "child_c",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/c", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 10,
+			"max_num_objects": 300,
+			"creation_time": 4000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+}
+
+TEST_F(StrictHierarchyTest, Axiom2ThreeChildrenPartialOverlapExceedsLimit) {
+	// Three children with a moment of triple overlap that exceeds parent → FAIL
+	addDefaultLot();
+	addRootLot(); // 100 ded, [100, 9000]
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// A: 40 ded, [200, 5000)
+	addLot(R"({
+		"lot_name": "child_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 10,
+			"max_num_objects": 300,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	// B: 40 ded, [2000, 7000) — overlaps A during [2000, 5000), peak A+B=80
+	addLot(R"({
+		"lot_name": "child_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 10,
+			"max_num_objects": 300,
+			"creation_time": 2000,
+			"expiration_time": 7000,
+			"deletion_time": 7500
+		}
+	})");
+
+	// C: 40 ded, [3000, 8000) — triple overlap during [3000, 5000) = 120 > 100
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_c",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/c", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 10,
+			"max_num_objects": 300,
+			"creation_time": 3000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Expected axiom 2 violation for triple overlap exceeding parent";
+	EXPECT_NE(std::string(err.get()).find("peak concurrent"), std::string::npos) << "Error: " << err.get();
+}
+
+TEST_F(StrictHierarchyTest, Axiom2IndependentPeaksAtDifferentTimes) {
+	// Regression test for C1 bug: sweep-line must track peak_total (concurrent ded+opp),
+	// not sum independent peak_ded and peak_opp which can occur at different times.
+	//
+	// Setup: Parent with 155 total capacity, three children with staggered times:
+	//   A [100,400): 90 ded + 10 opp
+	//   B [300,600): 10 ded + 40 opp
+	//   C [500,800): 50 ded + 20 opp
+	//
+	// Peak ded across all time = 100 (at t=300, A+B)
+	// Peak opp across all time =  60 (at t=500, B+C)
+	// Sum of independent peaks = 160 > 155 (would falsely reject with buggy code)
+	//
+	// Actual peak_total at any single moment:
+	//   t∈[100,300): A alone = 100
+	//   t∈[300,400): A+B = 90+10 ded + 10+40 opp = 100+50 = 150 ← true peak
+	//   t∈[400,500): B alone = 50
+	//   t∈[500,600): B+C = 10+50 ded + 40+20 opp = 60+60 = 120
+	//   t∈[600,800): C alone = 70
+	// True peak_total = 150 ≤ 155 → should PASS
+
+	addDefaultLot();
+	// Root: 155 ded, 0 opp, [100, 9000]
+	addLot(R"({
+		"lot_name": "root",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 155,
+			"opportunistic_GB": 0,
+			"max_num_objects": 10000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child A: 90 ded, 10 opp, [100, 400)
+	addLot(R"({
+		"lot_name": "child_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 90,
+			"opportunistic_GB": 10,
+			"max_num_objects": 300,
+			"creation_time": 100,
+			"expiration_time": 400,
+			"deletion_time": 500
+		}
+	})");
+
+	// Child B: 10 ded, 40 opp, [300, 600) — overlaps A during [300, 400)
+	addLot(R"({
+		"lot_name": "child_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 40,
+			"max_num_objects": 300,
+			"creation_time": 300,
+			"expiration_time": 600,
+			"deletion_time": 700
+		}
+	})");
+
+	// Child C: 50 ded, 20 opp, [500, 800) — overlaps B during [500, 600)
+	// This should PASS because actual concurrent peak = 150 at t=300, under limit of 155
+	rv = lotman_add_lot(R"({
+		"lot_name": "child_c",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/c", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 20,
+			"max_num_objects": 300,
+			"creation_time": 500,
+			"expiration_time": 800,
+			"deletion_time": 900
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Should pass: true concurrent peak=150 ≤ 155, despite independent peak sum=160. Error: "
+					 << err.get();
+}
+
+// ============================================================================
+// Re-validation gap tests (path-temporal overlap on MPA/path updates)
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, ExtendExpirationCausesPathOverlap) {
+	// Two lots with same path but non-overlapping times. Extending lot A's
+	// expiration_time so it overlaps lot B should fail.
+	addDefaultLot();
+	addRootLot();
+
+	// Lot A: path /root/data/shared, [200, 3000)
+	addLot(R"({
+		"lot_name": "lot_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/shared", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 3000,
+			"deletion_time": 3500
+		}
+	})");
+
+	// Lot B: same path, [3000, 6000) — no overlap
+	addLot(R"({
+		"lot_name": "lot_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/shared", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 3000,
+			"expiration_time": 6000,
+			"deletion_time": 6500
+		}
+	})");
+
+	// Now extend lot_a's expiration to 4000 → overlaps lot_b's path during [3000, 4000)
+	char *raw_err = nullptr;
+	int rv =
+		lotman_update_lot(R"({"lot_name": "lot_a", "management_policy_attrs": {"expiration_time": 4000}})", &raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0) << "Expected path temporal overlap failure when extending expiration";
+	EXPECT_NE(std::string(err.get()).find("temporal overlap"), std::string::npos) << "Error: " << err.get();
+}
+
+TEST_F(StrictHierarchyTest, UpdatePathToConflictingPathFails) {
+	// Two lots with different paths but overlapping times. Changing lot A's path
+	// to match lot B's should fail.
+	addDefaultLot();
+	addRootLot();
+
+	// Lot A: path /root/data/a, [200, 5000)
+	addLot(R"({
+		"lot_name": "lot_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	// Lot B: path /root/data/b, [1000, 4000) — overlapping times with A
+	addLot(R"({
+		"lot_name": "lot_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 1000,
+			"expiration_time": 4000,
+			"deletion_time": 4500
+		}
+	})");
+
+	// Change lot_a's path from /root/data/a to /root/data/b → temporal overlap with lot_b
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot(
+		R"({"lot_name": "lot_a", "paths": [{"current": "/root/data/a", "new": "/root/data/b", "recursive": true}]})",
+		&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0) << "Expected path temporal overlap when changing path to conflicting one";
+	EXPECT_NE(std::string(err.get()).find("temporal overlap"), std::string::npos) << "Error: " << err.get();
+}
+
+TEST_F(StrictHierarchyTest, UpdatePathToNonConflictingPathSucceeds) {
+	// Two lots with different paths and non-overlapping times. Changing lot A's path
+	// to match lot B's should succeed since times don't overlap.
+	addDefaultLot();
+	addRootLot();
+
+	// Lot A: path /root/data/a, [200, 3000)
+	addLot(R"({
+		"lot_name": "lot_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 3000,
+			"deletion_time": 3500
+		}
+	})");
+
+	// Lot B: path /root/data/b, [4000, 7000) — non-overlapping times with A
+	addLot(R"({
+		"lot_name": "lot_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 4000,
+			"expiration_time": 7000,
+			"deletion_time": 7500
+		}
+	})");
+
+	// Change lot_a's path to /root/data/b — should succeed (no temporal overlap)
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot(
+		R"({"lot_name": "lot_a", "paths": [{"current": "/root/data/a", "new": "/root/data/b", "recursive": true}]})",
+		&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Path update should succeed for non-overlapping times: " << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, UpdatePathExcludeFalseConflictsFails) {
+	// Regression test for C2 bug: flipping exclude from true→false must trigger temporal
+	// overlap validation even when path string stays the same.
+	//
+	// Setup:
+	//   Lot A: path /root/data/shared, exclude=true, [200, 5000)
+	//   Lot B: path /root/data/shared, exclude=false, [1000, 4000) (overlapping times with A)
+	//
+	// Action: Update lot A to flip exclude=false (path string unchanged)
+	// Expected: Reject due to temporal overlap with lot B on /root/data/shared
+	addDefaultLot();
+	addRootLot();
+
+	// Lot A with excluded path during [200, 5000)
+	addLot(R"({
+		"lot_name": "lot_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/shared", "recursive": true, "exclude": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	// Lot B with same path but exclude=false during overlapping times [1000, 4000)
+	addLot(R"({
+		"lot_name": "lot_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/shared", "recursive": true, "exclude": false}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 1000,
+			"expiration_time": 4000,
+			"deletion_time": 4500
+		}
+	})");
+
+	// Attempt to flip lot_a's exclude flag from true → false (path string unchanged)
+	// This should fail because lot A would now conflict with lot B on /root/data/shared during [1000, 4000)
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot(
+		R"({"lot_name": "lot_a", "paths": [{"current": "/root/data/shared", "new": "/root/data/shared", "recursive": true, "exclude": false}]})",
+		&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0) << "Flipping exclude to false should trigger temporal overlap check even when path unchanged";
+	EXPECT_NE(std::string(err.get()).find("temporal overlap"), std::string::npos)
+		<< "Error should mention temporal overlap. Got: " << err.get();
+}
+
+// ============================================================================
+// Advisory capacity query tests (informational — not a reservation mechanism)
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, AvailableCapacityNoChildren) {
+	// Parent with no children should report full capacity available
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	auto [result, err_msg] = lotman::Lot::get_available_capacity("root", 100, 9000);
+	ASSERT_TRUE(err_msg.empty()) << err_msg;
+	EXPECT_DOUBLE_EQ(result["available_dedicated_GB"].get<double>(), 100.0);
+	EXPECT_DOUBLE_EQ(result["available_opportunistic_GB"].get<double>(), 50.0);
+	EXPECT_EQ(result["available_max_num_objects"].get<int64_t>(), 1000);
+	EXPECT_DOUBLE_EQ(result["peak_dedicated_GB"].get<double>(), 0.0);
+	EXPECT_DOUBLE_EQ(result["peak_opportunistic_GB"].get<double>(), 0.0);
+	EXPECT_EQ(result["peak_max_num_objects"].get<int64_t>(), 0);
+}
+
+TEST_F(StrictHierarchyTest, AvailableCapacityOneChild) {
+	// Parent with one child — capacity reduced during child's interval
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "child1",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/c1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	auto [result, err_msg] = lotman::Lot::get_available_capacity("root", 100, 9000);
+	ASSERT_TRUE(err_msg.empty()) << err_msg;
+	EXPECT_DOUBLE_EQ(result["available_dedicated_GB"].get<double>(), 70.0);
+	EXPECT_DOUBLE_EQ(result["available_opportunistic_GB"].get<double>(), 40.0);
+	EXPECT_EQ(result["available_max_num_objects"].get<int64_t>(), 800);
+	EXPECT_DOUBLE_EQ(result["peak_dedicated_GB"].get<double>(), 30.0);
+}
+
+TEST_F(StrictHierarchyTest, AvailableCapacityPartialOverlap) {
+	// Query window only partially overlaps child — still reports peak during overlap
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child lives [200, 5000)
+	addLot(R"({
+		"lot_name": "child1",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/c1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 20,
+			"max_num_objects": 300,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	// Query window [3000, 9000) — overlaps child's [200, 5000) partially
+	auto [result, err_msg] = lotman::Lot::get_available_capacity("root", 3000, 9000);
+	ASSERT_TRUE(err_msg.empty()) << err_msg;
+	// Peak is from the single child's attribution during the overlap
+	EXPECT_DOUBLE_EQ(result["peak_dedicated_GB"].get<double>(), 40.0);
+	EXPECT_DOUBLE_EQ(result["available_dedicated_GB"].get<double>(), 60.0);
+}
+
+TEST_F(StrictHierarchyTest, AvailableCapacityNonOverlappingChildren) {
+	// Two children that don't overlap — peak is the max of each individually
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child A: [200, 3000), 30 GB dedicated
+	addLot(R"({
+		"lot_name": "childA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/ca", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 3000,
+			"deletion_time": 3500
+		}
+	})");
+
+	// Child B: [3000, 6000), 50 GB dedicated — starts exactly when A ends
+	addLot(R"({
+		"lot_name": "childB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/cb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 20,
+			"max_num_objects": 200,
+			"creation_time": 3000,
+			"expiration_time": 6000,
+			"deletion_time": 6500
+		}
+	})");
+
+	auto [result, err_msg] = lotman::Lot::get_available_capacity("root", 100, 9000);
+	ASSERT_TRUE(err_msg.empty()) << err_msg;
+	// They don't overlap, so peak is the max of the two (50 GB)
+	EXPECT_DOUBLE_EQ(result["peak_dedicated_GB"].get<double>(), 50.0);
+	EXPECT_DOUBLE_EQ(result["available_dedicated_GB"].get<double>(), 50.0);
+}
+
+TEST_F(StrictHierarchyTest, AvailableCapacityOverlappingChildren) {
+	// Two children whose intervals overlap — peak is their sum during overlap
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child A: [200, 5000), 30 GB dedicated
+	addLot(R"({
+		"lot_name": "childA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/ca", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	// Child B: [4000, 8000), 50 GB dedicated — overlaps A during [4000, 5000)
+	addLot(R"({
+		"lot_name": "childB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/cb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 20,
+			"max_num_objects": 200,
+			"creation_time": 4000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	auto [result, err_msg] = lotman::Lot::get_available_capacity("root", 100, 9000);
+	ASSERT_TRUE(err_msg.empty()) << err_msg;
+	// During [4000, 5000), both are active: 30 + 50 = 80 GB
+	EXPECT_DOUBLE_EQ(result["peak_dedicated_GB"].get<double>(), 80.0);
+	EXPECT_DOUBLE_EQ(result["available_dedicated_GB"].get<double>(), 20.0);
+}
+
+TEST_F(StrictHierarchyTest, AvailableCapacityQueryOutsideChildren) {
+	// Query window doesn't overlap any child — full capacity
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child: [200, 3000)
+	addLot(R"({
+		"lot_name": "child1",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/c1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 15,
+			"max_num_objects": 300,
+			"creation_time": 200,
+			"expiration_time": 3000,
+			"deletion_time": 3500
+		}
+	})");
+
+	// Query window [5000, 8000) — child already expired
+	auto [result, err_msg] = lotman::Lot::get_available_capacity("root", 5000, 8000);
+	ASSERT_TRUE(err_msg.empty()) << err_msg;
+	EXPECT_DOUBLE_EQ(result["peak_dedicated_GB"].get<double>(), 0.0);
+	EXPECT_DOUBLE_EQ(result["available_dedicated_GB"].get<double>(), 100.0);
+	EXPECT_DOUBLE_EQ(result["available_opportunistic_GB"].get<double>(), 50.0);
+	EXPECT_EQ(result["available_max_num_objects"].get<int64_t>(), 1000);
+}
+
+TEST_F(StrictHierarchyTest, AvailableCapacityNonexistentParent) {
+	// Querying a non-existent parent returns an error
+	addDefaultLot();
+
+	auto [result, err_msg] = lotman::Lot::get_available_capacity("no_such_lot", 100, 9000);
+	EXPECT_FALSE(err_msg.empty());
+	EXPECT_TRUE(result.empty());
+}
+
+TEST_F(StrictHierarchyTest, AvailableCapacityCApi) {
+	// Exercise the C entry point lotman_get_available_capacity end-to-end.
+	addDefaultLot();
+	addRootLot(); // root: 100 ded, 50 opp, 1000 obj, [100, 9000)
+
+	addLot(R"({
+		"lot_name": "c_api_child",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/c_api_child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 200,
+			"expiration_time": 3000,
+			"deletion_time": 3500
+		}
+	})");
+
+	char *raw_out = nullptr;
+	char *raw_err = nullptr;
+	int rv = lotman_get_available_capacity("root", 100, 9000, &raw_out, &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << "C API call failed: " << (err.get() ? err.get() : "");
+	ASSERT_NE(raw_out, nullptr);
+
+	auto out = nlohmann::json::parse(raw_out);
+	free(raw_out);
+
+	// Child's full attribution (equal-split with one parent) is its own MPAs.
+	EXPECT_DOUBLE_EQ(out["peak_dedicated_GB"].get<double>(), 30.0);
+	EXPECT_DOUBLE_EQ(out["available_dedicated_GB"].get<double>(), 70.0);
+	EXPECT_DOUBLE_EQ(out["peak_opportunistic_GB"].get<double>(), 10.0);
+	EXPECT_DOUBLE_EQ(out["available_opportunistic_GB"].get<double>(), 40.0);
+	EXPECT_EQ(out["peak_max_num_objects"].get<int64_t>(), 200);
+	EXPECT_EQ(out["available_max_num_objects"].get<int64_t>(), 800);
+
+	// Null parent_lot_name should error
+	raw_out = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_available_capacity(nullptr, 100, 9000, &raw_out, &raw_err);
+	UniqueCString err2(raw_err);
+	EXPECT_NE(rv, 0);
+	EXPECT_EQ(raw_out, nullptr);
+
+	// Non-existent parent should error and not allocate output
+	raw_out = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_available_capacity("nope", 100, 9000, &raw_out, &raw_err);
+	UniqueCString err3(raw_err);
+	EXPECT_NE(rv, 0);
+	EXPECT_EQ(raw_out, nullptr);
+}
+
+// ============================================================================
+// Atomic reservation test (lot creation is the reservation mechanism)
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, LotCreationEnforcesCapacityAtomically) {
+	// Verify that lot creation itself is the capacity enforcement mechanism:
+	// creating a child that would exceed the parent's capacity fails atomically.
+	addDefaultLot();
+	addRootLot(); // root: 100 ded, 50 opp, 1000 obj, [100, 9000)
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child A consumes 60 of 100 dedicated_GB during [200, 5000)
+	addLot(R"({
+		"lot_name": "childA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/ca", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	// Child B tries to take 50 during [4000, 8000) — overlaps A during [4000, 5000)
+	// Peak would be 60+50=110 > 100, so Axiom 2 should block this atomically
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "childB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/cb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 4000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Lot creation should fail when overlapping children exceed parent capacity";
+	ASSERT_NE(err.get(), nullptr);
+	std::string err_str(err.get());
+	EXPECT_TRUE(err_str.find("peak concurrent") != std::string::npos || err_str.find("exceeds") != std::string::npos)
+		<< "Error should report combined concurrent children exceed parent capacity: " << err_str;
+
+	// But Child B with non-overlapping time window [5000, 8000) should succeed
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "childB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/cb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 5000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Lot creation should succeed when children don't overlap: " << (err.get() ? err.get() : "");
+}
+
+// ============================================================================
+// C API reservation edge-case tests
+// These exercise the full reservation lifecycle through the external C API,
+// testing every mutation path that can affect capacity enforcement.
+// ============================================================================
+
+// --- lotman_add_lot: reservation creation ---
+
+TEST_F(StrictHierarchyTest, ReserveExactCapacity) {
+	// A single child reserving exactly 100% of the parent's resources should succeed
+	addDefaultLot();
+	addRootLot(); // root: 100 ded, 50 opp, 1000 obj, [100, 9000)
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "full_child",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/full", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Reserving exactly 100% of parent capacity should succeed: " << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, ReserveOverCapacityDedicatedOnly) {
+	// A single child exceeding parent's dedicated_GB must fail
+	addDefaultLot();
+	addRootLot(); // 100 ded
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "greedy",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/greedy", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 101,
+			"opportunistic_GB": 0,
+			"max_num_objects": 1,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Exceeding parent dedicated_GB should fail";
+}
+
+TEST_F(StrictHierarchyTest, ReserveOverCapacityDedPlusOpp) {
+	// dedicated fits, but dedicated+opportunistic exceeds parent's ded+opp total
+	addDefaultLot();
+	addRootLot(); // 100 ded + 50 opp = 150 total
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "opp_hog",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/opp", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 90,
+			"opportunistic_GB": 70,
+			"max_num_objects": 1,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "ded(90)+opp(70)=160 exceeding parent total(150) should fail";
+}
+
+TEST_F(StrictHierarchyTest, ReserveOverCapacityMaxObjects) {
+	// Only max_num_objects exceeds — should still fail
+	addDefaultLot();
+	addRootLot(); // 1000 max_num_objects
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "obj_hog",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/obj", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 1,
+			"opportunistic_GB": 1,
+			"max_num_objects": 1001,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Exceeding parent max_num_objects should fail";
+}
+
+TEST_F(StrictHierarchyTest, ReserveSecondChildNonOverlappingTimeFitsExactly) {
+	// First child takes 100% of capacity during [200, 5000).
+	// Second child also takes 100% during [5000, 8000) — no temporal overlap, should succeed.
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "first",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/first", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "second",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/second", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 5000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Sequential 100% reservations should succeed: " << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, ReserveSecondChildOverlappingByOneUnitFails) {
+	// First child: [200, 5001), 100% capacity
+	// Second child: [5000, 8000), 100% capacity — overlap during [5000, 5001)
+	// Peak = 200% → must fail
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "first",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/first", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 200,
+			"expiration_time": 5001,
+			"deletion_time": 5500
+		}
+	})");
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "second",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/second", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 5000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "One-unit temporal overlap at 200% should fail";
+}
+
+TEST_F(StrictHierarchyTest, ReservePathTemporalOverlapBlocked) {
+	// Two lots claiming the same path with overlapping time windows — must fail
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "pathA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/shared", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "pathB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/shared", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 4000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Same path with overlapping times should fail";
+}
+
+TEST_F(StrictHierarchyTest, ReservePathTemporalNoOverlapAllowed) {
+	// Two lots claiming the same path with NON-overlapping time windows — should succeed
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "pathA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/shared", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 4000,
+			"deletion_time": 4500
+		}
+	})");
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "pathB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/shared", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 4000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Same path with non-overlapping times should succeed: " << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, ReserveFailedCreationLeavesNoDB) {
+	// A failed reservation must not leave partial DB state
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Create child taking full capacity
+	addLot(R"({
+		"lot_name": "existing",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/ex", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	// Try to create overlapping child — will fail Axiom 2
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "failed_lot",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/fail", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Over-capacity creation should fail";
+
+	// Verify the failed lot does not exist
+	raw_err = nullptr;
+	rv = lotman_lot_exists("failed_lot", &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Failed lot should not exist in DB: " << (err.get() ? err.get() : "");
+}
+
+// --- lotman_update_lot: post-creation mutations ---
+
+TEST_F(StrictHierarchyTest, ShrinkExpirationFreesCapacity) {
+	// Shrink first child's expiration so second child no longer overlaps
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "childA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/ca", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 6000,
+			"deletion_time": 6500
+		}
+	})");
+
+	// childB at [5000, 8000) with 60 ded — overlaps childA during [5000, 6000), peak = 120 > 100 → fail
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "childB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/cb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 5000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Should fail while childA still overlaps";
+
+	// Shrink childA's expiration to 5000, eliminating overlap
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "childA", "management_policy_attrs": {"expiration_time": 5000}})", &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Shrinking expiration should succeed: " << (err.get() ? err.get() : "");
+
+	// Now childB should succeed
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "childB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/cb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 5000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "After shrinking childA, childB should fit: " << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, ExtendExpirationCausesCapacityViolation) {
+	// Two non-overlapping children, then extending the first to overlap the second
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "childA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/ca", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 4000,
+			"deletion_time": 4500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "childB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/cb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 4000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Extend childA's expiration to 5000 — now overlaps childB during [4000, 5000)
+	// Peak = 60+60 = 120 > 100
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "childA", "management_policy_attrs": {"expiration_time": 5000}})", &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Extending expiration to cause overlap should fail";
+}
+
+TEST_F(StrictHierarchyTest, ShrinkDedicatedGBToFitNewChild) {
+	// Shrink existing child's dedicated_GB to make room for a new reservation
+	addDefaultLot();
+	addRootLot(); // 100 ded
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "big",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/big", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 80,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// New child wants 30 during overlapping period — 80+30=110 > 100
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "small",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/small", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Should fail: 80+30=110 > 100";
+
+	// Shrink "big" from 80 to 60
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "big", "management_policy_attrs": {"dedicated_GB": 60}})", &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Shrinking dedicated_GB should succeed: " << (err.get() ? err.get() : "");
+
+	// Now 60+30=90 ≤ 100 → should succeed
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "small",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/small", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 5,
+			"max_num_objects": 50,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "After shrinking, new child should fit: " << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, GrowDedicatedGBBlockedByAxiom2) {
+	// Growing a child's dedicated_GB so that siblings now exceed parent
+	addDefaultLot();
+	addRootLot(); // 100 ded
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "childA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/ca", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "childB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/cb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Try to grow childA to 60 → 60+50=110 > 100
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "childA", "management_policy_attrs": {"dedicated_GB": 60}})", &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Growing dedicated_GB to exceed parent capacity should fail";
+}
+
+// --- lotman_update_lot with paths: path temporal overlap on update ---
+
+TEST_F(StrictHierarchyTest, UpdatePathToOverlappingTimeFails) {
+	// Lot A has path /root/data/x during [200, 5000).
+	// Lot B has path /root/data/y during [200, 5000).
+	// Changing lot B's path to /root/data/x should fail (temporal overlap).
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "lotA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/x", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "lotB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/y", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	raw_err = nullptr;
+	rv = lotman_update_lot(
+		R"({"lot_name": "lotB", "paths": [{"current": "/root/data/y", "new": "/root/data/x", "recursive": true}]})",
+		&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Changing path to one with overlapping time should fail";
+}
+
+// --- lotman_add_to_lot: adding paths after creation ---
+
+TEST_F(StrictHierarchyTest, AddPathOverlappingExistingFails) {
+	// Lot A claims /root/data/shared during [200, 5000).
+	// Adding /root/data/shared to lot B (also [200, 5000)) should fail.
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "lotA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/shared", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "lotB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/other", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})");
+
+	raw_err = nullptr;
+	rv = lotman_add_to_lot(R"({"lot_name": "lotB", "paths": [{"path": "/root/data/shared", "recursive": true}]})",
+						   &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Adding path that overlaps another lot's time range should fail";
+}
+
+TEST_F(StrictHierarchyTest, AddPathNonOverlappingSucceeds) {
+	// Lot A has /root/data/shared during [200, 3000).
+	// Adding /root/data/shared to lot B [4000, 7000) should succeed.
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "lotA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/shared", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 3000,
+			"deletion_time": 3500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "lotB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/other", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 4000,
+			"expiration_time": 7000,
+			"deletion_time": 7500
+		}
+	})");
+
+	raw_err = nullptr;
+	rv = lotman_add_to_lot(R"({"lot_name": "lotB", "paths": [{"path": "/root/data/shared", "recursive": true}]})",
+						   &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Adding path with non-overlapping times should succeed: " << (err.get() ? err.get() : "");
+}
+
+// --- lotman_update_lot with parent_attributions: re-attribution mutations ---
+
+TEST_F(StrictHierarchyTest, UpdateAttributionsCausesAxiom2Violation) {
+	// Two children under root, each attributed 50% of parent's 100 ded.
+	// Re-attributing one child to take 60% causes peak = 60+50 = 110 > 100.
+	addDefaultLot();
+	addRootLot(); // 100 ded
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// childA: 50 ded during [200, 8000) — attributed as 50/100 = 50%
+	addLot(R"({
+		"lot_name": "childA",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/ca", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// childB: 50 ded during [200, 8000) — attributed as 50/100 = 50%
+	addLot(R"({
+		"lot_name": "childB",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/cb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Now grow childA's MPAs to 60 ded — Axiom 1 passes (60 ≤ 100), but Axiom 2 peak = 60+50 = 110 > 100
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({"lot_name": "childA", "management_policy_attrs": {"dedicated_GB": 60}})", &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Growing sibling capacity to exceed parent should fail via Axiom 2";
+}
+
+// --- lotman_remove_lot / lotman_remove_lots_recursive: releasing reservations ---
+
+TEST_F(StrictHierarchyTest, DeleteLotFreesCapacityForNew) {
+	// Create child consuming 80/100 ded. Delete it. Create new child with full 100.
+	addDefaultLot();
+	addRootLot();
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "to_delete",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/del", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 80,
+			"opportunistic_GB": 40,
+			"max_num_objects": 800,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Can't create full child while to_delete exists
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "full_replacement",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/rep", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Should fail while to_delete still holds capacity";
+
+	// Delete the old lot
+	raw_err = nullptr;
+	rv = lotman_remove_lots_recursive("to_delete", &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Delete should succeed: " << (err.get() ? err.get() : "");
+
+	// Now the full replacement should succeed
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "full_replacement",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/rep", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "After deletion, full replacement should succeed: " << (err.get() ? err.get() : "");
+}
+
+// --- Strict hierarchy on/off: reservations only enforced when strict_hierarchy=true ---
+
+TEST_F(StrictHierarchyTest, ReservationNotEnforcedWhenStrictOff) {
+	// With strict_hierarchy=false, over-subscription is allowed
+	addDefaultLot();
+	addRootLot(); // 100 ded
+	// strict_hierarchy defaults to false in setUp
+
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "over",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/over", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 200,
+			"opportunistic_GB": 100,
+			"max_num_objects": 2000,
+			"creation_time": 200,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Over-subscription should be allowed when strict_hierarchy is off: "
+					 << (err.get() ? err.get() : "");
+}
+
+// --- Multi-parent reservation: child attributed across multiple parents ---
+
+TEST_F(StrictHierarchyTest, MultiParentReservationFitsEachParent) {
+	// Child has two parents. Attribution is split evenly.
+	// Each parent must independently satisfy its share.
+	addDefaultLot();
+	addRootLot(); // root: 100 ded
+
+	// Second parent
+	addLot(R"({
+		"lot_name": "root2",
+		"owner": "owner1",
+		"parents": ["root2"],
+		"paths": [{"path": "/root2/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child with 120 ded, two parents → each gets 60 attributed (within each parent's 100)
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "dual_parent_child",
+		"owner": "owner1",
+		"parents": ["root", "root2"],
+		"paths": [{"path": "/root/data/dual", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 120,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Child with 120 ded split across 2 parents (60 each ≤ 100) should succeed: "
+					 << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, MultiParentReservationExceedsOneParent) {
+	// Child has two parents but one has limited capacity → Axiom 1 or 2 should catch it
+	addDefaultLot();
+
+	// Big parent
+	addLot(R"({
+		"lot_name": "big_parent",
+		"owner": "owner1",
+		"parents": ["big_parent"],
+		"paths": [{"path": "/big/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 200,
+			"opportunistic_GB": 100,
+			"max_num_objects": 2000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Small parent (only 10 ded total)
+	addLot(R"({
+		"lot_name": "small_parent",
+		"owner": "owner1",
+		"parents": ["small_parent"],
+		"paths": [{"path": "/small/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child with 100 ded → equal split = 50 per parent. small_parent(10) < 50 → Axiom 1 or 2 violation
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "too_big",
+		"owner": "owner1",
+		"parents": ["big_parent", "small_parent"],
+		"paths": [{"path": "/big/data/tb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Child exceeding one of its parents should fail";
+}
+
+// --- Timestamp boundary edge cases ---
+
+TEST_F(StrictHierarchyTest, ChildExpirationEqualsParentExpiration) {
+	// Child's expiration exactly equals parent's expiration — Axiom 3 should pass
+	addDefaultLot();
+	addRootLot(); // expiration 9000
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "exact_exp",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/exact", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Child expiration == parent expiration should be allowed: " << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, ChildExpirationExceedsParentFails) {
+	// Child's expiration exceeds parent's expiration — Axiom 3 violation
+	addDefaultLot();
+	addRootLot(); // expiration 9000
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "late_exp",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/late", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 9001,
+			"deletion_time": 9500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Child expiration exceeding parent should fail (Axiom 3)";
+}
+
+TEST_F(StrictHierarchyTest, ChildCreationBeforeParentFails) {
+	// Child's creation_time is before parent's creation_time — Axiom 3 violation
+	addDefaultLot();
+	addRootLot(); // creation 100
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "early_child",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/early", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 10,
+			"max_num_objects": 100,
+			"creation_time": 50,
+			"expiration_time": 5000,
+			"deletion_time": 5500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Child creation before parent should fail (Axiom 3)";
+}
+
+// --- Three-level hierarchy: grandchild reservation enforcement ---
+
+TEST_F(StrictHierarchyTest, GrandchildCapacityConstrainedByParentNotGrandparent) {
+	// Root (100 ded) -> middle (50 ded) -> grandchild
+	// Grandchild's capacity is bounded by middle (50), not root (100)
+	addDefaultLot();
+	addRootLot(); // 100 ded
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	addLot(R"({
+		"lot_name": "middle",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/mid", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 20,
+			"max_num_objects": 500,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Grandchild asking for 60 ded — within root's 100 but exceeds middle's 50
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "grandchild",
+		"owner": "owner1",
+		"parents": ["middle"],
+		"paths": [{"path": "/root/data/mid/gc", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 300,
+			"expiration_time": 7000,
+			"deletion_time": 7500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Grandchild exceeding parent middle should fail (Axiom 1)";
+
+	// Grandchild asking for 40 ded — within middle's 50
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "grandchild",
+		"owner": "owner1",
+		"parents": ["middle"],
+		"paths": [{"path": "/root/data/mid/gc", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 300,
+			"expiration_time": 7000,
+			"deletion_time": 7500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Grandchild within parent middle should succeed: " << (err.get() ? err.get() : "");
+}
+
+// ============================================================================
+// Bug regression tests
+// ============================================================================
+
+// Bug 1: lotman_rm_paths_from_lots used LIMIT 1, so if the same path appeared
+// in multiple lots (with non-overlapping time ranges) only one lot's path entry
+// was removed.  After the fix, all lots sharing that path are cleaned up.
+TEST_F(StrictHierarchyTest, RmPathsRemovesFromAllLotsWithSharedPath) {
+	addDefaultLot();
+
+	char *raw_err = nullptr;
+	int rv;
+
+	// Enable strict hierarchy so temporal overlap enforcement is active
+	rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Root lot that spans a wide time range
+	addLot(R"({
+		"lot_name": "root",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/shared", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 200,
+			"opportunistic_GB": 100,
+			"max_num_objects": 5000,
+			"creation_time": 100,
+			"expiration_time": 90000,
+			"deletion_time": 99000
+		}
+	})");
+
+	// lot_a owns /shared/data during [1000, 2000)
+	addLot(R"({
+		"lot_name": "lot_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/shared/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 1000,
+			"expiration_time": 2000,
+			"deletion_time": 3000
+		}
+	})");
+
+	// lot_b owns /shared/data during [3000, 4000) — non-overlapping
+	addLot(R"({
+		"lot_name": "lot_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/shared/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 3000,
+			"expiration_time": 4000,
+			"deletion_time": 5000
+		}
+	})");
+
+	// Remove the shared path
+	raw_err = nullptr;
+	rv = lotman_rm_paths_from_lots(R"({"paths": ["/shared/data"]})", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << "rm_paths failed: " << (err.get() ? err.get() : "");
+
+	// Verify lot_a no longer has the path
+	char *dirs_output = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lot_dirs("lot_a", false, &dirs_output, &raw_err);
+	UniqueCString dirs_err(raw_err);
+	UniqueCString dirs_str(dirs_output);
+	ASSERT_EQ(rv, 0) << (dirs_err.get() ? dirs_err.get() : "");
+	json lot_a_dirs = json::parse(dirs_str.get());
+	EXPECT_TRUE(lot_a_dirs.empty()) << "lot_a should have no paths after removal, got: " << lot_a_dirs.dump();
+
+	// Verify lot_b no longer has the path either
+	dirs_output = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lot_dirs("lot_b", false, &dirs_output, &raw_err);
+	dirs_err.reset(raw_err);
+	dirs_str.reset(dirs_output);
+	ASSERT_EQ(rv, 0) << (dirs_err.get() ? dirs_err.get() : "");
+	json lot_b_dirs = json::parse(dirs_str.get());
+	EXPECT_TRUE(lot_b_dirs.empty()) << "lot_b should have no paths after removal, got: " << lot_b_dirs.dump();
+}
+
+// Bug 2: When store_lot inserts a lot between an existing parent-child pair
+// (insertion adjustment), the child's attributions were not recomputed.  This
+// could allow a sibling to over-allocate from the newly-inserted parent because
+// Axiom 2 did not count the existing child's share.
+TEST_F(StrictHierarchyTest, InsertionAdjustmentRecomputesChildAttributions) {
+	addDefaultLot();
+
+	char *raw_err = nullptr;
+	int rv;
+
+	rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Root with 100 ded
+	addLot(R"({
+		"lot_name": "root",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// child with 30 ded, parent = root
+	addLot(R"({
+		"lot_name": "child",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 10,
+			"max_num_objects": 200,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Insert "middle" between root and child.  middle has 50 ded.
+	// After insertion, child's parent becomes middle (not root).
+	// child's 30 ded should be counted against middle's 50.
+	addLot(R"({
+		"lot_name": "middle",
+		"owner": "owner1",
+		"parents": ["root"],
+		"children": ["child"],
+		"paths": [{"path": "/root/data/mid", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 20,
+			"max_num_objects": 500,
+			"creation_time": 150,
+			"expiration_time": 8500,
+			"deletion_time": 9000
+		}
+	})");
+
+	// Verify child's parent is now middle
+	char **parent_output = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_parent_names("child", false, false, &parent_output, &raw_err);
+	err.reset(raw_err);
+	UniqueStringList parents(parent_output);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	ASSERT_NE(parents.get(), nullptr);
+	EXPECT_STREQ(parents.get()[0], "middle");
+
+	// Now try to add child2 under middle with 30 ded.
+	// middle has 50 total; child already uses 30 → only 20 remains.
+	// child2 asking for 30 should FAIL if attributions were properly recomputed.
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "child2",
+		"owner": "owner1",
+		"parents": ["middle"],
+		"paths": [{"path": "/root/data/mid/child2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "child2 should fail: child already uses 30 of middle's 50 ded";
+
+	// But asking for 20 should succeed (exactly fills the remaining capacity)
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "child2",
+		"owner": "owner1",
+		"parents": ["middle"],
+		"paths": [{"path": "/root/data/mid/child2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "child2 with 20 ded should fit: " << (err.get() ? err.get() : "");
+}
+
+// Bug 3: update_parents did not call reload_and_recompute_attributions, unlike
+// add_parents and remove_parents.  After swapping a child's parent, Axiom 2
+// accounting on the new parent was stale.
+TEST_F(StrictHierarchyTest, UpdateParentsRecomputesAttributions) {
+	addDefaultLot();
+
+	char *raw_err = nullptr;
+	int rv;
+
+	rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Root with 200 ded
+	addLot(R"({
+		"lot_name": "root",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 200,
+			"opportunistic_GB": 100,
+			"max_num_objects": 5000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// parent_a with 50 ded
+	addLot(R"({
+		"lot_name": "parent_a",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 20,
+			"max_num_objects": 500,
+			"creation_time": 200,
+			"expiration_time": 8500,
+			"deletion_time": 9000
+		}
+	})");
+
+	// parent_b with 40 ded
+	addLot(R"({
+		"lot_name": "parent_b",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/root/data/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 40,
+			"opportunistic_GB": 15,
+			"max_num_objects": 400,
+			"creation_time": 200,
+			"expiration_time": 8500,
+			"deletion_time": 9000
+		}
+	})");
+
+	// child with 25 ded under parent_a
+	addLot(R"({
+		"lot_name": "child",
+		"owner": "owner1",
+		"parents": ["parent_a"],
+		"paths": [{"path": "/root/data/a/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 25,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 300,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Move child from parent_a to parent_b via update_lot
+	raw_err = nullptr;
+	rv = lotman_update_lot(R"({
+		"lot_name": "child",
+		"parents": [{"current": "parent_a", "new": "parent_b"}]
+	})",
+						   &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << "update_parents failed: " << (err.get() ? err.get() : "");
+
+	// Now child uses 25 of parent_b's 40, leaving only 15.
+	// Adding child2 under parent_b with 20 should fail.
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "child2",
+		"owner": "owner1",
+		"parents": ["parent_b"],
+		"paths": [{"path": "/root/data/b/child2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 300,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "child2 with 20 ded should fail: child already uses 25 of parent_b's 40";
+
+	// But 15 should succeed (exactly fills remaining)
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "child2",
+		"owner": "owner1",
+		"parents": ["parent_b"],
+		"paths": [{"path": "/root/data/b/child2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 15,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 300,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "child2 with 15 ded should fit: " << (err.get() ? err.get() : "");
+}
+
+// Bug 4/5: Temporal queries used closed intervals [creation, expiration] instead
+// of half-open [creation, expiration).  This test verifies half-open semantics:
+// a lot is NOT found at its exact expiration_time, and an adjacent lot starting
+// at that same time IS found.
+TEST_F(StrictHierarchyTest, HalfOpenIntervalGetLotsFromDir) {
+	addDefaultLot();
+
+	char *raw_err = nullptr;
+	int rv;
+
+	rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Root spanning a wide range
+	addLot(R"({
+		"lot_name": "root",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/temporal", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 200,
+			"opportunistic_GB": 100,
+			"max_num_objects": 5000,
+			"creation_time": 100,
+			"expiration_time": 90000,
+			"deletion_time": 99000
+		}
+	})");
+
+	// lot_early: owns /temporal/data during [1000, 2000)
+	addLot(R"({
+		"lot_name": "lot_early",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/temporal/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 1000,
+			"expiration_time": 2000,
+			"deletion_time": 3000
+		}
+	})");
+
+	// lot_late: owns /temporal/data during [2000, 3000) — immediately follows lot_early
+	addLot(R"({
+		"lot_name": "lot_late",
+		"owner": "owner1",
+		"parents": ["root"],
+		"paths": [{"path": "/temporal/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 2000,
+			"expiration_time": 3000,
+			"deletion_time": 4000
+		}
+	})");
+
+	// Helper lambda to query which lot owns /temporal/data at a given time
+	auto query_lot = [&](int64_t t) -> std::string {
+		char **lots_output = nullptr;
+		char *qerr = nullptr;
+		int qrv = lotman_get_lots_from_dir("/temporal/data", false, t, &lots_output, &qerr);
+		UniqueCString qerr_str(qerr);
+		UniqueStringList lots(lots_output);
+		if (qrv != 0 || !lots.get() || !lots.get()[0])
+			return "";
+		return std::string(lots.get()[0]);
+	};
+
+	// Before lot_early's creation: should fall through to default or root
+	EXPECT_NE(query_lot(999), "lot_early") << "Before creation_time, lot_early should not own the path";
+
+	// At lot_early's creation_time (inclusive start): lot_early should own it
+	EXPECT_EQ(query_lot(1000), "lot_early") << "At creation_time, lot_early should own the path";
+
+	// Mid-interval: lot_early
+	EXPECT_EQ(query_lot(1500), "lot_early");
+
+	// One tick before lot_early expires: still lot_early
+	EXPECT_EQ(query_lot(1999), "lot_early");
+
+	// At lot_early's expiration_time (half-open: excluded for lot_early, included for lot_late)
+	EXPECT_NE(query_lot(2000), "lot_early") << "At expiration_time, lot_early should no longer own the path";
+	EXPECT_EQ(query_lot(2000), "lot_late") << "At lot_late's creation_time, lot_late should own the path";
+
+	// Mid-interval lot_late
+	EXPECT_EQ(query_lot(2500), "lot_late");
+
+	// One tick before lot_late expires
+	EXPECT_EQ(query_lot(2999), "lot_late");
+
+	// At lot_late's expiration: neither should own it
+	EXPECT_NE(query_lot(3000), "lot_late") << "At expiration_time, lot_late should no longer own the path";
+}
+
+// Verify get_lot_from_dir (the internal single-lot lookup) also uses half-open
+// semantics by testing with lotman_update_lot_usage_by_dir at boundary times.
+TEST_F(StrictHierarchyTest, HalfOpenIntervalGetLotFromDir) {
+	addDefaultLot();
+
+	char *raw_err = nullptr;
+	int rv;
+
+	// A simple lot with known time range [1000, 2000)
+	addLot(R"({
+		"lot_name": "timed_lot",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/timed/path", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 1000,
+			"expiration_time": 2000,
+			"deletion_time": 3000
+		}
+	})");
+
+	// Query at 1999 (inside) — should find timed_lot
+	char **lots_output = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lots_from_dir("/timed/path", false, 1999, &lots_output, &raw_err);
+	UniqueCString err(raw_err);
+	UniqueStringList lots(lots_output);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	ASSERT_NE(lots.get(), nullptr);
+	EXPECT_STREQ(lots.get()[0], "timed_lot");
+
+	// Query at 2000 (expiration, excluded by half-open) — should NOT find timed_lot
+	lots_output = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lots_from_dir("/timed/path", false, 2000, &lots_output, &raw_err);
+	err.reset(raw_err);
+	lots.reset(lots_output);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	// Should fall through to default
+	ASSERT_NE(lots.get(), nullptr);
+	EXPECT_STREQ(lots.get()[0], "default") << "At expiration_time, path should fall through to default";
+
+	// Query at 1000 (creation, included) — should find timed_lot
+	lots_output = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lots_from_dir("/timed/path", false, 1000, &lots_output, &raw_err);
+	err.reset(raw_err);
+	lots.reset(lots_output);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	ASSERT_NE(lots.get(), nullptr);
+	EXPECT_STREQ(lots.get()[0], "timed_lot");
+
+	// Query at 999 (before creation, excluded) — should NOT find timed_lot
+	lots_output = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lots_from_dir("/timed/path", false, 999, &lots_output, &raw_err);
+	err.reset(raw_err);
+	lots.reset(lots_output);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	ASSERT_NE(lots.get(), nullptr);
+	EXPECT_STREQ(lots.get()[0], "default") << "Before creation_time, path should fall through to default";
+}
+
+// --- Multi-parent overlap stress & edge cases (3+ parents) ---
+
+TEST_F(StrictHierarchyTest, ThreeParentChildSweepLineOverlap) {
+	// Three root lots as parents, each with 50 ded.
+	// A child with 90 ded split equally across 3 parents (30 each ≤ 50) should succeed.
+	// A sibling from one of those parents with 25 ded pushes that parent to 55 > 50 → fail.
+	addDefaultLot();
+
+	addLot(R"({"lot_name": "pA", "owner": "owner1", "parents": ["pA"],
+		"paths": [{"path": "/pA/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50, "opportunistic_GB": 0, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})");
+	addLot(R"({"lot_name": "pB", "owner": "owner1", "parents": ["pB"],
+		"paths": [{"path": "/pB/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50, "opportunistic_GB": 0, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})");
+	addLot(R"({"lot_name": "pC", "owner": "owner1", "parents": ["pC"],
+		"paths": [{"path": "/pC/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50, "opportunistic_GB": 0, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Joint child under all three parents — 90 ded / 3 = 30 each ≤ 50
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "tri_child", "owner": "owner1",
+		"parents": ["pA", "pB", "pC"],
+		"paths": [{"path": "/pA/data/tri", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 90, "opportunistic_GB": 0, "max_num_objects": 60,
+			"creation_time": 200, "expiration_time": 8000, "deletion_time": 8500}})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "90 ded split across 3 parents (30 each ≤ 50) should succeed: " << (err.get() ? err.get() : "");
+
+	// Now add a sibling under pA with 25 ded → pA concurrent load = 30 + 25 = 55 > 50
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "pA_sibling", "owner": "owner1",
+		"parents": ["pA"],
+		"paths": [{"path": "/pA/data/sib", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 25, "opportunistic_GB": 0, "max_num_objects": 10,
+			"creation_time": 200, "expiration_time": 8000, "deletion_time": 8500}})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Sibling that tips pA over capacity should be rejected by Axiom 2";
+}
+
+TEST_F(StrictHierarchyTest, ThreeParentTemporalStaggerAvoidsSweepConflict) {
+	// Three parents, child under all three. A sibling under pA does NOT overlap
+	// with the child in time → sweep-line should allow it even though the sum of
+	// raw allocations would exceed pA if concurrent.
+	addDefaultLot();
+
+	addLot(R"({"lot_name": "pA", "owner": "owner1", "parents": ["pA"],
+		"paths": [{"path": "/pA/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50, "opportunistic_GB": 0, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})");
+	addLot(R"({"lot_name": "pB", "owner": "owner1", "parents": ["pB"],
+		"paths": [{"path": "/pB/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50, "opportunistic_GB": 0, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})");
+	addLot(R"({"lot_name": "pC", "owner": "owner1", "parents": ["pC"],
+		"paths": [{"path": "/pC/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50, "opportunistic_GB": 0, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child under all three, lives [200, 4000)
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "early_child", "owner": "owner1",
+		"parents": ["pA", "pB", "pC"],
+		"paths": [{"path": "/pA/data/early", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 90, "opportunistic_GB": 0, "max_num_objects": 60,
+			"creation_time": 200, "expiration_time": 4000, "deletion_time": 4500}})",
+						&raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+
+	// Sibling under pA only, lives [5000, 8000) — no temporal overlap with early_child
+	// So pA's peak concurrent load is max(30, 45) = 45 ≤ 50
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "late_sib", "owner": "owner1",
+		"parents": ["pA"],
+		"paths": [{"path": "/pA/data/late", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 45, "opportunistic_GB": 0, "max_num_objects": 80,
+			"creation_time": 5000, "expiration_time": 8000, "deletion_time": 8500}})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Non-overlapping sibling should succeed: " << (err.get() ? err.get() : "");
+}
+
+TEST_F(StrictHierarchyTest, ThreeParentObjectCapacity) {
+	// Three parents with different object capacities.
+	// A child attributed across all three must satisfy the smallest parent.
+	addDefaultLot();
+
+	addLot(R"({"lot_name": "pX", "owner": "owner1", "parents": ["pX"],
+		"paths": [{"path": "/pX/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 0, "max_num_objects": 30,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})");
+	addLot(R"({"lot_name": "pY", "owner": "owner1", "parents": ["pY"],
+		"paths": [{"path": "/pY/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 0, "max_num_objects": 30,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})");
+	addLot(R"({"lot_name": "pZ", "owner": "owner1", "parents": ["pZ"],
+		"paths": [{"path": "/pZ/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 0, "max_num_objects": 30,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Child with 90 objects / 3 parents = 30 each. 30 ≤ 30 → should succeed
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "obj_child", "owner": "owner1",
+		"parents": ["pX", "pY", "pZ"],
+		"paths": [{"path": "/pX/data/oc", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10, "opportunistic_GB": 0, "max_num_objects": 90,
+			"creation_time": 200, "expiration_time": 8000, "deletion_time": 8500}})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "90 objects across 3 parents (30 each = 30 limit) should succeed: "
+					 << (err.get() ? err.get() : "");
+
+	// Another child under pX with 1 object → pX now has 30 + 1 = 31 > 30
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "extra_obj", "owner": "owner1",
+		"parents": ["pX"],
+		"paths": [{"path": "/pX/data/xo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 1, "opportunistic_GB": 0, "max_num_objects": 1,
+			"creation_time": 200, "expiration_time": 8000, "deletion_time": 8500}})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "One extra object should push pX past its 30-object limit";
+}
+
+// ---------------------------------------------------------------------------
+// Tests for attribution input-validation fixes
+// ---------------------------------------------------------------------------
+
+// Fix 1: When every non-self parent is explicitly attributed for an MPA key
+// but the sum falls short of the child's total, we must get an error rather
+// than silently dropping the remainder.
+TEST_F(StrictHierarchyTest, ExplicitAttributionShortfallRejected) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+
+	// Two parents with plenty of capacity
+	int rv = lotman_add_lot(R"({"lot_name": "shortfall_p1", "owner": "owner1",
+		"parents": ["shortfall_p1"],
+		"paths": [{"path": "/shortfall/p1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 50, "max_num_objects": 500,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << "shortfall_p1 creation failed: " << (err.get() ? err.get() : "");
+
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "shortfall_p2", "owner": "owner1",
+		"parents": ["shortfall_p2"],
+		"paths": [{"path": "/shortfall/p2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 50, "max_num_objects": 500,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})",
+						&raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << "shortfall_p2 creation failed: " << (err.get() ? err.get() : "");
+
+	raw_err = nullptr;
+	rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child with 20 dedicated_GB, but explicitly attribute only 5+5 = 10 to the
+	// two parents. Since every parent is explicit for dedicated_GB, the missing
+	// 10 GB cannot be distributed and must be flagged as an error.
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "shortfall_child", "owner": "owner1",
+		"parents": ["shortfall_p1", "shortfall_p2"],
+		"paths": [{"path": "/shortfall/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20, "opportunistic_GB": 10, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500},
+		"parent_attributions": {
+			"shortfall_p1": {"dedicated_GB": 5, "opportunistic_GB": 5, "max_num_objects": 50},
+			"shortfall_p2": {"dedicated_GB": 5, "opportunistic_GB": 5, "max_num_objects": 50}
+		}})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Should reject explicit attributions that sum to less than child total";
+	if (err.get()) {
+		EXPECT_TRUE(std::string(err.get()).find("remainder") != std::string::npos ||
+					std::string(err.get()).find("sum") != std::string::npos)
+			<< "Error message should mention the shortfall: " << err.get();
+	}
+
+	// Same via lotman_update_lot with parent_attributions: create child with equal split first
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "shortfall_child2", "owner": "owner1",
+		"parents": ["shortfall_p1", "shortfall_p2"],
+		"paths": [{"path": "/shortfall/child2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20, "opportunistic_GB": 10, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})",
+						&raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << "shortfall_child2 creation failed: " << (err.get() ? err.get() : "");
+
+	raw_err = nullptr;
+	rv = lotman_update_lot(
+		R"({"lot_name": "shortfall_child2",
+			"parent_attributions": {
+				"shortfall_p1": {"dedicated_GB": 5, "opportunistic_GB": 5, "max_num_objects": 50},
+				"shortfall_p2": {"dedicated_GB": 5, "opportunistic_GB": 5, "max_num_objects": 50}
+			}})",
+		&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "update_lot with parent_attributions should also reject shortfall";
+}
+
+// Fix 2: Attribution JSON keys that don't match any actual parent must be
+// rejected rather than silently ignored (catches typos).
+TEST_F(StrictHierarchyTest, UnknownParentKeyInAttributionRejected) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+
+	// Create a parent
+	int rv = lotman_add_lot(R"({"lot_name": "typo_parent", "owner": "owner1",
+		"parents": ["typo_parent"],
+		"paths": [{"path": "/typo/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 50, "max_num_objects": 500,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << "typo_parent creation failed: " << (err.get() ? err.get() : "");
+
+	raw_err = nullptr;
+	rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Create child with a typo in the attribution key ("typo_praent" instead
+	// of "typo_parent"). Previously this was silently ignored and all allocation
+	// would go to equal-split. Now it must error.
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "typo_child", "owner": "owner1",
+		"parents": ["typo_parent"],
+		"paths": [{"path": "/typo/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20, "opportunistic_GB": 10, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500},
+		"parent_attributions": {
+			"typo_praent": {"dedicated_GB": 20, "opportunistic_GB": 10, "max_num_objects": 100}
+		}})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Should reject attribution JSON with unknown parent key";
+	if (err.get()) {
+		EXPECT_TRUE(std::string(err.get()).find("unknown parent") != std::string::npos ||
+					std::string(err.get()).find("typo_praent") != std::string::npos)
+			<< "Error should mention the bad key: " << err.get();
+	}
+
+	// Same via lotman_update_lot with parent_attributions
+	// First create the child normally (equal split)
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "typo_child2", "owner": "owner1",
+		"parents": ["typo_parent"],
+		"paths": [{"path": "/typo/child2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 20, "opportunistic_GB": 10, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})",
+						&raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << "typo_child2 creation failed: " << (err.get() ? err.get() : "");
+
+	raw_err = nullptr;
+	rv = lotman_update_lot(
+		R"({"lot_name": "typo_child2",
+			"parent_attributions": {"typo_praent": {"dedicated_GB": 20, "opportunistic_GB": 10, "max_num_objects": 100}}})",
+		&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "update_lot with parent_attributions should reject unknown parent key";
+}
+
+// Fixes 3 & 4: When attribution rows are missing for a parent (e.g. DB
+// corruption or incomplete migration), validate_axiom1 and the sweep-line
+// (build_attribution_events) must detect and report the problem rather than
+// silently treating the attributed usage as 0.
+TEST_F(StrictHierarchyTest, MissingAttributionRowsDetected) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+
+	// Parent with modest capacity
+	int rv = lotman_add_lot(R"({"lot_name": "missing_attr_p", "owner": "owner1",
+		"parents": ["missing_attr_p"],
+		"paths": [{"path": "/missattr/p", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50, "opportunistic_GB": 20, "max_num_objects": 200,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << "missing_attr_p creation failed: " << (err.get() ? err.get() : "");
+
+	raw_err = nullptr;
+	rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// Child that uses up some capacity
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "missing_attr_c", "owner": "owner1",
+		"parents": ["missing_attr_p"],
+		"paths": [{"path": "/missattr/c", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 30, "opportunistic_GB": 10, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})",
+						&raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << "missing_attr_c creation failed: " << (err.get() ? err.get() : "");
+
+	// Direct DB surgery: delete all attribution rows for this child
+	{
+		using namespace sqlite_orm;
+		auto &storage = lotman::db::StorageManager::get_storage();
+		storage.remove_all<lotman::db::ParentChildAttribution>(
+			where(c(&lotman::db::ParentChildAttribution::child_lot_name) == "missing_attr_c"));
+
+		// Verify they're gone
+		auto remaining = storage.count<lotman::db::ParentChildAttribution>(
+			where(c(&lotman::db::ParentChildAttribution::child_lot_name) == "missing_attr_c"));
+		ASSERT_EQ(remaining, 0) << "Attribution rows should be deleted";
+	}
+
+	// Now try to add a sibling — this triggers validate_axiom2_for_parents_of
+	// which calls build_attribution_events for missing_attr_p. With strict
+	// hierarchy enabled, the missing attribution rows should be detected.
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({"lot_name": "missing_attr_c2", "owner": "owner1",
+		"parents": ["missing_attr_p"],
+		"paths": [{"path": "/missattr/c2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10, "opportunistic_GB": 5, "max_num_objects": 50,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500}})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Adding a sibling should fail because attribution rows are missing for missing_attr_c";
+	if (err.get()) {
+		EXPECT_TRUE(std::string(err.get()).find("attribution") != std::string::npos ||
+					std::string(err.get()).find("Missing") != std::string::npos)
+			<< "Error should mention missing attributions: " << err.get();
+	}
+}
+
+// ============================================================================
+// Rollback verification: failed axiom validation must leave DB unchanged
+// ============================================================================
+
+TEST_F(StrictHierarchyTest, FailedAxiomValidationRollsBackMpaUpdate) {
+	// Verifies that when an MPA update would violate the parent-capacity invariant,
+	// the in-transaction rollback leaves the lot's stored MPA unchanged. Without
+	// proper rollback, a partial write would leave the lot DB in an invalid state.
+	addDefaultLot();
+	char *raw_err = nullptr;
+
+	// Parent with 100 GB dedicated.
+	addLot(R"({
+		"lot_name": "rb_parent", "owner": "owner1", "parents": ["rb_parent"],
+		"paths": [{"path": "/rb/parent", "recursive": true}],
+		"management_policy_attrs": {"dedicated_GB": 100, "opportunistic_GB": 0,
+			"max_num_objects": 1000, "creation_time": 100,
+			"expiration_time": 9000, "deletion_time": 9500}})");
+
+	// Child fully attributed to parent at 80 GB dedicated.
+	addLot(R"({
+		"lot_name": "rb_child", "owner": "owner1", "parents": ["rb_parent"],
+		"paths": [{"path": "/rb/child", "recursive": true}],
+		"management_policy_attrs": {"dedicated_GB": 80, "opportunistic_GB": 0,
+			"max_num_objects": 100, "creation_time": 200,
+			"expiration_time": 8000, "deletion_time": 8500}})");
+
+	// Enable strict hierarchy and try to shrink parent below child's allocation.
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	rv = lotman_update_lot(R"({"lot_name": "rb_parent",
+		"management_policy_attrs": {"dedicated_GB": 50}})",
+						   &raw_err);
+	err.reset(raw_err);
+	ASSERT_NE(rv, 0) << "Shrinking parent below child's allocation must fail under strict hierarchy";
+
+	// Verify rollback: parent's stored dedicated_GB must still be 100.
+	raw_err = nullptr;
+	char *parent_out = nullptr;
+	rv = lotman_get_lot_as_json("rb_parent", false, &parent_out, &raw_err);
+	UniqueCString parent_str(parent_out);
+	UniqueCString err_p(raw_err);
+	ASSERT_EQ(rv, 0) << (err_p.get() ? err_p.get() : "");
+	ASSERT_NE(parent_str.get(), nullptr);
+	auto parent_json = json::parse(parent_str.get());
+	EXPECT_DOUBLE_EQ(parent_json["management_policy_attrs"]["dedicated_GB"].get<double>(), 100.0)
+		<< "Parent MPA must be unchanged after rolled-back update; got: " << parent_str.get();
+
+	// Verify the child is also untouched and the attribution still holds.
+	raw_err = nullptr;
+	char *child_out = nullptr;
+	rv = lotman_get_lot_as_json("rb_child", false, &child_out, &raw_err);
+	UniqueCString child_str(child_out);
+	UniqueCString err_c(raw_err);
+	ASSERT_EQ(rv, 0) << (err_c.get() ? err_c.get() : "");
+	ASSERT_NE(child_str.get(), nullptr);
+	auto child_json = json::parse(child_str.get());
+	EXPECT_DOUBLE_EQ(child_json["management_policy_attrs"]["dedicated_GB"].get<double>(), 80.0)
+		<< "Child MPA must be unchanged after rolled-back update; got: " << child_str.get();
+}
+
+TEST_F(StrictHierarchyTest, ContractionPolicyToleratesFloatingPointNoise) {
+	// Re-applying a lot's current MPA value (e.g. via a JSON round-trip that
+	// introduces sub-epsilon floating-point noise) must not be misinterpreted as
+	// a contraction when contraction_policy='always'. Without an epsilon the
+	// check `update_val < mpa.dedicated_GB` could spuriously fire.
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "fp_lot", "owner": "owner1", "parents": ["fp_lot"],
+		"paths": [{"path": "/fp/lot", "recursive": true}],
+		"management_policy_attrs": {"dedicated_GB": 10, "opportunistic_GB": 5,
+			"max_num_objects": 100, "creation_time": 100,
+			"expiration_time": 9000, "deletion_time": 9500}})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("contraction_policy", "always", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Sub-epsilon decrease (well below 1e-9) — should be treated as a no-op,
+	// not as a contraction, and therefore must succeed.
+	rv = lotman_update_lot(R"({"lot_name": "fp_lot",
+		"management_policy_attrs": {"dedicated_GB": 9.9999999999999}})",
+						   &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Sub-epsilon MPA noise must not trip the contraction policy. Got: "
+					 << (err.get() ? err.get() : "");
+
+	// A real contraction (well above the epsilon) must still be blocked.
+	rv = lotman_update_lot(R"({"lot_name": "fp_lot",
+		"management_policy_attrs": {"dedicated_GB": 9.5}})",
+						   &raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "A genuine contraction must still be blocked by contraction_policy='always'";
+}
+
+TEST_F(StrictHierarchyTest, UpdateLotIsAtomicAcrossSubOperations) {
+	// Verifies that lotman_update_lot wraps all of its sub-operations
+	// (owner, paths, management_policy_attrs, ...) in a single transaction:
+	// when a late sub-operation fails (here, an MPA update that violates a
+	// strict-hierarchy axiom), every earlier sub-operation in the same
+	// envelope must also be rolled back.
+	addDefaultLot();
+	char *raw_err = nullptr;
+
+	addLot(R"({
+		"lot_name": "atomic_parent", "owner": "owner1", "parents": ["atomic_parent"],
+		"paths": [{"path": "/atomic/parent", "recursive": true}],
+		"management_policy_attrs": {"dedicated_GB": 100, "opportunistic_GB": 0,
+			"max_num_objects": 1000, "creation_time": 100,
+			"expiration_time": 9000, "deletion_time": 9500}})");
+
+	addLot(R"({
+		"lot_name": "atomic_child", "owner": "owner1", "parents": ["atomic_parent"],
+		"paths": [{"path": "/atomic/child", "recursive": true}],
+		"management_policy_attrs": {"dedicated_GB": 80, "opportunistic_GB": 0,
+			"max_num_objects": 100, "creation_time": 200,
+			"expiration_time": 8000, "deletion_time": 8500}})");
+
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Single envelope: change the owner (would succeed on its own), then
+	// attempt to shrink dedicated_GB below the child's allocation (must
+	// fail under strict hierarchy). The owner change must be rolled back.
+	rv = lotman_update_lot(R"({
+		"lot_name": "atomic_parent",
+		"owner": "owner_should_be_rolled_back",
+		"management_policy_attrs": {"dedicated_GB": 50}
+	})",
+						   &raw_err);
+	err.reset(raw_err);
+	ASSERT_NE(rv, 0) << "Envelope must fail when a sub-operation fails";
+
+	// Verify owner was rolled back.
+	char **raw_owners = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_owners("atomic_parent", false, &raw_owners, &raw_err);
+	UniqueCString owners_err(raw_err);
+	UniqueStringList owners(raw_owners);
+	ASSERT_EQ(rv, 0) << (owners_err.get() ? owners_err.get() : "");
+	bool found_original = false;
+	bool found_pending = false;
+	for (int i = 0; owners.get()[i]; ++i) {
+		if (std::string(owners.get()[i]) == "owner1")
+			found_original = true;
+		if (std::string(owners.get()[i]) == "owner_should_be_rolled_back")
+			found_pending = true;
+	}
+	EXPECT_TRUE(found_original) << "Original owner must remain after rolled-back envelope";
+	EXPECT_FALSE(found_pending) << "Owner write must be rolled back when a later sub-op fails";
+
+	// And verify the MPA itself is also unchanged (sanity).
+	char *parent_out = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lot_as_json("atomic_parent", false, &parent_out, &raw_err);
+	UniqueCString parent_str(parent_out);
+	UniqueCString err_p(raw_err);
+	ASSERT_EQ(rv, 0) << (err_p.get() ? err_p.get() : "");
+	auto parent_json = json::parse(parent_str.get());
+	EXPECT_DOUBLE_EQ(parent_json["management_policy_attrs"]["dedicated_GB"].get<double>(), 100.0);
+}
+
+} // namespace


### PR DESCRIPTION
## Strict hierarchy enforcement and reservation semantics

This PR introduces strict hierarchy enforcement for lot trees, parent-child attribution tracking, temporal path semantics, time-aware reservation scheduling, and hierarchical threshold queries. Together these features allow LotMan to model and enforce storage reservation contracts across a hierarchy of lots with proper temporal overlap detection.

### Key changes

**DB schema and migrations** — New `parent_child_attributions` table tracks how each child's managed policy attributes (dedicated GB, opportunistic GB, max objects) are split across its parents, allowing two parents to combine portions of their allocations for a child lot (e.g. two allocations can share what they have to construct a child lot whose storage comes from portions of both parents' allocations). Lot path primary key changed from `unique(path)` to composite `(lot_name, path)`. DB write helpers refactored to return status pairs for transactional composability.

**Context settings** — Three new context knobs: `strict_hierarchy` (enable/disable axiom enforcement), `contraction_policy` (`none`/`alive`/`always` — controls whether lot deletion is blocked as a contraction-to-zero), and `admin_override` (bypass contraction checks).

**Temporal path semantics** — `lotman_get_lots_from_dir` and `lotman_update_lot_usage_by_dir` now accept a `query_time` parameter. Path-to-lot resolution filters by `creation_time <= query_time <= expiration_time`, so only lots active at the queried time are matched. Path removal remains time-independent.

**Strict hierarchy enforcement** — Three axioms are validated when `strict_hierarchy` is enabled:
- **Axiom 1**: For each parent P of child C, the attributed amount from C to P must not exceed P's own MPAs. Put simply, a each MPA of a child lot's quota must never exceed the quota of any parent.
- **Axiom 2**: For each parent P, the peak concurrent usage across all children's reservations must not exceed P's own MPAs at any point in time. Put simply, if all children of a parent lot are within their quotas, then the parent lot must also be within its quotas. Implemented via sweep-line algorithm that tracks reservation start/end events and computes maximum concurrent dedicated, opportunistic, and object allocations.
- **Axiom 3**: A child lot's timestamps must fit within all parents' timestamps (creation_time, expiration_time, deletion_time).

Axioms are checked on lot creation, parent changes, MPA updates, and attribution updates. All mutating operations (`store_lot`, `destroy_lot`, `add/remove/update_parents`, `update_man_policy_attrs`) are wrapped in transactions with axiom validation and automatic attribution recomputation on rollback-safe failure paths.

**Temporal overlap enforcement** — Paths with `exclude=false` cannot have overlapping time windows within the same lot. This prevents double-counting the same filesystem path during overlapping reservation periods. Validated on path creation and mutation (including exclude flag changes and time window updates).

**Re-validation on mutations** — Path and policy mutations trigger re-validation:
- Flipping a path from `exclude=true` to `exclude=false` triggers temporal overlap checks
- Changes to `creation_time` or `expiration_time` in `update_man_policy_attrs` trigger re-validation to catch newly-introduced time window conflicts

**Advisory capacity query** — New `get_available_capacity(parent_lot_name, start_time, end_time)` API returns JSON with available and peak usage metrics for a given time window:
- `available_dedicated_GB` / `available_opportunistic_GB` / `available_max_num_objects` — capacity remaining at query time
- `peak_dedicated_GB` / `peak_opportunistic_GB` / `peak_max_num_objects` — maximum concurrent usage across the window
- `available_total_GB` / `peak_total_GB` — combined dedicated + opportunistic metrics

Useful for reservation planning and capacity monitoring.

**Hierarchical threshold queries** — `lotman_get_lots_past_opp/ded/obj` gain a `hierarchical` parameter. When true, a parent's usage is adjusted by adding any overage from its children (usage exceeding the child's own threshold), and results are returned depth-ordered (deepest/leaf lots first).

**Attribution management** — New `lotman_update_attributions` API function. Attributions are automatically computed on lot creation and recomputed when parents change. Unspecified parents receive an equal split of the remainder.

**Contraction policy** — Lot deletion checks whether removing the lot should be blocked based on the contraction policy. `none` allows all deletions, `alive` blocks deletion of currently-alive lots, `always` blocks all deletions. `admin_override` can bypass the check.

**Test coverage** — Added 90 new tests (48 → 138 total)" — covering all strict hierarchy tests added across all commits in the branch.