### PR TITLE
Per-axis "unbounded" sentinel for resource MPAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Lot objects are comprised of several components:
 
       The two resource axes (and the timestamp axis) are independent: a lot may be unbounded on storage while still capping objects, or vice versa. An unbounded axis:
 
-        - is excluded from the corresponding `lotman_get_lots_past_*` query (an unbounded lot can never be "past quota" on that axis), and reports the matching `available_*` field as `null` from `lotman_get_lot_capacity`;
+        - is excluded from the corresponding `lotman_get_lots_past_*` query (an unbounded lot can never be "past quota" on that axis), and reports the matching `available_*` field as `null` from `lotman_get_available_capacity`;
         - under `strict_hierarchy`, is treated as `+∞` on that axis only: an unbounded parent absorbs any finite child allocation on that axis (Axioms 1 and 2 skip per-axis cap checks against an unbounded parent), but an unbounded child requires **every** parent to also be unbounded on that axis. Bounds on other axes are still enforced normally.
 
       To flip an existing lot to or from unbounded storage, supply both `dedicated_GB` and `opportunistic_GB` in the same `lotman_update_lot` envelope; the per-field axiom checks tolerate the transient partial state inside the transaction and a final post-update invariant pass enforces the storage-axis consistency rule, rolling back any partial flip that would leave the lot in the rejected `(dedicated_GB == 0, opportunistic_GB > 0)` state.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ Lot objects are comprised of several components:
     - *Dedicated GB* -- The amount of storage made available to the lot owner. Owners who stay within this limit should be guaranteed this amount of storage while the lot is still viable.
     - *Opportunistic GB* -- Once a lot has used its entire allotment of dedicated storage, data is counted toward its opportunistic storage. Similar to expired lots, a system *may* make opportunistic storage available to the lot when resources are abundant. However, because LotMan intentionally does not track which paths associated with a lot are tied to different types of storage, when a system must make space, it must make a decision about which files from the lot are to be deleted. For this reason, exceeding dedicated storage limits should be treated as making any portion of the lot's associated data transient.
     - *Max Objects* -- The maximum number of objects a lot can store.
+
+      **Unbounded MPAs (sentinel `0`):** Just as the timestamp axis uses `0` to mean "non-expiring", each *resource* axis uses `0` to mean "no bound on this axis". The resource MPAs are grouped into two independent axes:
+
+      - *Storage axis* -- `dedicated_GB` together with `opportunistic_GB`. The storage axis is unbounded **iff both** values are `0`. Because opportunistic storage is meaningful only relative to a finite dedicated allotment, the combination `dedicated_GB == 0` with `opportunistic_GB > 0` is rejected outright (an unbounded base capacity makes a finite burst cap meaningless). The combination `dedicated_GB > 0` with `opportunistic_GB == 0` is allowed and simply means "no burst capacity".
+      - *Object axis* -- `max_num_objects`. The object axis is unbounded **iff** `max_num_objects == 0`.
+
+      The two resource axes (and the timestamp axis) are independent: a lot may be unbounded on storage while still capping objects, or vice versa. An unbounded axis:
+
+        - is excluded from the corresponding `lotman_get_lots_past_*` query (an unbounded lot can never be "past quota" on that axis), and reports the matching `available_*` field as `null` from `lotman_get_lot_capacity`;
+        - under `strict_hierarchy`, is treated as `+∞` on that axis only: an unbounded parent absorbs any finite child allocation on that axis (Axioms 1 and 2 skip per-axis cap checks against an unbounded parent), but an unbounded child requires **every** parent to also be unbounded on that axis. Bounds on other axes are still enforced normally.
+
+      To flip an existing lot to or from unbounded storage, supply both `dedicated_GB` and `opportunistic_GB` in the same `lotman_update_lot` envelope; the per-field axiom checks tolerate the transient partial state inside the transaction and a final post-update invariant pass enforces the storage-axis consistency rule, rolling back any partial flip that would leave the lot in the rejected `(dedicated_GB == 0, opportunistic_GB > 0)` state.
+
 - **Usage Statistics:** Several usage statistics can be tracked for each lot. They are:
     - *Self GB* -- The number of GB a lot is currently using, not including those of its children.
     - *Children GB* -- The cumulative number of GB being used by all of a lot's children, not including itself in cases where a lot is a self parent.
@@ -47,8 +60,8 @@ LotMan supports a *reservation* model in which a parent lot's resources (dedicat
 These are set with `lotman_set_context_str` and read with `lotman_get_context_str`:
 
 - **`strict_hierarchy`** (`"true"` / `"false"`, default `"false"`) -- When enabled, every operation that creates or mutates a lot is validated against the following axioms before it is committed; failure rolls the change back atomically:
-    1. **Axiom 1** -- A child's MPAs may not exceed the sum of its parents' attributions to it.
-    2. **Axiom 2** -- For any parent, the *peak concurrent* attributed usage across its children (over their active time windows) must not exceed the parent's own MPAs. This is checked with a sweep-line algorithm over the children's `[creation_time, expiration_time)` intervals so that two children whose windows don't overlap can both reserve the same capacity.
+    1. **Axiom 1** -- A child's MPAs may not exceed the sum of its parents' attributions to it. Each resource axis (storage = `dedicated_GB`+`opportunistic_GB`, objects = `max_num_objects`) is checked independently; an unbounded parent on a given axis is treated as `+∞` and disables the cap check for that axis only.
+    2. **Axiom 2** -- For any parent, the *peak concurrent* attributed usage across its children (over their active time windows) must not exceed the parent's own MPAs. This is checked with a sweep-line algorithm over the children's `[creation_time, expiration_time)` intervals so that two children whose windows don't overlap can both reserve the same capacity. The sweep is performed per axis; an axis on which the parent is unbounded is skipped (any concurrent child sum is acceptable on that axis), while bounded axes are still enforced.
     3. **Axiom 3** -- A child's active interval must lie within each of its parents' intervals. The non-expiring sentinel (all timestamps `0`) is treated as the interval `(-∞, +∞)`: a non-expiring parent absorbs any child window, but a non-expiring child requires every parent to also be non-expiring.
 - **`contraction_policy`** (`"none"` / `"strict"`, default `"none"`) -- Controls whether MPAs may be *reduced* on an existing lot. Under `"strict"`, an update that would lower a parent's capacity below what its children have already reserved is rejected.
 - **`admin_override`** (`"true"` / `"false"`, default `"false"`) -- Bypasses contraction-policy restrictions for privileged callers. Strict-hierarchy axioms are still enforced.

--- a/src/lotman.cpp
+++ b/src/lotman.cpp
@@ -358,15 +358,16 @@ int lotman_update_lot(const char *lotman_JSON_str, char **err_msg) {
 				}
 
 				// After all per-field MPA updates have been applied, re-load
-				// the lot's final timestamp triple and enforce the sentinel
-				// invariant. Per-field updates intentionally tolerate
+				// the lot's final MPA triple and enforce the sentinel
+				// invariants. Per-field updates intentionally tolerate
 				// transient partial-zero state inside the transaction so a
-				// caller can flip a lot to/from non-expiring atomically; this
-				// final pass rejects any update whose end state leaves the
-				// timestamps in an inconsistent state. We also re-run the
-				// hierarchy time-containment axiom (axiom 3) here because
-				// per-field axiom checks defer for partial-zero intermediate
-				// states.
+				// caller can flip a lot to/from non-expiring (timestamps) or
+				// to/from unbounded storage (dedicated_GB/opportunistic_GB)
+				// atomically; this final pass rejects any update whose end
+				// state leaves the timestamps or storage axis in an
+				// inconsistent state. We also re-run the hierarchy axioms
+				// here because per-field axiom checks defer for partial
+				// intermediate states.
 				auto &storage_check = lotman::db::StorageManager::get_storage();
 				auto mpa_final = storage_check.get_pointer<lotman::db::ManagementPolicyAttributes>(
 					update_JSON_obj["lot_name"].get<std::string>());
@@ -382,8 +383,26 @@ int lotman_update_lot(const char *lotman_JSON_str, char **err_msg) {
 								"' rejected: " + inv_rp.second;
 					return false;
 				}
+				auto mpa_inv_rp = lotman::validate_mpa_invariants(mpa_final->dedicated_GB, mpa_final->opportunistic_GB,
+																  mpa_final->max_num_objects);
+				if (!mpa_inv_rp.first) {
+					txn_error = "Update on lot '" + update_JSON_obj["lot_name"].get<std::string>() +
+								"' rejected: " + mpa_inv_rp.second;
+					return false;
+				}
 				if (lotman::Context::get_strict_hierarchy()) {
-					auto a3 = lotman::Lot::validate_axiom3(update_JSON_obj["lot_name"].get<std::string>());
+					const std::string &final_name = update_JSON_obj["lot_name"].get<std::string>();
+					auto a1 = lotman::Lot::validate_axiom1(final_name);
+					if (!a1.first) {
+						txn_error = a1.second;
+						return false;
+					}
+					auto a2 = lotman::Lot::validate_axiom2_for_parents_of(final_name);
+					if (!a2.first) {
+						txn_error = a2.second;
+						return false;
+					}
+					auto a3 = lotman::Lot::validate_axiom3(final_name);
 					if (!a3.first) {
 						txn_error = a3.second;
 						return false;

--- a/src/lotman.h
+++ b/src/lotman.h
@@ -89,6 +89,22 @@ int lotman_add_lot(const char *lotman_JSON_str, char **err_msg);
 			that are using some amount of opp storage may be subject to purging in the event that the system
 			needs to create space.
 		"max_num_objects": An int64 indicating the maxiximum number of objects a lot may have attributed to it.
+
+			Sentinel for unbounded MPAs: a value of 0 on a quota MPA marks that resource axis as
+			unbounded for this lot. MPAs are grouped into independent axes that are validated
+			internally but treated independently of each other:
+			  * Storage axis (dedicated_GB + opportunistic_GB): the axis is unbounded iff BOTH
+				dedicated_GB and opportunistic_GB are 0. Setting dedicated_GB to 0 with
+				opportunistic_GB > 0 is rejected -- if the dedicated capacity is unbounded, a finite
+				opportunistic cap is meaningless. The reverse (dedicated_GB > 0 with
+				opportunistic_GB == 0) is allowed and means the lot has no opportunistic burst
+				capacity.
+			  * Object-count axis (max_num_objects): unbounded iff 0.
+			Different axes are independent: a lot may be unbounded on one axis and bounded on
+			another (e.g. unbounded storage with a finite max_num_objects). Under strict_hierarchy,
+			a child that is unbounded on an axis requires every parent to also be unbounded on that
+			axis; an unbounded parent absorbs any child allocation on that axis. Lots that are
+			unbounded on an axis never appear in past-quota queries for that axis.
 		"creation_time":
 			REQUIRED: A Unix timestamp in milliseconds indicating when the lot should begin its existence.
 			The lot is considered active starting at this time (inclusive). Together with expiration_time,

--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -163,6 +163,15 @@ std::pair<bool, std::string> lotman::Lot::init_full(json lot_JSON) {
 	man_policy_attr.expiration_time = lot_JSON["management_policy_attrs"]["expiration_time"];
 	man_policy_attr.deletion_time = lot_JSON["management_policy_attrs"]["deletion_time"];
 
+	// Validate per-axis MPA invariants. A value of 0 on a quota MPA marks
+	// that axis as unbounded; the storage axis (dedicated_GB +
+	// opportunistic_GB) is validated for self-consistency.
+	auto mpa_rp = validate_mpa_invariants(man_policy_attr.dedicated_GB, man_policy_attr.opportunistic_GB,
+										  man_policy_attr.max_num_objects);
+	if (!mpa_rp.first) {
+		return mpa_rp;
+	}
+
 	// Validate timestamp invariants. The all-zero tuple is a sentinel for a
 	// non-expiring lot; otherwise creation_time < expiration_time is required.
 	auto time_rp = validate_time_invariants(man_policy_attr.creation_time, man_policy_attr.expiration_time,
@@ -2199,12 +2208,17 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_opp(
 																				const bool recursive_children) {
 	std::vector<std::string> lots_past_opp;
 	if (recursive_quota) {
+		// Skip lots whose storage axis is unbounded (dedicated_GB == 0 AND
+		// opportunistic_GB == 0 is the unbounded-storage sentinel; such a lot
+		// is never "past" its quota).
 		std::string rec_opp_usage_query =
 			"SELECT "
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE lot_usage.self_GB + lot_usage.children_GB >= management_policy_attributes.dedicated_GB + "
+			"WHERE NOT (management_policy_attributes.dedicated_GB = 0 AND "
+			"           management_policy_attributes.opportunistic_GB = 0) "
+			"AND lot_usage.self_GB + lot_usage.children_GB >= management_policy_attributes.dedicated_GB + "
 			"management_policy_attributes.opportunistic_GB;";
 		auto rp = lotman::db::SQL_get_matches(rec_opp_usage_query);
 		if (!rp.second.empty()) { // There was an error
@@ -2219,7 +2233,9 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_opp(
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE lot_usage.self_GB >= management_policy_attributes.dedicated_GB + "
+			"WHERE NOT (management_policy_attributes.dedicated_GB = 0 AND "
+			"           management_policy_attributes.opportunistic_GB = 0) "
+			"AND lot_usage.self_GB >= management_policy_attributes.dedicated_GB + "
 			"management_policy_attributes.opportunistic_GB;";
 
 		auto rp = lotman::db::SQL_get_matches(opp_usage_query);
@@ -2261,12 +2277,16 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_ded(
 																				const bool recursive_children) {
 	std::vector<std::string> lots_past_ded;
 	if (recursive_quota) {
+		// Skip lots with dedicated_GB == 0 (unbounded-storage sentinel: a lot
+		// with both dedicated_GB and opportunistic_GB equal to 0 has unbounded
+		// storage and can never be past its dedicated quota).
 		std::string rec_ded_usage_query =
 			"SELECT "
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE lot_usage.self_GB + lot_usage.children_GB >= management_policy_attributes.dedicated_GB;";
+			"WHERE management_policy_attributes.dedicated_GB > 0 "
+			"AND lot_usage.self_GB + lot_usage.children_GB >= management_policy_attributes.dedicated_GB;";
 
 		auto rp = lotman::db::SQL_get_matches(rec_ded_usage_query);
 		if (!rp.second.empty()) { // There was an error
@@ -2281,7 +2301,8 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_ded(
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE lot_usage.self_GB >= management_policy_attributes.dedicated_GB;";
+			"WHERE management_policy_attributes.dedicated_GB > 0 "
+			"AND lot_usage.self_GB >= management_policy_attributes.dedicated_GB;";
 
 		auto rp = lotman::db::SQL_get_matches(ded_usage_query);
 		if (!rp.second.empty()) { // There was an error
@@ -2322,12 +2343,14 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_obj(
 																				const bool recursive_children) {
 	std::vector<std::string> lots_past_obj;
 	if (recursive_quota) {
+		// Skip lots with max_num_objects == 0 (unbounded-objects sentinel).
 		std::string rec_obj_usage_query =
 			"SELECT "
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE lot_usage.self_objects + lot_usage.children_objects >= "
+			"WHERE management_policy_attributes.max_num_objects > 0 "
+			"AND lot_usage.self_objects + lot_usage.children_objects >= "
 			"management_policy_attributes.max_num_objects;";
 
 		auto rp = lotman::db::SQL_get_matches(rec_obj_usage_query);
@@ -2343,7 +2366,8 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_obj(
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE lot_usage.self_objects >= management_policy_attributes.max_num_objects;";
+			"WHERE management_policy_attributes.max_num_objects > 0 "
+			"AND lot_usage.self_objects >= management_policy_attributes.max_num_objects;";
 
 		auto rp = lotman::db::SQL_get_matches(obj_usage_query);
 		if (!rp.second.empty()) { // There was an error
@@ -2456,15 +2480,27 @@ get_lots_past_threshold_hierarchical(const std::string &self_usage_col, const st
 							  "Internal error: unrecognized SQL fragment in hierarchical query");
 	}
 
+	// Per-axis sentinel handling:
+	//   * Parent threshold == 0 marks that axis as unbounded; the parent can
+	//     never be "past" its quota on that axis, so we exclude such parents.
+	//   * Child threshold == 0 marks the child as unbounded on that axis;
+	//     such a child can only exist under an unbounded parent (rejected
+	//     by axiom 1 otherwise), but defensively we treat its overflow
+	//     contribution as 0 so an unbounded child can never push a parent
+	//     past quota.
 	std::string query = "SELECT p_usage.lot_name "
 						"FROM lot_usage p_usage "
 						"JOIN management_policy_attributes p_mpa ON p_usage.lot_name = p_mpa.lot_name "
-						"WHERE p_usage." +
+						"WHERE (" +
+						parent_threshold_expr +
+						") > 0 "
+						"AND p_usage." +
 						self_usage_col +
 						" + COALESCE("
-						"    (SELECT SUM(MAX(0, (" +
-						child_usage_expr + ") - (" + child_threshold_expr +
-						"))) "
+						"    (SELECT SUM(CASE WHEN (" +
+						child_threshold_expr + ") = 0 THEN 0 ELSE MAX(0, (" + child_usage_expr + ") - (" +
+						child_threshold_expr +
+						")) END) "
 						"     FROM parents c_par "
 						"     JOIN lot_usage c_usage ON c_par.lot_name = c_usage.lot_name "
 						"     JOIN management_policy_attributes c_mpa ON c_par.lot_name = c_mpa.lot_name "
@@ -2527,16 +2563,34 @@ std::pair<json, std::string> lotman::Lot::get_available_capacity(const std::stri
 		auto events = build_attribution_events(parent_lot_name, start_time, end_time);
 		auto peak = run_sweep_line(events);
 
+		// Per-axis sentinel handling: a parent that is unbounded on an axis
+		// has no meaningful "available" value on that axis (the cap is +inf).
+		// Report null for those fields rather than a negative or misleading
+		// number; callers can detect unbounded by checking for null.
+		const bool parent_unbounded_storage =
+			is_unbounded_storage(parent_mpa->dedicated_GB, parent_mpa->opportunistic_GB);
+		const bool parent_unbounded_objects = is_unbounded_objects(parent_mpa->max_num_objects);
+
 		json result;
-		result["available_dedicated_GB"] = parent_mpa->dedicated_GB - peak.peak_ded;
-		result["available_opportunistic_GB"] = parent_mpa->opportunistic_GB - peak.peak_opp;
-		result["available_max_num_objects"] = parent_mpa->max_num_objects - static_cast<int64_t>(peak.peak_obj);
+		if (parent_unbounded_storage) {
+			result["available_dedicated_GB"] = nullptr;
+			result["available_opportunistic_GB"] = nullptr;
+			result["available_total_GB"] = nullptr;
+		} else {
+			result["available_dedicated_GB"] = parent_mpa->dedicated_GB - peak.peak_ded;
+			result["available_opportunistic_GB"] = parent_mpa->opportunistic_GB - peak.peak_opp;
+			double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
+			result["available_total_GB"] = parent_total - peak.peak_total;
+		}
+		if (parent_unbounded_objects) {
+			result["available_max_num_objects"] = nullptr;
+		} else {
+			result["available_max_num_objects"] = parent_mpa->max_num_objects - static_cast<int64_t>(peak.peak_obj);
+		}
 		result["peak_dedicated_GB"] = peak.peak_ded;
 		result["peak_opportunistic_GB"] = peak.peak_opp;
 		result["peak_max_num_objects"] = static_cast<int64_t>(peak.peak_obj);
 		// peak_total is the true max of (ded+opp) at a single point in time
-		double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
-		result["available_total_GB"] = parent_total - peak.peak_total;
 		result["peak_total_GB"] = peak.peak_total;
 
 		return std::make_pair(result, "");
@@ -3125,6 +3179,18 @@ std::vector<lotman::Lot::ValidationPredicate> lotman::Lot::build_axiom_predicate
 std::pair<bool, std::string> lotman::Lot::validate_axiom1(const std::string &child_lot_name) {
 	// Axiom 1: For each parent P of child C, the attributed amount from C to P
 	// must not exceed P's own MPAs.
+	//
+	// Per-axis sentinel handling:
+	//   * If a parent's storage axis is unbounded (dedicated_GB == 0 AND
+	//     opportunistic_GB == 0), no attributed storage value can exceed it,
+	//     so storage checks are skipped for that parent.
+	//   * If a parent's object axis is unbounded (max_num_objects == 0),
+	//     the object check is skipped for that parent.
+	//   * If the child is unbounded on an axis but a parent is bounded on
+	//     that axis, the child cannot fit and the relationship is rejected.
+	//   * If the child is in a transient partial-zero storage state during a
+	//     multi-field update, defer; the post-loop invariant check in
+	//     lotman_update_lot rejects any persisting partial state.
 	try {
 		auto &storage = db::StorageManager::get_storage();
 		using namespace sqlite_orm;
@@ -3134,6 +3200,13 @@ std::pair<bool, std::string> lotman::Lot::validate_axiom1(const std::string &chi
 		if (!child_mpa) {
 			return std::make_pair(false, "Child lot '" + child_lot_name + "' not found");
 		}
+
+		if (is_partial_storage_sentinel(child_mpa->dedicated_GB, child_mpa->opportunistic_GB)) {
+			// Defer: transient state inside an in-progress MPA update.
+			return std::make_pair(true, "");
+		}
+		const bool child_unbounded_storage = is_unbounded_storage(child_mpa->dedicated_GB, child_mpa->opportunistic_GB);
+		const bool child_unbounded_objects = is_unbounded_objects(child_mpa->max_num_objects);
 
 		// Get non-self parents from the parents table (authoritative source)
 		auto parent_records = storage.select(&db::Parent::parent, where(c(&db::Parent::lot_name) == child_lot_name));
@@ -3165,6 +3238,33 @@ std::pair<bool, std::string> lotman::Lot::validate_axiom1(const std::string &chi
 			if (!parent_mpa) {
 				return std::make_pair(false, "Parent lot '" + parent_name + "' not found");
 			}
+			if (is_partial_storage_sentinel(parent_mpa->dedicated_GB, parent_mpa->opportunistic_GB)) {
+				// Defer: transient state inside an in-progress MPA update.
+				continue;
+			}
+			const bool parent_unbounded_storage =
+				is_unbounded_storage(parent_mpa->dedicated_GB, parent_mpa->opportunistic_GB);
+			const bool parent_unbounded_objects = is_unbounded_objects(parent_mpa->max_num_objects);
+
+			// An unbounded child cannot fit inside a bounded parent on the
+			// same axis: the child's effective allocation on that axis is
+			// "infinite", which exceeds any finite parent cap.
+			if (child_unbounded_storage && !parent_unbounded_storage) {
+				return std::make_pair(false,
+									  "Hierarchy violation: child lot '" + child_lot_name +
+										  "' has unbounded storage (dedicated_GB == 0 and opportunistic_GB == 0) "
+										  "but parent lot '" +
+										  parent_name +
+										  "' has a bounded storage axis. An unbounded child requires every parent "
+										  "to also be unbounded on that axis.");
+			}
+			if (child_unbounded_objects && !parent_unbounded_objects) {
+				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name +
+												 "' has unbounded max_num_objects (== 0) but parent lot '" +
+												 parent_name +
+												 "' has a bounded max_num_objects. An unbounded child requires "
+												 "every parent to also be unbounded on that axis.");
+			}
 
 			// Compute attributed values
 			double attr_ded =
@@ -3176,36 +3276,43 @@ std::pair<bool, std::string> lotman::Lot::validate_axiom1(const std::string &chi
 								  ? std::round(fractions.at("max_num_objects") * child_mpa->max_num_objects)
 								  : 0.0;
 
-			// Check: attributed dedicated ≤ parent dedicated
-			if (attr_ded > parent_mpa->dedicated_GB + 1e-9) {
-				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
-												 std::to_string(attr_ded) + " dedicated_GB to parent lot '" +
-												 parent_name +
-												 "', which exceeds the parent's dedicated_GB allocation of " +
-												 std::to_string(parent_mpa->dedicated_GB) +
-												 ". A child lot's allocation may not exceed any parent's.");
+			// Storage axis: skip the per-axis cap checks if the parent's
+			// storage axis is unbounded.
+			if (!parent_unbounded_storage) {
+				// Check: attributed dedicated ≤ parent dedicated
+				if (attr_ded > parent_mpa->dedicated_GB + 1e-9) {
+					return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
+													 std::to_string(attr_ded) + " dedicated_GB to parent lot '" +
+													 parent_name +
+													 "', which exceeds the parent's dedicated_GB allocation of " +
+													 std::to_string(parent_mpa->dedicated_GB) +
+													 ". A child lot's allocation may not exceed any parent's.");
+				}
+
+				// Check: attributed (ded+opp) ≤ parent (ded+opp)
+				double attr_total = attr_ded + attr_opp;
+				double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
+				if (attr_total > parent_total + 1e-9) {
+					return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
+													 std::to_string(attr_total) +
+													 " total GB (dedicated + opportunistic) to parent lot '" +
+													 parent_name +
+													 "', which exceeds the parent's combined allocation of " +
+													 std::to_string(parent_total) +
+													 " GB. A child lot's allocation may not exceed any parent's.");
+				}
 			}
 
-			// Check: attributed (ded+opp) ≤ parent (ded+opp)
-			double attr_total = attr_ded + attr_opp;
-			double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
-			if (attr_total > parent_total + 1e-9) {
-				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
-												 std::to_string(attr_total) +
-												 " total GB (dedicated + opportunistic) to parent lot '" + parent_name +
-												 "', which exceeds the parent's combined allocation of " +
-												 std::to_string(parent_total) +
-												 " GB. A child lot's allocation may not exceed any parent's.");
-			}
-
-			// Check: attributed objects ≤ parent objects
-			if (attr_obj > parent_mpa->max_num_objects) {
-				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
-												 std::to_string(static_cast<int64_t>(attr_obj)) +
-												 " max_num_objects to parent lot '" + parent_name +
-												 "', which exceeds the parent's max_num_objects allocation of " +
-												 std::to_string(parent_mpa->max_num_objects) +
-												 ". A child lot's allocation may not exceed any parent's.");
+			// Object axis: skip if the parent's object axis is unbounded.
+			if (!parent_unbounded_objects) {
+				if (attr_obj > parent_mpa->max_num_objects) {
+					return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
+													 std::to_string(static_cast<int64_t>(attr_obj)) +
+													 " max_num_objects to parent lot '" + parent_name +
+													 "', which exceeds the parent's max_num_objects allocation of " +
+													 std::to_string(parent_mpa->max_num_objects) +
+													 ". A child lot's allocation may not exceed any parent's.");
+				}
 			}
 		}
 
@@ -3220,6 +3327,14 @@ std::pair<bool, std::string> lotman::Lot::validate_axiom2_for_parents_of(const s
 	// Axiom 2 (time-aware): For each parent P, at no point in time may the sum of
 	// concurrently-active children's attributed MPAs exceed P's own MPAs.
 	// Uses a sweep-line over children's [creation_time, expiration_time) intervals.
+	//
+	// Per-axis sentinel handling: a parent that is unbounded on an axis
+	// (storage axis: dedicated_GB == 0 AND opportunistic_GB == 0; object
+	// axis: max_num_objects == 0) cannot be exceeded on that axis, so the
+	// per-axis cap check is skipped for that parent. Cross-axis containment
+	// (an unbounded child under a bounded parent) is rejected by axiom 1
+	// before the sweep is reached, so children feeding into the sweep are
+	// guaranteed to be bounded on each axis the parent is bounded on.
 	try {
 		auto &storage = db::StorageManager::get_storage();
 		using namespace sqlite_orm;
@@ -3235,45 +3350,62 @@ std::pair<bool, std::string> lotman::Lot::validate_axiom2_for_parents_of(const s
 			if (!parent_mpa) {
 				return std::make_pair(false, "Parent lot '" + parent_name + "' not found");
 			}
+			if (is_partial_storage_sentinel(parent_mpa->dedicated_GB, parent_mpa->opportunistic_GB)) {
+				// Defer: transient state inside an in-progress MPA update.
+				continue;
+			}
+			const bool parent_unbounded_storage =
+				is_unbounded_storage(parent_mpa->dedicated_GB, parent_mpa->opportunistic_GB);
+			const bool parent_unbounded_objects = is_unbounded_objects(parent_mpa->max_num_objects);
+
+			// If the parent is unbounded on every axis, no peak can exceed
+			// it; skip the sweep entirely.
+			if (parent_unbounded_storage && parent_unbounded_objects)
+				continue;
 
 			// Build sweep-line events from children's attributions
 			auto events = build_attribution_events(parent_name);
 			auto peak = run_sweep_line(events);
 
-			// Check: peak dedicated ≤ parent dedicated
-			if (peak.peak_ded > parent_mpa->dedicated_GB + 1e-9) {
-				return std::make_pair(
-					false, "Hierarchy violation: peak concurrent dedicated_GB across children of parent lot '" +
-							   parent_name + "' is " + std::to_string(peak.peak_ded) +
-							   ", which exceeds the parent's dedicated_GB allocation of " +
-							   std::to_string(parent_mpa->dedicated_GB) +
-							   ". The combined allocations of children active at the same time may not exceed the "
-							   "parent's capacity.");
+			if (!parent_unbounded_storage) {
+				// Check: peak dedicated ≤ parent dedicated
+				if (peak.peak_ded > parent_mpa->dedicated_GB + 1e-9) {
+					return std::make_pair(
+						false, "Hierarchy violation: peak concurrent dedicated_GB across children of parent lot '" +
+								   parent_name + "' is " + std::to_string(peak.peak_ded) +
+								   ", which exceeds the parent's dedicated_GB allocation of " +
+								   std::to_string(parent_mpa->dedicated_GB) +
+								   ". The combined allocations of children active at the same time may not exceed "
+								   "the parent's capacity.");
+				}
+
+				// Check: peak (ded+opp) ≤ parent (ded+opp)
+				// Use peak_total which is the true max of (ded+opp) at a single point in time,
+				// not the sum of independent peaks which can occur at different times.
+				double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
+				if (peak.peak_total > parent_total + 1e-9) {
+					return std::make_pair(false,
+										  "Hierarchy violation: peak concurrent total GB (dedicated + "
+										  "opportunistic) across children of parent lot '" +
+											  parent_name + "' is " + std::to_string(peak.peak_total) +
+											  ", which exceeds the parent's combined allocation of " +
+											  std::to_string(parent_total) +
+											  " GB. The combined allocations of children active at the same time "
+											  "may not exceed the parent's capacity.");
+				}
 			}
 
-			// Check: peak (ded+opp) ≤ parent (ded+opp)
-			// Use peak_total which is the true max of (ded+opp) at a single point in time,
-			// not the sum of independent peaks which can occur at different times.
-			double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
-			if (peak.peak_total > parent_total + 1e-9) {
-				return std::make_pair(false, "Hierarchy violation: peak concurrent total GB (dedicated + "
-											 "opportunistic) across children of parent lot '" +
-												 parent_name + "' is " + std::to_string(peak.peak_total) +
-												 ", which exceeds the parent's combined allocation of " +
-												 std::to_string(parent_total) +
-												 " GB. The combined allocations of children active at the same time "
-												 "may not exceed the parent's capacity.");
-			}
-
-			// Check: peak objects ≤ parent objects
-			if (std::round(peak.peak_obj) > parent_mpa->max_num_objects) {
-				return std::make_pair(
-					false, "Hierarchy violation: peak concurrent max_num_objects across children of parent lot '" +
-							   parent_name + "' is " + std::to_string(static_cast<int64_t>(peak.peak_obj)) +
-							   ", which exceeds the parent's max_num_objects allocation of " +
-							   std::to_string(parent_mpa->max_num_objects) +
-							   ". The combined allocations of children active at the same time may not exceed the "
-							   "parent's capacity.");
+			if (!parent_unbounded_objects) {
+				// Check: peak objects ≤ parent objects
+				if (std::round(peak.peak_obj) > parent_mpa->max_num_objects) {
+					return std::make_pair(
+						false, "Hierarchy violation: peak concurrent max_num_objects across children of parent lot '" +
+								   parent_name + "' is " + std::to_string(static_cast<int64_t>(peak.peak_obj)) +
+								   ", which exceeds the parent's max_num_objects allocation of " +
+								   std::to_string(parent_mpa->max_num_objects) +
+								   ". The combined allocations of children active at the same time may not exceed "
+								   "the parent's capacity.");
+				}
 			}
 		}
 

--- a/src/lotman_internal.h
+++ b/src/lotman_internal.h
@@ -67,10 +67,10 @@ inline bool is_unbounded_objects(int64_t max_num_objects) {
 }
 
 // True when the storage axis is in a transient, inconsistent state that can
-// occur mid-transaction during a multi-field update (dedicated_GB == 0 with
-// opportunistic_GB still > 0, or vice versa during an atomic flip). Hierarchy
-// validation predicates short-circuit when they encounter this state and
-// rely on a post-loop check in lotman_update_lot to reject any persisting
+// occur mid-transaction during a multi-field update (dedicated_GB has already
+// been set to 0 while opportunistic_GB has not yet been updated to match).
+// Hierarchy validation predicates short-circuit when they encounter this state
+// and rely on a post-loop check in lotman_update_lot to reject any persisting
 // partial state.
 inline bool is_partial_storage_sentinel(double dedicated_GB, double opportunistic_GB) {
 	return dedicated_GB == 0.0 && opportunistic_GB > 0.0;

--- a/src/lotman_internal.h
+++ b/src/lotman_internal.h
@@ -46,6 +46,59 @@ inline bool is_non_expiring(int64_t creation_time, int64_t expiration_time, int6
 	return creation_time == 0 && expiration_time == 0 && deletion_time == 0;
 }
 
+// Resource-axis sentinels: a value of 0 on a quota MPA marks that axis as
+// "unbounded". MPAs are grouped into independent axes that are validated
+// internally but treated independently of each other:
+//   * Storage axis: dedicated_GB and opportunistic_GB. The storage axis is
+//     unbounded iff both are 0. Mixing (dedicated_GB == 0 with
+//     opportunistic_GB > 0) is rejected -- if the dedicated capacity is
+//     unbounded, a finite opportunistic cap is meaningless. The reverse
+//     (dedicated_GB > 0 with opportunistic_GB == 0) is allowed and means
+//     the lot has no opportunistic burst capacity.
+//   * Object-count axis: max_num_objects. Unbounded iff 0.
+// Different axes are independent: a lot may be unbounded on one axis and
+// bounded on another.
+inline bool is_unbounded_storage(double dedicated_GB, double opportunistic_GB) {
+	return dedicated_GB == 0.0 && opportunistic_GB == 0.0;
+}
+
+inline bool is_unbounded_objects(int64_t max_num_objects) {
+	return max_num_objects == 0;
+}
+
+// True when the storage axis is in a transient, inconsistent state that can
+// occur mid-transaction during a multi-field update (dedicated_GB == 0 with
+// opportunistic_GB still > 0, or vice versa during an atomic flip). Hierarchy
+// validation predicates short-circuit when they encounter this state and
+// rely on a post-loop check in lotman_update_lot to reject any persisting
+// partial state.
+inline bool is_partial_storage_sentinel(double dedicated_GB, double opportunistic_GB) {
+	return dedicated_GB == 0.0 && opportunistic_GB > 0.0;
+}
+
+// Validate the per-axis MPA invariants for a lot:
+//   * All MPAs must be non-negative.
+//   * Storage axis: if dedicated_GB == 0, opportunistic_GB must also be 0.
+// Returns (true, "") when valid, otherwise (false, message).
+inline std::pair<bool, std::string> validate_mpa_invariants(double dedicated_GB, double opportunistic_GB,
+															int64_t max_num_objects) {
+	if (dedicated_GB < 0 || opportunistic_GB < 0 || max_num_objects < 0) {
+		return std::make_pair(false, std::string("MPAs must be non-negative; got dedicated_GB=") +
+										 std::to_string(dedicated_GB) +
+										 ", opportunistic_GB=" + std::to_string(opportunistic_GB) +
+										 ", max_num_objects=" + std::to_string(max_num_objects) + ".");
+	}
+	if (dedicated_GB == 0.0 && opportunistic_GB > 0.0) {
+		return std::make_pair(
+			false, std::string("Storage-axis sentinel violation: when dedicated_GB is 0 (the unbounded sentinel), "
+							   "opportunistic_GB must also be 0. The storage axis must be either fully bounded "
+							   "(dedicated_GB > 0) or fully unbounded (both dedicated_GB and opportunistic_GB equal "
+							   "to 0). Got dedicated_GB=") +
+					   std::to_string(dedicated_GB) + ", opportunistic_GB=" + std::to_string(opportunistic_GB) + ".");
+	}
+	return std::make_pair(true, "");
+}
+
 // Validate the time-field invariants for a lot's MPAs. Enforces:
 //   * If any of creation_time/expiration_time/deletion_time is 0, all three
 //     must be 0 (non-expiring sentinel).

--- a/test/strict_hierarchy_tests.cpp
+++ b/test/strict_hierarchy_tests.cpp
@@ -6424,4 +6424,633 @@ TEST_F(StrictHierarchyTest, NonExpiringLotPathOverlapsAnyOtherLot) {
 	EXPECT_NE(rv, 0) << "Finite lot must conflict with a non-expiring lot on the same path";
 }
 
+// ============================================================================
+// Unbounded MPA sentinel (per-axis 0 == "no bound") tests
+// ============================================================================
+//
+// Resource axes:
+//   * Storage axis: dedicated_GB + opportunistic_GB.
+//     - Unbounded iff BOTH are 0.
+//     - dedicated_GB == 0 with opportunistic_GB > 0 is rejected (an
+//       unbounded base capacity makes a finite opportunistic cap meaningless).
+//     - dedicated_GB > 0 with opportunistic_GB == 0 is allowed (no burst).
+//   * Object axis: max_num_objects.
+//     - Unbounded iff 0.
+// Different axes are independent.
+
+// Add a lot that is unbounded on the storage axis but bounded on objects.
+TEST_F(StrictHierarchyTest, AddLotUnboundedStorageBoundedObjectsSucceeds) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "unbounded_storage",
+		"owner": "owner1",
+		"parents": ["unbounded_storage"],
+		"paths": [{"path": "/unbounded/storage", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 0,
+			"opportunistic_GB": 0,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Unbounded storage with bounded objects should succeed: "
+					 << (err.get() ? err.get() : "<no error>");
+}
+
+// Add a lot that is unbounded on the object axis but bounded on storage.
+TEST_F(StrictHierarchyTest, AddLotUnboundedObjectsBoundedStorageSucceeds) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "unbounded_objs",
+		"owner": "owner1",
+		"parents": ["unbounded_objs"],
+		"paths": [{"path": "/unbounded/objs", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 0,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Unbounded objects with bounded storage should succeed: "
+					 << (err.get() ? err.get() : "<no error>");
+}
+
+// Add a lot that is unbounded on every axis.
+TEST_F(StrictHierarchyTest, AddLotFullyUnboundedSucceeds) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "fully_unbounded",
+		"owner": "owner1",
+		"parents": ["fully_unbounded"],
+		"paths": [{"path": "/unbounded/all", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 0,
+			"opportunistic_GB": 0,
+			"max_num_objects": 0,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Fully unbounded lot should succeed: " << (err.get() ? err.get() : "<no error>");
+}
+
+// dedicated_GB == 0 with opportunistic_GB > 0 must be rejected.
+TEST_F(StrictHierarchyTest, AddLotRejectsZeroDedicatedNonZeroOpportunistic) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "bad_storage",
+		"owner": "owner1",
+		"parents": ["bad_storage"],
+		"paths": [{"path": "/bad/storage", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 0,
+			"opportunistic_GB": 50,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0) << "dedicated_GB == 0 with opportunistic_GB > 0 must be rejected";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("Storage-axis") != std::string::npos || err_str.find("dedicated_GB") != std::string::npos)
+		<< "Error message should mention the storage axis violation; got: " << err_str;
+}
+
+// dedicated_GB > 0 with opportunistic_GB == 0 is fine (no burst).
+TEST_F(StrictHierarchyTest, AddLotZeroOpportunisticOnlySucceeds) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "no_burst",
+		"owner": "owner1",
+		"parents": ["no_burst"],
+		"paths": [{"path": "/no/burst", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 0,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "dedicated_GB > 0 with opportunistic_GB == 0 should be allowed (no burst capacity): "
+					 << (err.get() ? err.get() : "<no error>");
+}
+
+// Strict hierarchy: a parent that is unbounded on the storage axis absorbs
+// any finite child storage allocation.
+TEST_F(StrictHierarchyTest, FiniteChildAllowedUnderUnboundedStorageParentStrict) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "us_parent",
+		"owner": "owner1",
+		"parents": ["us_parent"],
+		"paths": [{"path": "/us/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 0,
+			"opportunistic_GB": 0,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	rv = lotman_add_lot(R"({
+		"lot_name": "us_child_finite",
+		"owner": "owner1",
+		"parents": ["us_parent"],
+		"paths": [{"path": "/us/parent/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 1000000,
+			"opportunistic_GB": 1000000,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "An unbounded-storage parent must absorb any child storage allocation: "
+					 << (err.get() ? err.get() : "<no error>");
+}
+
+// Strict hierarchy: an unbounded-storage child cannot live under a
+// bounded-storage parent.
+TEST_F(StrictHierarchyTest, UnboundedStorageChildRejectedUnderBoundedStorageParentStrict) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "bs_parent",
+		"owner": "owner1",
+		"parents": ["bs_parent"],
+		"paths": [{"path": "/bs/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	rv = lotman_add_lot(R"({
+		"lot_name": "bs_child_unbounded",
+		"owner": "owner1",
+		"parents": ["bs_parent"],
+		"paths": [{"path": "/bs/parent/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 0,
+			"opportunistic_GB": 0,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "An unbounded-storage child cannot live under a bounded-storage parent";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("unbounded") != std::string::npos)
+		<< "Error message should mention unbounded; got: " << err_str;
+}
+
+// Object axis is independent of storage axis: a parent unbounded on objects
+// only must still enforce its storage cap.
+TEST_F(StrictHierarchyTest, AxesAreIndependentObjectsUnboundedOnly) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "axis_parent",
+		"owner": "owner1",
+		"parents": ["axis_parent"],
+		"paths": [{"path": "/axis/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 0,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Unbounded-objects child fits because parent is also unbounded on objects.
+	// But finite storage that exceeds parent's storage axis must fail.
+	rv = lotman_add_lot(R"({
+		"lot_name": "axis_child_bad_storage",
+		"owner": "owner1",
+		"parents": ["axis_parent"],
+		"paths": [{"path": "/axis/parent/c1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 1000,
+			"opportunistic_GB": 0,
+			"max_num_objects": 0,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "Finite storage > parent storage cap must still fail when only the object axis is unbounded";
+
+	// A child whose storage fits and has unbounded objects succeeds.
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "axis_child_ok",
+		"owner": "owner1",
+		"parents": ["axis_parent"],
+		"paths": [{"path": "/axis/parent/c2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 0,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	EXPECT_EQ(rv, 0) << "Storage-fitting unbounded-objects child under unbounded-objects parent should succeed: "
+					 << (err2.get() ? err2.get() : "<no error>");
+}
+
+// Strict hierarchy: an unbounded-objects child cannot live under a
+// bounded-objects parent.
+TEST_F(StrictHierarchyTest, UnboundedObjectsChildRejectedUnderBoundedObjectsParentStrict) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "bo_parent",
+		"owner": "owner1",
+		"parents": ["bo_parent"],
+		"paths": [{"path": "/bo/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	rv = lotman_add_lot(R"({
+		"lot_name": "bo_child_unbounded",
+		"owner": "owner1",
+		"parents": ["bo_parent"],
+		"paths": [{"path": "/bo/parent/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 0,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_NE(rv, 0) << "An unbounded-objects child cannot live under a bounded-objects parent";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("unbounded") != std::string::npos || err_str.find("max_num_objects") != std::string::npos)
+		<< "Error should mention unbounded/max_num_objects; got: " << err_str;
+}
+
+// Sweep line: a parent unbounded on the storage axis allows the sum of
+// concurrently-active children's attributed storage to exceed any finite
+// number.
+TEST_F(StrictHierarchyTest, SweepLineUnboundedStorageParentAllowsAnyChildSum) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "sw_unb_parent",
+		"owner": "owner1",
+		"parents": ["sw_unb_parent"],
+		"paths": [{"path": "/sw/unb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 0,
+			"opportunistic_GB": 0,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// Two large overlapping children both "exceed" any finite cap on storage.
+	for (const char *child : {R"({
+			"lot_name": "sw_unb_c1",
+			"owner": "owner1",
+			"parents": ["sw_unb_parent"],
+			"paths": [{"path": "/sw/unb/c1", "recursive": true}],
+			"management_policy_attrs": {
+				"dedicated_GB": 5000, "opportunistic_GB": 5000, "max_num_objects": 100,
+				"creation_time": 200, "expiration_time": 8000, "deletion_time": 9000
+			}
+		})",
+							  R"({
+			"lot_name": "sw_unb_c2",
+			"owner": "owner1",
+			"parents": ["sw_unb_parent"],
+			"paths": [{"path": "/sw/unb/c2", "recursive": true}],
+			"management_policy_attrs": {
+				"dedicated_GB": 5000, "opportunistic_GB": 5000, "max_num_objects": 100,
+				"creation_time": 300, "expiration_time": 8500, "deletion_time": 9000
+			}
+		})"}) {
+		raw_err = nullptr;
+		rv = lotman_add_lot(child, &raw_err);
+		UniqueCString cerr(raw_err);
+		EXPECT_EQ(rv, 0) << "Child should succeed under unbounded-storage parent: "
+						 << (cerr.get() ? cerr.get() : "<no error>");
+	}
+}
+
+// Sweep line: a bounded parent still rejects an over-allocation when only
+// the object axis is unbounded.
+TEST_F(StrictHierarchyTest, SweepLineBoundedStorageRejectsOverAllocationDespiteUnboundedObjects) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "sw_mix_parent",
+		"owner": "owner1",
+		"parents": ["sw_mix_parent"],
+		"paths": [{"path": "/sw/mix", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 0,
+			"max_num_objects": 0,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// First child takes 60 GB during [200, 8000).
+	rv = lotman_add_lot(R"({
+		"lot_name": "sw_mix_c1",
+		"owner": "owner1",
+		"parents": ["sw_mix_parent"],
+		"paths": [{"path": "/sw/mix/c1", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 60, "opportunistic_GB": 0, "max_num_objects": 0,
+			"creation_time": 200, "expiration_time": 8000, "deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	UniqueCString err1(raw_err);
+	ASSERT_EQ(rv, 0) << "First child should fit: " << (err1.get() ? err1.get() : "<no error>");
+
+	// Second child takes 50 GB during [300, 7000), overlapping the first;
+	// concurrent peak = 110 GB > parent cap of 100 GB.
+	raw_err = nullptr;
+	rv = lotman_add_lot(R"({
+		"lot_name": "sw_mix_c2",
+		"owner": "owner1",
+		"parents": ["sw_mix_parent"],
+		"paths": [{"path": "/sw/mix/c2", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50, "opportunistic_GB": 0, "max_num_objects": 0,
+			"creation_time": 300, "expiration_time": 7000, "deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	UniqueCString err2(raw_err);
+	EXPECT_NE(rv, 0) << "Concurrent children must not exceed bounded storage axis even when objects are unbounded";
+}
+
+// Sweep line: a non-expiring child that is unbounded on storage under a
+// non-expiring, unbounded-storage parent is accepted (worst case combined
+// with finite siblings).
+TEST_F(StrictHierarchyTest, SweepLineNonExpiringUnboundedChildUnderNonExpiringUnboundedParent) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "ne_unb_parent",
+		"owner": "owner1",
+		"parents": ["ne_unb_parent"],
+		"paths": [{"path": "/ne/unb/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 0, "opportunistic_GB": 0, "max_num_objects": 0,
+			"creation_time": 0, "expiration_time": 0, "deletion_time": 0
+		}
+	})");
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	// A non-expiring child unbounded on every axis under a non-expiring
+	// unbounded parent: must succeed.
+	rv = lotman_add_lot(R"({
+		"lot_name": "ne_unb_child",
+		"owner": "owner1",
+		"parents": ["ne_unb_parent"],
+		"paths": [{"path": "/ne/unb/parent/c", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 0, "opportunistic_GB": 0, "max_num_objects": 0,
+			"creation_time": 0, "expiration_time": 0, "deletion_time": 0
+		}
+	})",
+						&raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Non-expiring fully-unbounded child under non-expiring fully-unbounded parent should succeed: "
+					 << (err.get() ? err.get() : "<no error>");
+}
+
+// Past-quota query: an unbounded-storage lot is never returned from
+// lotman_get_lots_past_ded / past_opp.
+TEST_F(StrictHierarchyTest, UnboundedStorageLotNotReturnedFromPastDedQuery) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "pq_unbounded",
+		"owner": "owner1",
+		"parents": ["pq_unbounded"],
+		"paths": [{"path": "/pq/unb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 0, "opportunistic_GB": 0, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500
+		}
+	})");
+
+	// Push self_GB very high; an unbounded-storage lot can never be "past"
+	// its dedicated quota.
+	const char *usage_json = R"({
+		"lot_name": "pq_unbounded",
+		"self_GB": 999999.0
+	})";
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot_usage(usage_json, false, &raw_err);
+	UniqueCString uerr(raw_err);
+	ASSERT_EQ(rv, 0) << "Failed to set usage: " << (uerr.get() ? uerr.get() : "<no error>");
+
+	char **lots = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lots_past_ded(false, false, &lots, false, &raw_err);
+	UniqueCString perr(raw_err);
+	ASSERT_EQ(rv, 0) << "lotman_get_lots_past_ded failed: " << (perr.get() ? perr.get() : "<no error>");
+	bool found = false;
+	if (lots) {
+		for (size_t i = 0; lots[i] != nullptr; ++i) {
+			if (std::string(lots[i]) == "pq_unbounded")
+				found = true;
+		}
+		lotman_free_string_list(lots);
+	}
+	EXPECT_FALSE(found) << "An unbounded-storage lot must never appear in past-dedicated-quota queries";
+}
+
+// Past-quota query: an unbounded-objects lot is never returned from
+// lotman_get_lots_past_obj.
+TEST_F(StrictHierarchyTest, UnboundedObjectsLotNotReturnedFromPastObjQuery) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "pq_unb_obj",
+		"owner": "owner1",
+		"parents": ["pq_unb_obj"],
+		"paths": [{"path": "/pq/unb/obj", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 0, "max_num_objects": 0,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500
+		}
+	})");
+
+	const char *usage_json = R"({
+		"lot_name": "pq_unb_obj",
+		"self_objects": 999999
+	})";
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot_usage(usage_json, false, &raw_err);
+	UniqueCString uerr(raw_err);
+	ASSERT_EQ(rv, 0) << "Failed to set usage: " << (uerr.get() ? uerr.get() : "<no error>");
+
+	char **lots = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lots_past_obj(false, false, &lots, false, &raw_err);
+	UniqueCString perr(raw_err);
+	ASSERT_EQ(rv, 0) << "lotman_get_lots_past_obj failed: " << (perr.get() ? perr.get() : "<no error>");
+	bool found = false;
+	if (lots) {
+		for (size_t i = 0; lots[i] != nullptr; ++i) {
+			if (std::string(lots[i]) == "pq_unb_obj")
+				found = true;
+		}
+		lotman_free_string_list(lots);
+	}
+	EXPECT_FALSE(found) << "An unbounded-objects lot must never appear in past-object-quota queries";
+}
+
+// Atomic flip via lotman_update_lot: set both dedicated_GB and
+// opportunistic_GB to 0 in one envelope.
+TEST_F(StrictHierarchyTest, UpdateLotToUnboundedStorageIsAtomic) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "flip_target",
+		"owner": "owner1",
+		"parents": ["flip_target"],
+		"paths": [{"path": "/flip/target", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 50, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500
+		}
+	})");
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot(R"({
+		"lot_name": "flip_target",
+		"management_policy_attrs": {
+			"dedicated_GB": 0,
+			"opportunistic_GB": 0
+		}
+	})",
+							   &raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Atomic flip to unbounded storage should succeed: " << (err.get() ? err.get() : "<no error>");
+}
+
+// Atomic flip via lotman_update_lot: a partial flip leaving the storage
+// axis in (dedicated_GB == 0, opportunistic_GB > 0) must be rejected and
+// rolled back.
+TEST_F(StrictHierarchyTest, UpdateLotPartialStorageFlipRejectedAndRolledBack) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "partial_flip",
+		"owner": "owner1",
+		"parents": ["partial_flip"],
+		"paths": [{"path": "/partial/flip", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 50, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500
+		}
+	})");
+
+	// Try to set only dedicated_GB to 0 (leaving opportunistic_GB at 50).
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot(R"({
+		"lot_name": "partial_flip",
+		"management_policy_attrs": {
+			"dedicated_GB": 0
+		}
+	})",
+							   &raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0) << "Partial storage flip (dedicated_GB == 0 with opportunistic_GB > 0) must be rejected";
+
+	// Confirm rollback: original values still present.
+	char *out = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lot_as_json("partial_flip", false, &out, &raw_err);
+	UniqueCString gerr(raw_err);
+	UniqueCString out_owned(out);
+	ASSERT_EQ(rv, 0) << "Failed to read back lot: " << (gerr.get() ? gerr.get() : "<no error>");
+	json parsed = json::parse(out_owned.get());
+	EXPECT_DOUBLE_EQ(parsed["management_policy_attrs"]["dedicated_GB"].get<double>(), 100.0);
+	EXPECT_DOUBLE_EQ(parsed["management_policy_attrs"]["opportunistic_GB"].get<double>(), 50.0);
+}
+
 } // namespace


### PR DESCRIPTION
Just as all-zero timestamps mean a lot never expires, a zero value on a resource axis means that axis has no cap. The axes are independent — unbounded storage and a finite object limit is a perfectly coherent policy — so each is checked in isolation rather than as a single all-or-nothing flag.

The storage axis (dedicated_GB + opportunistic_GB) requires both fields to move together: allowing dedicated_GB == 0 with a non-zero opportunistic cap would be meaningless because opportunistic storage is defined relative to the dedicated allotment. Updates are therefore validated after the full per-field loop, not mid-transaction, so a two-field flip to unbounded can land atomically without being rejected on the intermediate state.

Under strict_hierarchy, an unbounded parent on a given axis simply absorbs any child allocation on that axis; the sweep-line algorithm and per-axis containment checks are skipped only for the unbounded axis, leaving all bounded axes fully enforced.