### PR TITLE
Use -1 as unbounded sentinel for storage-axis MPAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,29 @@ Lot objects are comprised of several components:
     - *Opportunistic GB* -- Once a lot has used its entire allotment of dedicated storage, data is counted toward its opportunistic storage. Similar to expired lots, a system *may* make opportunistic storage available to the lot when resources are abundant. However, because LotMan intentionally does not track which paths associated with a lot are tied to different types of storage, when a system must make space, it must make a decision about which files from the lot are to be deleted. For this reason, exceeding dedicated storage limits should be treated as making any portion of the lot's associated data transient.
     - *Max Objects* -- The maximum number of objects a lot can store.
 
-      **Unbounded MPAs (sentinel `0`):** Just as the timestamp axis uses `0` to mean "non-expiring", each *resource* axis uses `0` to mean "no bound on this axis". The resource MPAs are grouped into two independent axes:
+      **Unbounded MPAs (sentinel `-1`):** Each *resource* axis uses `-1` to mean "no bound on this axis". (The timestamp axis is unrelated: it uses `0` to mean "non-expiring" — see below.) The resource MPAs are grouped into two independent axes:
 
-      - *Storage axis* -- `dedicated_GB` together with `opportunistic_GB`. The storage axis is unbounded **iff both** values are `0`. Because opportunistic storage is meaningful only relative to a finite dedicated allotment, the combination `dedicated_GB == 0` with `opportunistic_GB > 0` is rejected outright (an unbounded base capacity makes a finite burst cap meaningless). The combination `dedicated_GB > 0` with `opportunistic_GB == 0` is allowed and simply means "no burst capacity".
-      - *Object axis* -- `max_num_objects`. The object axis is unbounded **iff** `max_num_objects == 0`.
+      - *Storage axis* -- `dedicated_GB` and `opportunistic_GB` are **independent storage pools**. A value of `-1` on either axis means "unbounded" on that axis. Because `opportunistic_GB` tracks data ABOVE the dedicated allotment, an unbounded dedicated allotment is meaningless without an unbounded opportunistic axis; therefore `dedicated_GB == -1` requires `opportunistic_GB == -1` (any other combination with `dedicated_GB == -1` is rejected). All other combinations are legal:
+
+        | `dedicated_GB` | `opportunistic_GB` | Meaning                                                            |
+        | -------------- | ------------------ | ------------------------------------------------------------------ |
+        | `0`            | `0`                | No storage at all (rare outside of default lot; placeholder).      |
+        | `0`            | `>= 0`             | Purely opportunistic lot with finite burst.                        |
+        | `0`            | `-1`               | Purely opportunistic lot with unbounded burst.                     |
+        | `> 0`          | `0`                | Finite guaranteed allotment with no burst capacity.                |
+        | `> 0`          | `> 0`              | Finite guaranteed allotment with finite burst.                     |
+        | `> 0`          | `-1`               | Finite guaranteed allotment with unbounded burst.                  |
+        | `-1`           | `-1`               | Fully unbounded storage.                                           |
+        | `-1`           | anything else      | **Rejected** -- unbounded dedicated requires unbounded opportunistic. |
+
+      - *Object axis* -- `max_num_objects`. `-1` means "unbounded objects"; `0` means "no objects allowed".
 
       The two resource axes (and the timestamp axis) are independent: a lot may be unbounded on storage while still capping objects, or vice versa. An unbounded axis:
 
         - is excluded from the corresponding `lotman_get_lots_past_*` query (an unbounded lot can never be "past quota" on that axis), and reports the matching `available_*` field as `null` from `lotman_get_available_capacity`;
         - under `strict_hierarchy`, is treated as `+∞` on that axis only: an unbounded parent absorbs any finite child allocation on that axis (Axioms 1 and 2 skip per-axis cap checks against an unbounded parent), but an unbounded child requires **every** parent to also be unbounded on that axis. Bounds on other axes are still enforced normally.
 
-      To flip an existing lot to or from unbounded storage, supply both `dedicated_GB` and `opportunistic_GB` in the same `lotman_update_lot` envelope; the per-field axiom checks tolerate the transient partial state inside the transaction and a final post-update invariant pass enforces the storage-axis consistency rule, rolling back any partial flip that would leave the lot in the rejected `(dedicated_GB == 0, opportunistic_GB > 0)` state.
+      To flip an existing lot to or from unbounded storage, supply both `dedicated_GB` and `opportunistic_GB` in the same `lotman_update_lot` envelope; the per-field axiom checks tolerate the transient partial state inside the transaction and a final post-update invariant pass enforces the storage-axis consistency rule, rolling back any partial flip that would leave the lot in the rejected `(dedicated_GB == -1, opportunistic_GB != -1)` state.
 
 - **Usage Statistics:** Several usage statistics can be tracked for each lot. They are:
     - *Self GB* -- The number of GB a lot is currently using, not including those of its children.
@@ -60,7 +72,7 @@ LotMan supports a *reservation* model in which a parent lot's resources (dedicat
 These are set with `lotman_set_context_str` and read with `lotman_get_context_str`:
 
 - **`strict_hierarchy`** (`"true"` / `"false"`, default `"false"`) -- When enabled, every operation that creates or mutates a lot is validated against the following axioms before it is committed; failure rolls the change back atomically:
-    1. **Axiom 1** -- A child's MPAs may not exceed the sum of its parents' attributions to it. Each resource axis (storage = `dedicated_GB`+`opportunistic_GB`, objects = `max_num_objects`) is checked independently; an unbounded parent on a given axis is treated as `+∞` and disables the cap check for that axis only.
+    1. **Axiom 1** -- A child's MPAs may not exceed the sum of its parents' attributions to it. Each resource sub-axis (`dedicated_GB`, `opportunistic_GB`, and `max_num_objects`) is checked independently — `dedicated_GB` and `opportunistic_GB` are independent storage pools, not summed into a single combined cap. An unbounded parent on a given sub-axis is treated as `+∞` and disables the cap check for that sub-axis only.
     2. **Axiom 2** -- For any parent, the *peak concurrent* attributed usage across its children (over their active time windows) must not exceed the parent's own MPAs. This is checked with a sweep-line algorithm over the children's `[creation_time, expiration_time)` intervals so that two children whose windows don't overlap can both reserve the same capacity. The sweep is performed per axis; an axis on which the parent is unbounded is skipped (any concurrent child sum is acceptable on that axis), while bounded axes are still enforced.
     3. **Axiom 3** -- A child's active interval must lie within each of its parents' intervals. The non-expiring sentinel (all timestamps `0`) is treated as the interval `(-∞, +∞)`: a non-expiring parent absorbs any child window, but a non-expiring child requires every parent to also be non-expiring.
 - **`contraction_policy`** (`"none"` / `"strict"`, default `"none"`) -- Controls whether MPAs may be *reduced* on an existing lot. Under `"strict"`, an update that would lower a parent's capacity below what its children have already reserved is rejected.

--- a/src/lotman.cpp
+++ b/src/lotman.cpp
@@ -637,6 +637,14 @@ int lotman_add_to_lot(const char *lotman_JSON_str, char **err_msg) {
 		auto &storage = lotman::db::StorageManager::get_storage();
 		std::string txn_error;
 		bool committed = storage.transaction([&]() -> bool {
+			// If the caller supplied parent_attributions, route the JSON through
+			// the parent-add flow so the post-add equal-split / axiom validation
+			// uses the explicit shares rather than auto-dividing the lot's MPAs
+			// across all (existing + newly-added) parents and rejecting the
+			// auto-split before the explicit shares can take effect.
+			const json explicit_attrs =
+				addition_obj.contains("parent_attributions") ? addition_obj["parent_attributions"] : json();
+
 			if (addition_obj.contains("parents")) {
 				std::vector<lotman::Lot> parent_lots;
 				for (const auto &parent_name : addition_obj["parents"]) {
@@ -644,7 +652,7 @@ int lotman_add_to_lot(const char *lotman_JSON_str, char **err_msg) {
 					parent_lots.push_back(parent_lot);
 				}
 
-				if (!lot.add_parents_in_txn(parent_lots, txn_error)) {
+				if (!lot.add_parents_in_txn(parent_lots, txn_error, explicit_attrs)) {
 					txn_error = "Failure to add parents: " + txn_error;
 					return false;
 				}
@@ -657,9 +665,12 @@ int lotman_add_to_lot(const char *lotman_JSON_str, char **err_msg) {
 				}
 			}
 
-			// `parent_attributions` runs last so any parents added above are visible
-			// when attributions are recomputed.
-			if (addition_obj.contains("parent_attributions")) {
+			// If parent_attributions was supplied alongside `parents`, the
+			// attributions were already applied inside add_parents_in_txn above
+			// using the merged parent set. Only re-run when no `parents` were
+			// added (i.e. caller is just rewriting attributions on the existing
+			// parent set).
+			if (addition_obj.contains("parent_attributions") && !addition_obj.contains("parents")) {
 				if (!lot.update_attributions_in_txn(addition_obj["parent_attributions"], txn_error)) {
 					txn_error = "Failure to update parent attributions: " + txn_error;
 					return false;

--- a/src/lotman.h
+++ b/src/lotman.h
@@ -90,16 +90,27 @@ int lotman_add_lot(const char *lotman_JSON_str, char **err_msg);
 			needs to create space.
 		"max_num_objects": An int64 indicating the maxiximum number of objects a lot may have attributed to it.
 
-			Sentinel for unbounded MPAs: a value of 0 on a quota MPA marks that resource axis as
-			unbounded for this lot. MPAs are grouped into independent axes that are validated
-			internally but treated independently of each other:
-			  * Storage axis (dedicated_GB + opportunistic_GB): the axis is unbounded iff BOTH
-				dedicated_GB and opportunistic_GB are 0. Setting dedicated_GB to 0 with
-				opportunistic_GB > 0 is rejected -- if the dedicated capacity is unbounded, a finite
-				opportunistic cap is meaningless. The reverse (dedicated_GB > 0 with
-				opportunistic_GB == 0) is allowed and means the lot has no opportunistic burst
-				capacity.
-			  * Object-count axis (max_num_objects): unbounded iff 0.
+			Sentinel for unbounded MPAs: a value of -1 on a quota MPA marks that resource axis
+			as unbounded for this lot. (Note: timestamp MPAs use 0 as a separate sentinel; see
+			creation_time below.) MPAs are grouped into independent axes that are validated
+			separately:
+			  * Storage axis: dedicated_GB and opportunistic_GB are independent storage pools.
+				A value of -1 on either axis means "unbounded" on that axis. Because
+				opportunistic_GB tracks data ABOVE the dedicated allotment, an unbounded
+				dedicated allotment is meaningless without an unbounded opportunistic axis;
+				therefore dedicated_GB == -1 requires opportunistic_GB == -1 (any other
+				combination with dedicated_GB == -1 is rejected). All other combinations are
+				legal:
+				  - (dedicated_GB == 0, opportunistic_GB == 0): no storage at all (rare; useful
+					mostly as a placeholder).
+				  - (dedicated_GB == 0, opportunistic_GB >= 0 or -1): a "purely opportunistic"
+					lot with no guaranteed allotment.
+				  - (dedicated_GB > 0, opportunistic_GB == 0): finite guaranteed allotment with
+					no burst capacity.
+				  - (dedicated_GB > 0, opportunistic_GB > 0 or -1): finite guaranteed allotment
+					with a finite or unbounded burst.
+				  - (dedicated_GB == -1, opportunistic_GB == -1): fully unbounded storage.
+			  * Object-count axis (max_num_objects): -1 == unbounded; 0 == no objects allowed.
 			Different axes are independent: a lot may be unbounded on one axis and bounded on
 			another (e.g. unbounded storage with a finite max_num_objects). Under strict_hierarchy,
 			a child that is unbounded on an axis requires every parent to also be unbounded on that

--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -113,11 +113,18 @@ std::vector<SweepEvent> build_attribution_events(const std::string &parent_lot_n
 									 parent_lot_name + "'");
 		}
 
-		double attr_ded =
-			fractions.count("dedicated_GB") ? fractions.at("dedicated_GB") * child_mpa->dedicated_GB : 0.0;
+		// Guard sentinel values: treat unbounded axes (value == -1) as contributing
+		// 0 to the sweep line.  Callers that only care about bounded axes (e.g.
+		// validate_axiom2, get_available_capacity) already short-circuit via the
+		// parent_unb_* flags, so an unbounded child never corrupts a cap check.
+		double attr_ded = (!is_unbounded_dedicated(child_mpa->dedicated_GB) && fractions.count("dedicated_GB"))
+							  ? fractions.at("dedicated_GB") * child_mpa->dedicated_GB
+							  : 0.0;
 		double attr_opp =
-			fractions.count("opportunistic_GB") ? fractions.at("opportunistic_GB") * child_mpa->opportunistic_GB : 0.0;
-		double attr_obj = fractions.count("max_num_objects")
+			(!is_unbounded_opportunistic(child_mpa->opportunistic_GB) && fractions.count("opportunistic_GB"))
+				? fractions.at("opportunistic_GB") * child_mpa->opportunistic_GB
+				: 0.0;
+		double attr_obj = (!is_unbounded_objects(child_mpa->max_num_objects) && fractions.count("max_num_objects"))
 							  ? std::round(fractions.at("max_num_objects") * child_mpa->max_num_objects)
 							  : 0.0;
 
@@ -847,16 +854,19 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 			std::string rec_ded_usage_query =
 				"SELECT "
 				"CASE "
+				"WHEN management_policy_attributes.dedicated_GB = -1 THEN lot_usage.self_GB + lot_usage.children_GB "
 				"WHEN lot_usage.self_GB + lot_usage.children_GB <= management_policy_attributes.dedicated_GB THEN "
 				"lot_usage.self_GB + lot_usage.children_GB "
 				"ELSE management_policy_attributes.dedicated_GB "
 				"END AS total, " // For readability, not actually referencing these column names
 				"CASE "
+				"WHEN management_policy_attributes.dedicated_GB = -1 THEN lot_usage.self_GB "
 				"WHEN lot_usage.self_GB >= management_policy_attributes.dedicated_GB THEN "
 				"management_policy_attributes.dedicated_GB "
 				"ELSE lot_usage.self_GB "
 				"END AS self_contrib, "
 				"CASE "
+				"WHEN management_policy_attributes.dedicated_GB = -1 THEN lot_usage.children_GB "
 				"WHEN lot_usage.self_GB >= management_policy_attributes.dedicated_GB THEN '0' "
 				"WHEN lot_usage.self_GB + lot_usage.children_GB >= management_policy_attributes.dedicated_GB THEN "
 				"management_policy_attributes.dedicated_GB - lot_usage.self_GB "
@@ -883,6 +893,7 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 			std::string ded_GB_query =
 				"SELECT "
 				"CASE "
+				"WHEN management_policy_attributes.dedicated_GB = -1 THEN lot_usage.self_GB "
 				"WHEN lot_usage.self_GB >= management_policy_attributes.dedicated_GB THEN "
 				"management_policy_attributes.dedicated_GB "
 				"ELSE lot_usage.self_GB "
@@ -912,6 +923,10 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 			std::string rec_opp_usage_query =
 				"SELECT "
 				"CASE "
+				"WHEN management_policy_attributes.dedicated_GB = -1 THEN '0' "
+				"WHEN management_policy_attributes.opportunistic_GB = -1 THEN "
+				"CASE WHEN lot_usage.self_GB + lot_usage.children_GB > management_policy_attributes.dedicated_GB THEN "
+				"lot_usage.self_GB + lot_usage.children_GB - management_policy_attributes.dedicated_GB ELSE '0' END "
 				"WHEN lot_usage.self_GB + lot_usage.children_GB >= management_policy_attributes.opportunistic_GB "
 				"+management_policy_attributes.dedicated_GB THEN management_policy_attributes.opportunistic_GB "
 				"WHEN lot_usage.self_GB + lot_usage.children_GB >= management_policy_attributes.dedicated_GB THEN "
@@ -919,6 +934,10 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				"ELSE '0' "
 				"END AS total, "
 				"CASE "
+				"WHEN management_policy_attributes.dedicated_GB = -1 THEN '0' "
+				"WHEN management_policy_attributes.opportunistic_GB = -1 THEN "
+				"CASE WHEN lot_usage.self_GB >= management_policy_attributes.dedicated_GB THEN "
+				"lot_usage.self_GB - management_policy_attributes.dedicated_GB ELSE '0' END "
 				"WHEN lot_usage.self_GB >= management_policy_attributes.opportunistic_GB + "
 				"management_policy_attributes.dedicated_GB THEN management_policy_attributes.opportunistic_GB "
 				"WHEN lot_usage.self_GB >= management_policy_attributes.dedicated_GB THEN  lot_usage.self_GB - "
@@ -926,6 +945,12 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 				"ELSE '0' "
 				"END AS self_contrib, "
 				"CASE "
+				"WHEN management_policy_attributes.dedicated_GB = -1 THEN '0' "
+				"WHEN management_policy_attributes.opportunistic_GB = -1 THEN "
+				"CASE WHEN lot_usage.self_GB >= management_policy_attributes.dedicated_GB THEN lot_usage.children_GB "
+				"WHEN lot_usage.self_GB + lot_usage.children_GB > management_policy_attributes.dedicated_GB THEN "
+				"lot_usage.self_GB + lot_usage.children_GB - management_policy_attributes.dedicated_GB "
+				"ELSE '0' END "
 				"WHEN lot_usage.self_GB >= management_policy_attributes.opportunistic_GB + "
 				"management_policy_attributes.dedicated_GB THEN '0' "
 				"WHEN lot_usage.self_GB >= management_policy_attributes.dedicated_GB AND lot_usage.self_GB + "
@@ -965,9 +990,13 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 			std::string opp_GB_query =
 				"SELECT "
 				"CASE "
+				"WHEN management_policy_attributes.dedicated_GB = -1 THEN '0' "
+				"WHEN management_policy_attributes.opportunistic_GB = -1 THEN "
+				"CASE WHEN lot_usage.self_GB >= management_policy_attributes.dedicated_GB THEN "
+				"lot_usage.self_GB - management_policy_attributes.dedicated_GB ELSE '0' END "
 				"WHEN lot_usage.self_GB >= management_policy_attributes.dedicated_GB + "
 				"management_policy_attributes.opportunistic_GB THEN management_policy_attributes.opportunistic_GB "
-				"WHEN lot_usage.self_GB >= management_policy_attributes.dedicated_GB THEN lot_usage.self_GB = "
+				"WHEN lot_usage.self_GB >= management_policy_attributes.dedicated_GB THEN lot_usage.self_GB - "
 				"management_policy_attributes.dedicated_GB "
 				"ELSE '0' "
 				"END AS total "
@@ -1142,8 +1171,9 @@ std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string &key, 
 }
 
 // Non-transactional helper: reloads parents and MPAs from DB, clears old attributions,
-// recomputes with equal split, and validates axioms. Caller MUST hold an active transaction.
-bool lotman::Lot::reload_and_recompute_attributions(std::string &txn_error) {
+// recomputes with the supplied per-parent shares (equal split for any unspecified
+// parent), and validates axioms. Caller MUST hold an active transaction.
+bool lotman::Lot::reload_and_recompute_attributions(std::string &txn_error, const json &parent_attributions_json) {
 	try {
 		auto &storage = db::StorageManager::get_storage();
 		using namespace sqlite_orm;
@@ -1165,10 +1195,12 @@ bool lotman::Lot::reload_and_recompute_attributions(std::string &txn_error) {
 		man_policy_attr.opportunistic_GB = mpa_ptr->opportunistic_GB;
 		man_policy_attr.max_num_objects = mpa_ptr->max_num_objects;
 
-		// Clear old attributions and recompute with equal split
+		// Clear old attributions and recompute, honoring any explicit per-parent
+		// shares supplied by the caller; remaining parents get an equal split of
+		// the remainder.
 		storage.remove_all<db::ParentChildAttribution>(
 			where(c(&db::ParentChildAttribution::child_lot_name) == lot_name));
-		auto attr_rp = compute_and_store_attributions();
+		auto attr_rp = compute_and_store_attributions(parent_attributions_json);
 		if (!attr_rp.first) {
 			txn_error = "Failed to recompute attributions for '" + lot_name + "': " + attr_rp.second;
 			return false;
@@ -1189,7 +1221,8 @@ bool lotman::Lot::reload_and_recompute_attributions(std::string &txn_error) {
 
 // Non-transactional helper: stores parents, reloads state, recomputes attributions, validates.
 // Caller MUST hold an active storage.transaction().
-bool lotman::Lot::add_parents_impl(const std::vector<Lot> &parents, std::string &txn_error) {
+bool lotman::Lot::add_parents_impl(const std::vector<Lot> &parents, std::string &txn_error,
+								   const json &parent_attributions_json) {
 	try {
 		auto rp = store_new_parents(parents);
 		if (!rp.first) {
@@ -1198,7 +1231,7 @@ bool lotman::Lot::add_parents_impl(const std::vector<Lot> &parents, std::string 
 		}
 
 		if (lot_name != "default") {
-			if (!reload_and_recompute_attributions(txn_error)) {
+			if (!reload_and_recompute_attributions(txn_error, parent_attributions_json)) {
 				return false;
 			}
 		}
@@ -1221,7 +1254,8 @@ std::pair<bool, std::string> lotman::Lot::add_parents(const std::vector<Lot> &pa
 	return std::make_pair(true, "");
 }
 
-bool lotman::Lot::add_parents_in_txn(const std::vector<Lot> &parents, std::string &txn_error) {
+bool lotman::Lot::add_parents_in_txn(const std::vector<Lot> &parents, std::string &txn_error,
+									 const json &parent_attributions_json) {
 	// Perform a cycle check
 	// Build the list of all proposed parents
 	std::vector<std::string> parent_names;
@@ -1246,7 +1280,7 @@ bool lotman::Lot::add_parents_in_txn(const std::vector<Lot> &parents, std::strin
 		return false;
 	}
 
-	return add_parents_impl(parents, txn_error);
+	return add_parents_impl(parents, txn_error, parent_attributions_json);
 }
 
 std::pair<bool, std::string> lotman::Lot::add_paths(const std::vector<json> &paths) {
@@ -2208,16 +2242,18 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_opp(
 																				const bool recursive_children) {
 	std::vector<std::string> lots_past_opp;
 	if (recursive_quota) {
-		// Skip lots whose storage axis is unbounded (dedicated_GB == 0 AND
-		// opportunistic_GB == 0 is the unbounded-storage sentinel; such a lot
-		// is never "past" its quota).
+		// Skip lots whose dedicated or opportunistic axis is the unbounded
+		// sentinel (-1). When dedicated_GB == -1 the storage axis is fully
+		// unbounded; when opportunistic_GB == -1 the burst capacity is
+		// unbounded, so the (ded+opp) total is meaningless. In either case
+		// the lot can never be "past" its opportunistic quota.
 		std::string rec_opp_usage_query =
 			"SELECT "
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE NOT (management_policy_attributes.dedicated_GB = 0 AND "
-			"           management_policy_attributes.opportunistic_GB = 0) "
+			"WHERE management_policy_attributes.dedicated_GB != -1 "
+			"  AND management_policy_attributes.opportunistic_GB != -1 "
 			"AND lot_usage.self_GB + lot_usage.children_GB >= management_policy_attributes.dedicated_GB + "
 			"management_policy_attributes.opportunistic_GB;";
 		auto rp = lotman::db::SQL_get_matches(rec_opp_usage_query);
@@ -2233,8 +2269,8 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_opp(
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE NOT (management_policy_attributes.dedicated_GB = 0 AND "
-			"           management_policy_attributes.opportunistic_GB = 0) "
+			"WHERE management_policy_attributes.dedicated_GB != -1 "
+			"  AND management_policy_attributes.opportunistic_GB != -1 "
 			"AND lot_usage.self_GB >= management_policy_attributes.dedicated_GB + "
 			"management_policy_attributes.opportunistic_GB;";
 
@@ -2277,15 +2313,15 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_ded(
 																				const bool recursive_children) {
 	std::vector<std::string> lots_past_ded;
 	if (recursive_quota) {
-		// Skip lots with dedicated_GB == 0 (unbounded-storage sentinel: a lot
-		// with both dedicated_GB and opportunistic_GB equal to 0 has unbounded
-		// storage and can never be past its dedicated quota).
+		// Skip lots with dedicated_GB == -1 (unbounded-dedicated sentinel).
+		// A lot with dedicated_GB == 0 (literal: no guaranteed storage) is
+		// kept and is "past" its dedicated quota the moment it has any usage.
 		std::string rec_ded_usage_query =
 			"SELECT "
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE management_policy_attributes.dedicated_GB > 0 "
+			"WHERE management_policy_attributes.dedicated_GB != -1 "
 			"AND lot_usage.self_GB + lot_usage.children_GB >= management_policy_attributes.dedicated_GB;";
 
 		auto rp = lotman::db::SQL_get_matches(rec_ded_usage_query);
@@ -2301,7 +2337,7 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_ded(
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE management_policy_attributes.dedicated_GB > 0 "
+			"WHERE management_policy_attributes.dedicated_GB != -1 "
 			"AND lot_usage.self_GB >= management_policy_attributes.dedicated_GB;";
 
 		auto rp = lotman::db::SQL_get_matches(ded_usage_query);
@@ -2343,13 +2379,13 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_obj(
 																				const bool recursive_children) {
 	std::vector<std::string> lots_past_obj;
 	if (recursive_quota) {
-		// Skip lots with max_num_objects == 0 (unbounded-objects sentinel).
+		// Skip lots with max_num_objects == -1 (unbounded-objects sentinel).
 		std::string rec_obj_usage_query =
 			"SELECT "
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE management_policy_attributes.max_num_objects > 0 "
+			"WHERE management_policy_attributes.max_num_objects != -1 "
 			"AND lot_usage.self_objects + lot_usage.children_objects >= "
 			"management_policy_attributes.max_num_objects;";
 
@@ -2366,7 +2402,7 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_obj(
 			"lot_usage.lot_name "
 			"FROM lot_usage "
 			"INNER JOIN management_policy_attributes ON lot_usage.lot_name=management_policy_attributes.lot_name "
-			"WHERE management_policy_attributes.max_num_objects > 0 "
+			"WHERE management_policy_attributes.max_num_objects != -1 "
 			"AND lot_usage.self_objects >= management_policy_attributes.max_num_objects;";
 
 		auto rp = lotman::db::SQL_get_matches(obj_usage_query);
@@ -2458,7 +2494,8 @@ static void sort_by_depth_descending(std::vector<std::string> &lots) {
 static std::pair<std::vector<std::string>, std::string>
 get_lots_past_threshold_hierarchical(const std::string &self_usage_col, const std::string &child_usage_expr,
 									 const std::string &child_threshold_expr, const std::string &parent_threshold_expr,
-									 const std::string &error_context) {
+									 const std::string &parent_unbounded_predicate,
+									 const std::string &child_unbounded_predicate, const std::string &error_context) {
 
 	// Defense-in-depth: validate all SQL fragments against known-good values.
 	// All callers pass compile-time constants, but this prevents future misuse.
@@ -2471,34 +2508,42 @@ get_lots_past_threshold_hierarchical(const std::string &self_usage_col, const st
 														"p_mpa.dedicated_GB",
 														"p_mpa.dedicated_GB + p_mpa.opportunistic_GB",
 														"p_mpa.max_num_objects"};
+	static const std::set<std::string> allowed_unbounded_predicates = {
+		"p_mpa.dedicated_GB = -1",
+		"p_mpa.dedicated_GB = -1 OR p_mpa.opportunistic_GB = -1",
+		"p_mpa.max_num_objects = -1",
+		"c_mpa.dedicated_GB = -1",
+		"c_mpa.dedicated_GB = -1 OR c_mpa.opportunistic_GB = -1",
+		"c_mpa.max_num_objects = -1"};
 
 	if (allowed_usage_cols.find(self_usage_col) == allowed_usage_cols.end() ||
 		allowed_exprs.find(child_usage_expr) == allowed_exprs.end() ||
 		allowed_exprs.find(child_threshold_expr) == allowed_exprs.end() ||
-		allowed_exprs.find(parent_threshold_expr) == allowed_exprs.end()) {
+		allowed_exprs.find(parent_threshold_expr) == allowed_exprs.end() ||
+		allowed_unbounded_predicates.find(parent_unbounded_predicate) == allowed_unbounded_predicates.end() ||
+		allowed_unbounded_predicates.find(child_unbounded_predicate) == allowed_unbounded_predicates.end()) {
 		return std::make_pair(std::vector<std::string>(),
 							  "Internal error: unrecognized SQL fragment in hierarchical query");
 	}
 
-	// Per-axis sentinel handling:
-	//   * Parent threshold == 0 marks that axis as unbounded; the parent can
-	//     never be "past" its quota on that axis, so we exclude such parents.
-	//   * Child threshold == 0 marks the child as unbounded on that axis;
-	//     such a child can only exist under an unbounded parent (rejected
-	//     by axiom 1 otherwise), but defensively we treat its overflow
-	//     contribution as 0 so an unbounded child can never push a parent
-	//     past quota.
+	// Per-axis sentinel handling (-1 marks an axis as unbounded):
+	//   * Parents that are unbounded on the relevant axis are excluded
+	//     entirely -- they can never be "past" their quota on that axis.
+	//   * Children that are unbounded on the axis can only legally exist
+	//     under an unbounded parent (rejected by axiom 1 otherwise);
+	//     defensively we treat their overflow contribution as 0 so they can
+	//     never push a parent past its own quota.
 	std::string query = "SELECT p_usage.lot_name "
 						"FROM lot_usage p_usage "
 						"JOIN management_policy_attributes p_mpa ON p_usage.lot_name = p_mpa.lot_name "
-						"WHERE (" +
-						parent_threshold_expr +
-						") > 0 "
+						"WHERE NOT (" +
+						parent_unbounded_predicate +
+						") "
 						"AND p_usage." +
 						self_usage_col +
 						" + COALESCE("
 						"    (SELECT SUM(CASE WHEN (" +
-						child_threshold_expr + ") = 0 THEN 0 ELSE MAX(0, (" + child_usage_expr + ") - (" +
+						child_unbounded_predicate + ") THEN 0 ELSE MAX(0, (" + child_usage_expr + ") - (" +
 						child_threshold_expr +
 						")) END) "
 						"     FROM parents c_par "
@@ -2524,7 +2569,8 @@ lotman::Lot::get_lots_past_ded(const bool recursive_quota, const bool recursive_
 		return get_lots_past_ded(recursive_quota, recursive_children);
 	}
 	return get_lots_past_threshold_hierarchical("self_GB", "c_usage.self_GB + c_usage.children_GB",
-												"c_mpa.dedicated_GB", "p_mpa.dedicated_GB", "adjusted dedicated query");
+												"c_mpa.dedicated_GB", "p_mpa.dedicated_GB", "p_mpa.dedicated_GB = -1",
+												"c_mpa.dedicated_GB = -1", "adjusted dedicated query");
 }
 
 std::pair<std::vector<std::string>, std::string>
@@ -2534,7 +2580,8 @@ lotman::Lot::get_lots_past_opp(const bool recursive_quota, const bool recursive_
 	}
 	return get_lots_past_threshold_hierarchical(
 		"self_GB", "c_usage.self_GB + c_usage.children_GB", "c_mpa.dedicated_GB + c_mpa.opportunistic_GB",
-		"p_mpa.dedicated_GB + p_mpa.opportunistic_GB", "adjusted opportunistic query");
+		"p_mpa.dedicated_GB + p_mpa.opportunistic_GB", "p_mpa.dedicated_GB = -1 OR p_mpa.opportunistic_GB = -1",
+		"c_mpa.dedicated_GB = -1 OR c_mpa.opportunistic_GB = -1", "adjusted opportunistic query");
 }
 
 std::pair<std::vector<std::string>, std::string>
@@ -2542,9 +2589,9 @@ lotman::Lot::get_lots_past_obj(const bool recursive_quota, const bool recursive_
 	if (!hierarchical) {
 		return get_lots_past_obj(recursive_quota, recursive_children);
 	}
-	return get_lots_past_threshold_hierarchical("self_objects", "c_usage.self_objects + c_usage.children_objects",
-												"c_mpa.max_num_objects", "p_mpa.max_num_objects",
-												"adjusted objects query");
+	return get_lots_past_threshold_hierarchical(
+		"self_objects", "c_usage.self_objects + c_usage.children_objects", "c_mpa.max_num_objects",
+		"p_mpa.max_num_objects", "p_mpa.max_num_objects = -1", "c_mpa.max_num_objects = -1", "adjusted objects query");
 }
 
 std::pair<json, std::string> lotman::Lot::get_available_capacity(const std::string &parent_lot_name, int64_t start_time,
@@ -2563,22 +2610,23 @@ std::pair<json, std::string> lotman::Lot::get_available_capacity(const std::stri
 		auto events = build_attribution_events(parent_lot_name, start_time, end_time);
 		auto peak = run_sweep_line(events);
 
-		// Per-axis sentinel handling: a parent that is unbounded on an axis
+		// Per-axis sentinel handling: a parent that is unbounded on a sub-axis
 		// has no meaningful "available" value on that axis (the cap is +inf).
 		// Report null for those fields rather than a negative or misleading
 		// number; callers can detect unbounded by checking for null.
-		const bool parent_unbounded_storage =
-			is_unbounded_storage(parent_mpa->dedicated_GB, parent_mpa->opportunistic_GB);
+		const bool parent_unb_ded = is_unbounded_dedicated(parent_mpa->dedicated_GB);
+		const bool parent_unb_opp = is_unbounded_opportunistic(parent_mpa->opportunistic_GB);
 		const bool parent_unbounded_objects = is_unbounded_objects(parent_mpa->max_num_objects);
 
 		json result;
-		if (parent_unbounded_storage) {
-			result["available_dedicated_GB"] = nullptr;
-			result["available_opportunistic_GB"] = nullptr;
+		result["available_dedicated_GB"] =
+			parent_unb_ded ? json(nullptr) : json(parent_mpa->dedicated_GB - peak.peak_ded);
+		result["available_opportunistic_GB"] =
+			parent_unb_opp ? json(nullptr) : json(parent_mpa->opportunistic_GB - peak.peak_opp);
+		// available_total_GB is meaningful only when both sub-axes are bounded.
+		if (parent_unb_ded || parent_unb_opp) {
 			result["available_total_GB"] = nullptr;
 		} else {
-			result["available_dedicated_GB"] = parent_mpa->dedicated_GB - peak.peak_ded;
-			result["available_opportunistic_GB"] = parent_mpa->opportunistic_GB - peak.peak_opp;
 			double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
 			result["available_total_GB"] = parent_total - peak.peak_total;
 		}
@@ -2929,6 +2977,28 @@ std::pair<bool, std::string> lotman::Lot::compute_and_store_attributions(const j
 
 		for (const auto &mpa_key : mpa_keys) {
 			double total_child_value = child_mpas.at(mpa_key);
+
+			// Unbounded child sentinel (-1): the unbounded designation flows
+			// to each parent — every parent attribution stores fraction = 1.0
+			// so that downstream consumers reconstruct "child.mpa * fraction"
+			// as -1 (i.e. unbounded) for every parent. We skip explicit-sum
+			// and remainder-distribution math entirely; if the caller supplied
+			// an explicit value for an unbounded axis we treat that as "this
+			// parent also propagates the unbounded designation". Hierarchy
+			// constraints (unbounded child under a bounded parent) are caught
+			// in validate_axiom1 / validate_axiom2_for_parents_of, not here.
+			if (total_child_value == -1.0) {
+				for (const auto &parent_name : non_self_parents) {
+					db::ParentChildAttribution attr;
+					attr.child_lot_name = lot_name;
+					attr.parent_lot_name = parent_name;
+					attr.mpa_key = mpa_key;
+					attr.fraction = 1.0;
+					storage.replace(attr);
+				}
+				continue;
+			}
+
 			double explicitly_attributed = 0.0;
 			std::vector<std::string> unspecified_parents;
 
@@ -3180,17 +3250,23 @@ std::pair<bool, std::string> lotman::Lot::validate_axiom1(const std::string &chi
 	// Axiom 1: For each parent P of child C, the attributed amount from C to P
 	// must not exceed P's own MPAs.
 	//
-	// Per-axis sentinel handling:
-	//   * If a parent's storage axis is unbounded (dedicated_GB == 0 AND
-	//     opportunistic_GB == 0), no attributed storage value can exceed it,
-	//     so storage checks are skipped for that parent.
-	//   * If a parent's object axis is unbounded (max_num_objects == 0),
-	//     the object check is skipped for that parent.
-	//   * If the child is unbounded on an axis but a parent is bounded on
-	//     that axis, the child cannot fit and the relationship is rejected.
-	//   * If the child is in a transient partial-zero storage state during a
-	//     multi-field update, defer; the post-loop invariant check in
+	// Per-axis sentinel handling: each of the three sub-axes (dedicated_GB,
+	// opportunistic_GB, max_num_objects) is checked independently.
+	//   * If a parent is unbounded on a sub-axis (-1 sentinel), that sub-axis
+	//     check is skipped entirely (no finite child value can exceed +inf).
+	//   * If a child is unbounded on a sub-axis but the parent is bounded on
+	//     the same sub-axis, the child cannot fit and the relationship is
+	//     rejected.
+	//   * If the child or parent is in the transient partial-storage state
+	//     (dedicated_GB == -1 with opportunistic_GB != -1) during a multi-
+	//     field update, defer; the post-loop invariant check in
 	//     lotman_update_lot rejects any persisting partial state.
+	//
+	// Note: there is intentionally no "combined" (dedicated + opportunistic)
+	// cap check. Dedicated and opportunistic are different storage pools, so
+	// per-pool caps are sufficient and the combined check would conflate
+	// independent sub-axes (and break in obvious ways once either pool is
+	// the unbounded sentinel).
 	try {
 		auto &storage = db::StorageManager::get_storage();
 		using namespace sqlite_orm;
@@ -3205,7 +3281,8 @@ std::pair<bool, std::string> lotman::Lot::validate_axiom1(const std::string &chi
 			// Defer: transient state inside an in-progress MPA update.
 			return std::make_pair(true, "");
 		}
-		const bool child_unbounded_storage = is_unbounded_storage(child_mpa->dedicated_GB, child_mpa->opportunistic_GB);
+		const bool child_unb_ded = is_unbounded_dedicated(child_mpa->dedicated_GB);
+		const bool child_unb_opp = is_unbounded_opportunistic(child_mpa->opportunistic_GB);
 		const bool child_unbounded_objects = is_unbounded_objects(child_mpa->max_num_objects);
 
 		// Get non-self parents from the parents table (authoritative source)
@@ -3242,28 +3319,31 @@ std::pair<bool, std::string> lotman::Lot::validate_axiom1(const std::string &chi
 				// Defer: transient state inside an in-progress MPA update.
 				continue;
 			}
-			const bool parent_unbounded_storage =
-				is_unbounded_storage(parent_mpa->dedicated_GB, parent_mpa->opportunistic_GB);
+			const bool parent_unb_ded = is_unbounded_dedicated(parent_mpa->dedicated_GB);
+			const bool parent_unb_opp = is_unbounded_opportunistic(parent_mpa->opportunistic_GB);
 			const bool parent_unbounded_objects = is_unbounded_objects(parent_mpa->max_num_objects);
 
 			// An unbounded child cannot fit inside a bounded parent on the
-			// same axis: the child's effective allocation on that axis is
+			// same sub-axis: the child's effective allocation on that axis is
 			// "infinite", which exceeds any finite parent cap.
-			if (child_unbounded_storage && !parent_unbounded_storage) {
-				return std::make_pair(false,
-									  "Hierarchy violation: child lot '" + child_lot_name +
-										  "' has unbounded storage (dedicated_GB == 0 and opportunistic_GB == 0) "
-										  "but parent lot '" +
-										  parent_name +
-										  "' has a bounded storage axis. An unbounded child requires every parent "
-										  "to also be unbounded on that axis.");
+			if (child_unb_ded && !parent_unb_ded) {
+				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name +
+												 "' has unbounded dedicated_GB (-1) but parent lot '" + parent_name +
+												 "' has a bounded dedicated_GB. An unbounded child requires every "
+												 "parent to also be unbounded on that sub-axis.");
+			}
+			if (child_unb_opp && !parent_unb_opp) {
+				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name +
+												 "' has unbounded opportunistic_GB (-1) but parent lot '" +
+												 parent_name +
+												 "' has a bounded opportunistic_GB. An unbounded child requires "
+												 "every parent to also be unbounded on that sub-axis.");
 			}
 			if (child_unbounded_objects && !parent_unbounded_objects) {
 				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name +
-												 "' has unbounded max_num_objects (== 0) but parent lot '" +
-												 parent_name +
+												 "' has unbounded max_num_objects (-1) but parent lot '" + parent_name +
 												 "' has a bounded max_num_objects. An unbounded child requires "
-												 "every parent to also be unbounded on that axis.");
+												 "every parent to also be unbounded on that sub-axis.");
 			}
 
 			// Compute attributed values
@@ -3276,31 +3356,24 @@ std::pair<bool, std::string> lotman::Lot::validate_axiom1(const std::string &chi
 								  ? std::round(fractions.at("max_num_objects") * child_mpa->max_num_objects)
 								  : 0.0;
 
-			// Storage axis: skip the per-axis cap checks if the parent's
-			// storage axis is unbounded.
-			if (!parent_unbounded_storage) {
-				// Check: attributed dedicated ≤ parent dedicated
-				if (attr_ded > parent_mpa->dedicated_GB + 1e-9) {
-					return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
-													 std::to_string(attr_ded) + " dedicated_GB to parent lot '" +
-													 parent_name +
-													 "', which exceeds the parent's dedicated_GB allocation of " +
-													 std::to_string(parent_mpa->dedicated_GB) +
-													 ". A child lot's allocation may not exceed any parent's.");
-				}
+			// Per-sub-axis cap checks. Each axis is skipped when the parent
+			// is unbounded on it.
+			if (!parent_unb_ded && attr_ded > parent_mpa->dedicated_GB + 1e-9) {
+				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
+												 std::to_string(attr_ded) + " dedicated_GB to parent lot '" +
+												 parent_name +
+												 "', which exceeds the parent's dedicated_GB allocation of " +
+												 std::to_string(parent_mpa->dedicated_GB) +
+												 ". A child lot's allocation may not exceed any parent's.");
+			}
 
-				// Check: attributed (ded+opp) ≤ parent (ded+opp)
-				double attr_total = attr_ded + attr_opp;
-				double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
-				if (attr_total > parent_total + 1e-9) {
-					return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
-													 std::to_string(attr_total) +
-													 " total GB (dedicated + opportunistic) to parent lot '" +
-													 parent_name +
-													 "', which exceeds the parent's combined allocation of " +
-													 std::to_string(parent_total) +
-													 " GB. A child lot's allocation may not exceed any parent's.");
-				}
+			if (!parent_unb_opp && attr_opp > parent_mpa->opportunistic_GB + 1e-9) {
+				return std::make_pair(false, "Hierarchy violation: child lot '" + child_lot_name + "' attributes " +
+												 std::to_string(attr_opp) + " opportunistic_GB to parent lot '" +
+												 parent_name +
+												 "', which exceeds the parent's opportunistic_GB allocation of " +
+												 std::to_string(parent_mpa->opportunistic_GB) +
+												 ". A child lot's allocation may not exceed any parent's.");
 			}
 
 			// Object axis: skip if the parent's object axis is unbounded.
@@ -3328,13 +3401,14 @@ std::pair<bool, std::string> lotman::Lot::validate_axiom2_for_parents_of(const s
 	// concurrently-active children's attributed MPAs exceed P's own MPAs.
 	// Uses a sweep-line over children's [creation_time, expiration_time) intervals.
 	//
-	// Per-axis sentinel handling: a parent that is unbounded on an axis
-	// (storage axis: dedicated_GB == 0 AND opportunistic_GB == 0; object
-	// axis: max_num_objects == 0) cannot be exceeded on that axis, so the
-	// per-axis cap check is skipped for that parent. Cross-axis containment
-	// (an unbounded child under a bounded parent) is rejected by axiom 1
-	// before the sweep is reached, so children feeding into the sweep are
-	// guaranteed to be bounded on each axis the parent is bounded on.
+	// Per-axis sentinel handling: each sub-axis (dedicated_GB, opportunistic_GB,
+	// max_num_objects) is checked independently; the per-sub-axis cap check is
+	// skipped when the parent is unbounded (-1) on that sub-axis. Cross-axis
+	// containment (an unbounded child under a bounded parent on the same axis)
+	// is rejected by axiom 1 before the sweep is reached, so children feeding
+	// into the sweep are guaranteed to be bounded on each axis the parent is
+	// bounded on. As in axiom 1, the per-pool checks are sufficient -- there
+	// is no separate "combined" (ded+opp) cap.
 	try {
 		auto &storage = db::StorageManager::get_storage();
 		using namespace sqlite_orm;
@@ -3354,45 +3428,37 @@ std::pair<bool, std::string> lotman::Lot::validate_axiom2_for_parents_of(const s
 				// Defer: transient state inside an in-progress MPA update.
 				continue;
 			}
-			const bool parent_unbounded_storage =
-				is_unbounded_storage(parent_mpa->dedicated_GB, parent_mpa->opportunistic_GB);
+			const bool parent_unb_ded = is_unbounded_dedicated(parent_mpa->dedicated_GB);
+			const bool parent_unb_opp = is_unbounded_opportunistic(parent_mpa->opportunistic_GB);
 			const bool parent_unbounded_objects = is_unbounded_objects(parent_mpa->max_num_objects);
 
-			// If the parent is unbounded on every axis, no peak can exceed
+			// If the parent is unbounded on every sub-axis, no peak can exceed
 			// it; skip the sweep entirely.
-			if (parent_unbounded_storage && parent_unbounded_objects)
+			if (parent_unb_ded && parent_unb_opp && parent_unbounded_objects)
 				continue;
 
 			// Build sweep-line events from children's attributions
 			auto events = build_attribution_events(parent_name);
 			auto peak = run_sweep_line(events);
 
-			if (!parent_unbounded_storage) {
-				// Check: peak dedicated ≤ parent dedicated
-				if (peak.peak_ded > parent_mpa->dedicated_GB + 1e-9) {
-					return std::make_pair(
-						false, "Hierarchy violation: peak concurrent dedicated_GB across children of parent lot '" +
-								   parent_name + "' is " + std::to_string(peak.peak_ded) +
-								   ", which exceeds the parent's dedicated_GB allocation of " +
-								   std::to_string(parent_mpa->dedicated_GB) +
-								   ". The combined allocations of children active at the same time may not exceed "
-								   "the parent's capacity.");
-				}
+			if (!parent_unb_ded && peak.peak_ded > parent_mpa->dedicated_GB + 1e-9) {
+				return std::make_pair(
+					false, "Hierarchy violation: peak concurrent dedicated_GB across children of parent lot '" +
+							   parent_name + "' is " + std::to_string(peak.peak_ded) +
+							   ", which exceeds the parent's dedicated_GB allocation of " +
+							   std::to_string(parent_mpa->dedicated_GB) +
+							   ". The combined allocations of children active at the same time may not exceed "
+							   "the parent's capacity.");
+			}
 
-				// Check: peak (ded+opp) ≤ parent (ded+opp)
-				// Use peak_total which is the true max of (ded+opp) at a single point in time,
-				// not the sum of independent peaks which can occur at different times.
-				double parent_total = parent_mpa->dedicated_GB + parent_mpa->opportunistic_GB;
-				if (peak.peak_total > parent_total + 1e-9) {
-					return std::make_pair(false,
-										  "Hierarchy violation: peak concurrent total GB (dedicated + "
-										  "opportunistic) across children of parent lot '" +
-											  parent_name + "' is " + std::to_string(peak.peak_total) +
-											  ", which exceeds the parent's combined allocation of " +
-											  std::to_string(parent_total) +
-											  " GB. The combined allocations of children active at the same time "
-											  "may not exceed the parent's capacity.");
-				}
+			if (!parent_unb_opp && peak.peak_opp > parent_mpa->opportunistic_GB + 1e-9) {
+				return std::make_pair(
+					false, "Hierarchy violation: peak concurrent opportunistic_GB across children of parent lot '" +
+							   parent_name + "' is " + std::to_string(peak.peak_opp) +
+							   ", which exceeds the parent's opportunistic_GB allocation of " +
+							   std::to_string(parent_mpa->opportunistic_GB) +
+							   ". The combined allocations of children active at the same time may not exceed "
+							   "the parent's capacity.");
 			}
 
 			if (!parent_unbounded_objects) {

--- a/src/lotman_internal.h
+++ b/src/lotman_internal.h
@@ -46,54 +46,62 @@ inline bool is_non_expiring(int64_t creation_time, int64_t expiration_time, int6
 	return creation_time == 0 && expiration_time == 0 && deletion_time == 0;
 }
 
-// Resource-axis sentinels: a value of 0 on a quota MPA marks that axis as
-// "unbounded". MPAs are grouped into independent axes that are validated
-// internally but treated independently of each other:
-//   * Storage axis: dedicated_GB and opportunistic_GB. The storage axis is
-//     unbounded iff both are 0. Mixing (dedicated_GB == 0 with
-//     opportunistic_GB > 0) is rejected -- if the dedicated capacity is
-//     unbounded, a finite opportunistic cap is meaningless. The reverse
-//     (dedicated_GB > 0 with opportunistic_GB == 0) is allowed and means
-//     the lot has no opportunistic burst capacity.
-//   * Object-count axis: max_num_objects. Unbounded iff 0.
-// Different axes are independent: a lot may be unbounded on one axis and
-// bounded on another.
-inline bool is_unbounded_storage(double dedicated_GB, double opportunistic_GB) {
-	return dedicated_GB == 0.0 && opportunistic_GB == 0.0;
+// Resource-axis sentinels: a value of -1 on a quota MPA marks that axis as
+// "unbounded". 0 is therefore reserved for its literal meaning ("zero
+// guaranteed storage", "zero burst capacity", "zero objects allowed"), so
+// callers can express purely-opportunistic lots, no-burst lots, etc.
+//
+// The three resource MPAs are treated as three independent sub-axes:
+//   * dedicated_GB:     -1 == unbounded, 0 == no guaranteed storage.
+//   * opportunistic_GB: -1 == unbounded burst, 0 == no burst capacity.
+//   * max_num_objects:  -1 == unbounded, 0 == no objects allowed.
+//
+// Cross-axis storage rule: an unbounded dedicated cap with a finite
+// opportunistic cap is meaningless (opportunistic is "data over the
+// dedicated allotment"); therefore (dedicated_GB == -1 && opportunistic_GB
+// != -1) is rejected. The reverse (finite dedicated, unbounded opportunistic)
+// is allowed and means "guaranteed N GB plus unlimited burst".
+inline bool is_unbounded_dedicated(double dedicated_GB) {
+	return dedicated_GB == -1.0;
+}
+
+inline bool is_unbounded_opportunistic(double opportunistic_GB) {
+	return opportunistic_GB == -1.0;
 }
 
 inline bool is_unbounded_objects(int64_t max_num_objects) {
-	return max_num_objects == 0;
+	return max_num_objects == -1;
 }
 
-// True when the storage axis is in a transient, inconsistent state that can
-// occur mid-transaction during a multi-field update (dedicated_GB has already
-// been set to 0 while opportunistic_GB has not yet been updated to match).
-// Hierarchy validation predicates short-circuit when they encounter this state
-// and rely on a post-loop check in lotman_update_lot to reject any persisting
-// partial state.
+// True when the storage axis is in the forbidden combination
+// (dedicated_GB == -1 with opportunistic_GB != -1). This may occur as a
+// transient state mid-transaction during a multi-field update where
+// dedicated_GB has been written first; hierarchy validation predicates
+// short-circuit when they encounter it and rely on a post-loop check in
+// lotman_update_lot to reject any persisting partial state.
 inline bool is_partial_storage_sentinel(double dedicated_GB, double opportunistic_GB) {
-	return dedicated_GB == 0.0 && opportunistic_GB > 0.0;
+	return dedicated_GB == -1.0 && opportunistic_GB != -1.0;
 }
 
 // Validate the per-axis MPA invariants for a lot:
-//   * All MPAs must be non-negative.
-//   * Storage axis: if dedicated_GB == 0, opportunistic_GB must also be 0.
+//   * Each MPA must be either >= 0 or exactly -1 (the unbounded sentinel).
+//   * Storage axis: dedicated_GB == -1 requires opportunistic_GB == -1.
 // Returns (true, "") when valid, otherwise (false, message).
 inline std::pair<bool, std::string> validate_mpa_invariants(double dedicated_GB, double opportunistic_GB,
 															int64_t max_num_objects) {
-	if (dedicated_GB < 0 || opportunistic_GB < 0 || max_num_objects < 0) {
-		return std::make_pair(false, std::string("MPAs must be non-negative; got dedicated_GB=") +
+	auto bad = [](double v) { return v < 0.0 && v != -1.0; };
+	if (bad(dedicated_GB) || bad(opportunistic_GB) || (max_num_objects < 0 && max_num_objects != -1)) {
+		return std::make_pair(false, std::string("MPAs must be >= 0 or exactly -1 (the unbounded sentinel); got "
+												 "dedicated_GB=") +
 										 std::to_string(dedicated_GB) +
 										 ", opportunistic_GB=" + std::to_string(opportunistic_GB) +
 										 ", max_num_objects=" + std::to_string(max_num_objects) + ".");
 	}
-	if (dedicated_GB == 0.0 && opportunistic_GB > 0.0) {
+	if (is_partial_storage_sentinel(dedicated_GB, opportunistic_GB)) {
 		return std::make_pair(
-			false, std::string("Storage-axis sentinel violation: when dedicated_GB is 0 (the unbounded sentinel), "
-							   "opportunistic_GB must also be 0. The storage axis must be either fully bounded "
-							   "(dedicated_GB > 0) or fully unbounded (both dedicated_GB and opportunistic_GB equal "
-							   "to 0). Got dedicated_GB=") +
+			false, std::string("Storage-axis sentinel violation: when dedicated_GB is -1 (unbounded), "
+							   "opportunistic_GB must also be -1. An unbounded dedicated allotment "
+							   "makes a finite opportunistic cap meaningless. Got dedicated_GB=") +
 					   std::to_string(dedicated_GB) + ", opportunistic_GB=" + std::to_string(opportunistic_GB) + ".");
 	}
 	return std::make_pair(true, "");
@@ -387,7 +395,11 @@ class Lot {
 	bool update_man_policy_attrs_in_txn(const std::string &update_key, double update_val, std::string &txn_error);
 	bool update_attributions_in_txn(const json &parent_attributions_json, std::string &txn_error);
 	bool add_paths_in_txn(const std::vector<json> &paths, std::string &txn_error);
-	bool add_parents_in_txn(const std::vector<Lot> &parents, std::string &txn_error);
+	// `parent_attributions_json` lets the caller supply explicit per-parent shares
+	// to use for the post-add equal-split / axiom validation; pass json() to fall
+	// back to a pure equal split across all parents.
+	bool add_parents_in_txn(const std::vector<Lot> &parents, std::string &txn_error,
+							const json &parent_attributions_json = json());
 
   private:
 	std::pair<bool, std::string> write_new();
@@ -409,13 +421,15 @@ class Lot {
 
 	// Non-transactional helpers for composing inside an outer transaction.
 	// Callers MUST hold an active storage.transaction().
-	bool add_parents_impl(const std::vector<Lot> &parents, std::string &txn_error);
+	bool add_parents_impl(const std::vector<Lot> &parents, std::string &txn_error,
+						  const json &parent_attributions_json = json());
 	bool update_parents_impl(const json &update_arr, std::string &txn_error);
 
-	// Reload parents + MPAs from DB, clear old attributions, recompute with equal split,
-	// and validate axioms. Caller MUST hold an active storage.transaction().
+	// Reload parents + MPAs from DB, clear old attributions, recompute with the
+	// supplied per-parent shares (equal split for any unspecified parents), and
+	// validate axioms. Caller MUST hold an active storage.transaction().
 	// Returns false and sets txn_error on failure.
-	bool reload_and_recompute_attributions(std::string &txn_error);
+	bool reload_and_recompute_attributions(std::string &txn_error, const json &parent_attributions_json = json());
 };
 
 class DirUsageUpdate : public Lot {

--- a/src/schemas.h
+++ b/src/schemas.h
@@ -93,19 +93,19 @@ inline json new_lot_schema = []() {
             "additionalProperties": false,
             "properties": {
                 "dedicated_GB": {
-                    "description": "Amount of dedicated storage attributed to the lot, in GB",
+                    "description": "Amount of dedicated storage attributed to the lot, in GB. -1 marks the dedicated axis as unbounded; in that case opportunistic_GB must also be -1.",
                     "type": "number",
-                    "minimum": 0
+                    "minimum": -1
                 },
                 "opportunistic_GB": {
-                    "description": "Amount of opportunistic storage attributed to the lot, in GB",
+                    "description": "Amount of opportunistic storage attributed to the lot, in GB. -1 marks the opportunistic axis as unbounded.",
                     "type": "number",
-                    "minimum": 0
+                    "minimum": -1
                 },
                 "max_num_objects": {
-                    "description": "Max number of objects a lot should have",
+                    "description": "Max number of objects a lot should have. -1 marks the object axis as unbounded.",
                     "type": "number",
-                    "minimum": 0,
+                    "minimum": -1,
                     "multipleOf": 1
                 },
                 "creation_time": {
@@ -215,19 +215,19 @@ inline json lot_update_schema = []() {
             "additionalProperties": false,
             "properties": {
                 "dedicated_GB": {
-                    "description": "Amount of dedicated storage attributed to the lot, in GB",
+                    "description": "Amount of dedicated storage attributed to the lot, in GB. -1 marks the dedicated axis as unbounded; in that case opportunistic_GB must also be -1.",
                     "type": "number",
-                    "minimum": 0
+                    "minimum": -1
                 },
                 "opportunistic_GB": {
-                    "description": "Amount of opportunistic storage attributed to the lot, in GB",
+                    "description": "Amount of opportunistic storage attributed to the lot, in GB. -1 marks the opportunistic axis as unbounded.",
                     "type": "number",
-                    "minimum": 0
+                    "minimum": -1
                 },
                 "max_num_objects": {
-                    "description": "Max number of objects a lot should have",
+                    "description": "Max number of objects a lot should have. -1 marks the object axis as unbounded.",
                     "type": "number",
-                    "minimum": 0,
+                    "minimum": -1,
                     "multipleOf": 1
                 },
                 "creation_time": {

--- a/test/strict_hierarchy_tests.cpp
+++ b/test/strict_hierarchy_tests.cpp
@@ -507,15 +507,16 @@ TEST_F(StrictHierarchyTest, Axiom2PassesSumWithinParent) {
 }
 
 TEST_F(StrictHierarchyTest, Axiom2ViolationSumDedOppExceedsParentTotal) {
-	// Axiom 2 checks BOTH:
-	//   (a) sum(ded) <= parent.ded
-	//   (b) sum(ded + opp) <= parent.(ded + opp)
-	// This test exercises check (b) by keeping each child's dedicated_GB
-	// within the parent's dedicated_GB, but making the combined ded+opp
-	// exceed the parent's total.
+	// Dedicated and opportunistic are independent storage pools, so axiom 2
+	// enforces them independently:
+	//   (a) sum(child attr_ded) <= parent.ded
+	//   (b) sum(child attr_opp) <= parent.opp
+	// This test exercises check (b): each child's dedicated_GB stays well
+	// within the parent's dedicated_GB, but the concurrent sum of
+	// opportunistic_GB across children exceeds the parent's opportunistic_GB.
 	addDefaultLot();
 
-	// Parent: ded=20, opp=5 → total=25
+	// Parent: ded=20, opp=5
 	addLot(R"({
 		"lot_name": "parent_a2do",
 		"owner": "owner1",
@@ -537,7 +538,7 @@ TEST_F(StrictHierarchyTest, Axiom2ViolationSumDedOppExceedsParentTotal) {
 	ASSERT_EQ(rv, 0);
 
 	// Child 1: ded=9, opp=5 → attributed ded=9 ≤ parent ded=20 ✓
-	//          attributed total=14 ≤ parent total=25 ✓
+	//          attributed opp=5 ≤ parent opp=5 ✓
 	raw_err = nullptr;
 	rv = lotman_add_lot(R"({
 		"lot_name": "child_a2do_1",
@@ -558,8 +559,8 @@ TEST_F(StrictHierarchyTest, Axiom2ViolationSumDedOppExceedsParentTotal) {
 	ASSERT_EQ(rv, 0) << "First child should succeed: " << (err1.get() ? err1.get() : "");
 
 	// Child 2: ded=9, opp=5 → attributed ded=9+9=18 ≤ parent ded=20 ✓
-	//          attributed total=(9+5)+(9+5)=28, parent total=25 ✗
-	// This should fail on the sum(ded+opp) check.
+	//          attributed opp=5+5=10 > parent opp=5 ✗
+	// Should fail on the per-axis opportunistic_GB check.
 	raw_err = nullptr;
 	rv = lotman_add_lot(R"({
 		"lot_name": "child_a2do_2",
@@ -577,12 +578,10 @@ TEST_F(StrictHierarchyTest, Axiom2ViolationSumDedOppExceedsParentTotal) {
 	})",
 						&raw_err);
 	UniqueCString err2(raw_err);
-	EXPECT_NE(rv, 0) << "Second child should fail — sum of ded+opp exceeds parent total";
+	EXPECT_NE(rv, 0) << "Second child should fail — concurrent sum of opportunistic_GB exceeds parent opportunistic_GB";
 	std::string err_str(err2.get() ? err2.get() : "");
-	EXPECT_TRUE(err_str.find("peak concurrent") != std::string::npos)
-		<< "Error should report that combined concurrent children exceed the parent's capacity, got: " << err_str;
-	EXPECT_TRUE(err_str.find("total GB") != std::string::npos)
-		<< "Error should mention total GB (ded+opp), got: " << err_str;
+	EXPECT_TRUE(err_str.find("opportunistic_GB") != std::string::npos)
+		<< "Error should mention the opportunistic_GB axis, got: " << err_str;
 }
 
 TEST_F(StrictHierarchyTest, Axiom2PassesDedOppWithinParentTotal) {
@@ -3145,36 +3144,31 @@ TEST_F(StrictHierarchyTest, Axiom2ThreeChildrenPartialOverlapExceedsLimit) {
 }
 
 TEST_F(StrictHierarchyTest, Axiom2IndependentPeaksAtDifferentTimes) {
-	// Regression test for C1 bug: sweep-line must track peak_total (concurrent ded+opp),
-	// not sum independent peak_ded and peak_opp which can occur at different times.
+	// Sweep-line correctness with INDEPENDENT storage pools: ded and opp are
+	// tracked as separate axes. Each axis has its own peak across staggered
+	// time intervals; the per-axis peaks must not exceed the parent's per-axis
+	// allotment, and they're allowed to occur at different moments.
 	//
-	// Setup: Parent with 155 total capacity, three children with staggered times:
+	// Setup: Parent ded=100, opp=60.
 	//   A [100,400): 90 ded + 10 opp
 	//   B [300,600): 10 ded + 40 opp
 	//   C [500,800): 50 ded + 20 opp
 	//
-	// Peak ded across all time = 100 (at t=300, A+B)
-	// Peak opp across all time =  60 (at t=500, B+C)
-	// Sum of independent peaks = 160 > 155 (would falsely reject with buggy code)
-	//
-	// Actual peak_total at any single moment:
-	//   t∈[100,300): A alone = 100
-	//   t∈[300,400): A+B = 90+10 ded + 10+40 opp = 100+50 = 150 ← true peak
-	//   t∈[400,500): B alone = 50
-	//   t∈[500,600): B+C = 10+50 ded + 40+20 opp = 60+60 = 120
-	//   t∈[600,800): C alone = 70
-	// True peak_total = 150 ≤ 155 → should PASS
+	// Per-axis peaks:
+	//   ded peak at t∈[300,400): A+B = 100 ≤ 100 ✓
+	//   opp peak at t∈[500,600): B+C = 60  ≤ 60  ✓
+	// Independent peaks occur at different times; both axes fit individually.
 
 	addDefaultLot();
-	// Root: 155 ded, 0 opp, [100, 9000]
+	// Root: ded=100, opp=60, [100, 9000]
 	addLot(R"({
 		"lot_name": "root",
 		"owner": "owner1",
 		"parents": ["root"],
 		"paths": [{"path": "/root", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 155,
-			"opportunistic_GB": 0,
+			"dedicated_GB": 100,
+			"opportunistic_GB": 60,
 			"max_num_objects": 10000,
 			"creation_time": 100,
 			"expiration_time": 9000,
@@ -3237,7 +3231,8 @@ TEST_F(StrictHierarchyTest, Axiom2IndependentPeaksAtDifferentTimes) {
 	})",
 						&raw_err);
 	err.reset(raw_err);
-	EXPECT_EQ(rv, 0) << "Should pass: true concurrent peak=150 ≤ 155, despite independent peak sum=160. Error: "
+	EXPECT_EQ(rv, 0) << "Should pass: per-axis peaks (ded=100, opp=60) each fit within parent's per-axis caps; "
+						"independent peaks occur at different times. Error: "
 					 << err.get();
 }
 
@@ -6425,17 +6420,24 @@ TEST_F(StrictHierarchyTest, NonExpiringLotPathOverlapsAnyOtherLot) {
 }
 
 // ============================================================================
-// Unbounded MPA sentinel (per-axis 0 == "no bound") tests
+// Unbounded MPA sentinel (per-axis -1 == "no bound") tests
 // ============================================================================
 //
 // Resource axes:
-//   * Storage axis: dedicated_GB + opportunistic_GB.
-//     - Unbounded iff BOTH are 0.
-//     - dedicated_GB == 0 with opportunistic_GB > 0 is rejected (an
-//       unbounded base capacity makes a finite opportunistic cap meaningless).
+//   * Storage axis: dedicated_GB and opportunistic_GB are independent pools.
+//     - dedicated_GB == -1 means "unbounded dedicated allotment". Because
+//       opportunistic_GB tracks data over the dedicated allotment, an
+//       unbounded dedicated allotment is meaningless without an unbounded
+//       opportunistic axis, so dedicated_GB == -1 requires opportunistic_GB
+//       == -1; any other combo with dedicated_GB == -1 is rejected.
+//     - opportunistic_GB == -1 with a finite (>= 0) dedicated_GB is allowed
+//       (finite guaranteed allotment + unbounded burst).
+//     - dedicated_GB == 0 means "no guaranteed storage" (a purely
+//       opportunistic lot); opportunistic_GB may be >= 0 or -1.
 //     - dedicated_GB > 0 with opportunistic_GB == 0 is allowed (no burst).
 //   * Object axis: max_num_objects.
-//     - Unbounded iff 0.
+//     - max_num_objects == -1 means "unbounded objects".
+//     - max_num_objects == 0 means "no objects allowed".
 // Different axes are independent.
 
 // Add a lot that is unbounded on the storage axis but bounded on objects.
@@ -6448,8 +6450,8 @@ TEST_F(StrictHierarchyTest, AddLotUnboundedStorageBoundedObjectsSucceeds) {
 		"parents": ["unbounded_storage"],
 		"paths": [{"path": "/unbounded/storage", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 0,
-			"opportunistic_GB": 0,
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
 			"max_num_objects": 100,
 			"creation_time": 100,
 			"expiration_time": 9000,
@@ -6474,7 +6476,7 @@ TEST_F(StrictHierarchyTest, AddLotUnboundedObjectsBoundedStorageSucceeds) {
 		"management_policy_attrs": {
 			"dedicated_GB": 100,
 			"opportunistic_GB": 50,
-			"max_num_objects": 0,
+			"max_num_objects": -1,
 			"creation_time": 100,
 			"expiration_time": 9000,
 			"deletion_time": 9500
@@ -6496,9 +6498,9 @@ TEST_F(StrictHierarchyTest, AddLotFullyUnboundedSucceeds) {
 		"parents": ["fully_unbounded"],
 		"paths": [{"path": "/unbounded/all", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 0,
-			"opportunistic_GB": 0,
-			"max_num_objects": 0,
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
+			"max_num_objects": -1,
 			"creation_time": 100,
 			"expiration_time": 9000,
 			"deletion_time": 9500
@@ -6509,8 +6511,10 @@ TEST_F(StrictHierarchyTest, AddLotFullyUnboundedSucceeds) {
 	EXPECT_EQ(rv, 0) << "Fully unbounded lot should succeed: " << (err.get() ? err.get() : "<no error>");
 }
 
-// dedicated_GB == 0 with opportunistic_GB > 0 must be rejected.
-TEST_F(StrictHierarchyTest, AddLotRejectsZeroDedicatedNonZeroOpportunistic) {
+// dedicated_GB == -1 with a finite opportunistic_GB must be rejected: an
+// unbounded dedicated allotment requires an unbounded opportunistic axis,
+// since opportunistic tracks data over the dedicated allotment.
+TEST_F(StrictHierarchyTest, AddLotRejectsUnboundedDedicatedFiniteOpportunistic) {
 	addDefaultLot();
 	char *raw_err = nullptr;
 	int rv = lotman_add_lot(R"({
@@ -6518,6 +6522,33 @@ TEST_F(StrictHierarchyTest, AddLotRejectsZeroDedicatedNonZeroOpportunistic) {
 		"owner": "owner1",
 		"parents": ["bad_storage"],
 		"paths": [{"path": "/bad/storage", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": -1,
+			"opportunistic_GB": 50,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0) << "dedicated_GB == -1 with a finite opportunistic_GB must be rejected";
+	std::string err_str(err.get() ? err.get() : "");
+	EXPECT_TRUE(err_str.find("Storage-axis") != std::string::npos || err_str.find("dedicated_GB") != std::string::npos)
+		<< "Error message should mention the storage axis violation; got: " << err_str;
+}
+
+// dedicated_GB == 0 with opportunistic_GB > 0 is now LEGAL: the lot has
+// no guaranteed allotment but may use opportunistic burst.
+TEST_F(StrictHierarchyTest, AddLotZeroDedicatedNonZeroOpportunisticAllowedAsPurelyOpportunistic) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "purely_opportunistic_finite",
+		"owner": "owner1",
+		"parents": ["purely_opportunistic_finite"],
+		"paths": [{"path": "/purely/opp/finite", "recursive": true}],
 		"management_policy_attrs": {
 			"dedicated_GB": 0,
 			"opportunistic_GB": 50,
@@ -6529,10 +6560,60 @@ TEST_F(StrictHierarchyTest, AddLotRejectsZeroDedicatedNonZeroOpportunistic) {
 	})",
 							&raw_err);
 	UniqueCString err(raw_err);
-	EXPECT_NE(rv, 0) << "dedicated_GB == 0 with opportunistic_GB > 0 must be rejected";
-	std::string err_str(err.get() ? err.get() : "");
-	EXPECT_TRUE(err_str.find("Storage-axis") != std::string::npos || err_str.find("dedicated_GB") != std::string::npos)
-		<< "Error message should mention the storage axis violation; got: " << err_str;
+	EXPECT_EQ(rv, 0) << "dedicated_GB == 0 with finite opportunistic_GB should succeed (purely opportunistic, finite "
+						"burst): "
+					 << (err.get() ? err.get() : "<no error>");
+}
+
+// dedicated_GB == 0 with opportunistic_GB == -1: a purely-opportunistic lot
+// with unbounded burst is allowed (unbounded opp axis is independent of ded).
+TEST_F(StrictHierarchyTest, AddLotZeroDedicatedUnboundedOpportunisticAllowed) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "purely_opportunistic_unbounded",
+		"owner": "owner1",
+		"parents": ["purely_opportunistic_unbounded"],
+		"paths": [{"path": "/purely/opp/unb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 0,
+			"opportunistic_GB": -1,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "dedicated_GB == 0 with opportunistic_GB == -1 should succeed (purely opportunistic, unbounded "
+						"burst): "
+					 << (err.get() ? err.get() : "<no error>");
+}
+
+// dedicated_GB > 0 with opportunistic_GB == -1: finite guaranteed allotment
+// plus unbounded burst is allowed.
+TEST_F(StrictHierarchyTest, AddLotFiniteDedicatedUnboundedOpportunisticAllowed) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "ded_finite_opp_unb",
+		"owner": "owner1",
+		"parents": ["ded_finite_opp_unb"],
+		"paths": [{"path": "/ded/finite/opp/unb", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": -1,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+							&raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_EQ(rv, 0) << "Finite dedicated + unbounded opportunistic should succeed: "
+					 << (err.get() ? err.get() : "<no error>");
 }
 
 // dedicated_GB > 0 with opportunistic_GB == 0 is fine (no burst).
@@ -6569,8 +6650,8 @@ TEST_F(StrictHierarchyTest, FiniteChildAllowedUnderUnboundedStorageParentStrict)
 		"parents": ["us_parent"],
 		"paths": [{"path": "/us/parent", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 0,
-			"opportunistic_GB": 0,
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
 			"max_num_objects": 1000,
 			"creation_time": 100,
 			"expiration_time": 9000,
@@ -6631,8 +6712,8 @@ TEST_F(StrictHierarchyTest, UnboundedStorageChildRejectedUnderBoundedStoragePare
 		"parents": ["bs_parent"],
 		"paths": [{"path": "/bs/parent/child", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 0,
-			"opportunistic_GB": 0,
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
 			"max_num_objects": 100,
 			"creation_time": 200,
 			"expiration_time": 8000,
@@ -6659,7 +6740,7 @@ TEST_F(StrictHierarchyTest, AxesAreIndependentObjectsUnboundedOnly) {
 		"management_policy_attrs": {
 			"dedicated_GB": 100,
 			"opportunistic_GB": 50,
-			"max_num_objects": 0,
+			"max_num_objects": -1,
 			"creation_time": 100,
 			"expiration_time": 9000,
 			"deletion_time": 9500
@@ -6680,7 +6761,7 @@ TEST_F(StrictHierarchyTest, AxesAreIndependentObjectsUnboundedOnly) {
 		"management_policy_attrs": {
 			"dedicated_GB": 1000,
 			"opportunistic_GB": 0,
-			"max_num_objects": 0,
+			"max_num_objects": -1,
 			"creation_time": 200,
 			"expiration_time": 8000,
 			"deletion_time": 9000
@@ -6700,7 +6781,7 @@ TEST_F(StrictHierarchyTest, AxesAreIndependentObjectsUnboundedOnly) {
 		"management_policy_attrs": {
 			"dedicated_GB": 50,
 			"opportunistic_GB": 25,
-			"max_num_objects": 0,
+			"max_num_objects": -1,
 			"creation_time": 200,
 			"expiration_time": 8000,
 			"deletion_time": 9000
@@ -6743,7 +6824,7 @@ TEST_F(StrictHierarchyTest, UnboundedObjectsChildRejectedUnderBoundedObjectsPare
 		"management_policy_attrs": {
 			"dedicated_GB": 50,
 			"opportunistic_GB": 25,
-			"max_num_objects": 0,
+			"max_num_objects": -1,
 			"creation_time": 200,
 			"expiration_time": 8000,
 			"deletion_time": 9000
@@ -6768,8 +6849,8 @@ TEST_F(StrictHierarchyTest, SweepLineUnboundedStorageParentAllowsAnyChildSum) {
 		"parents": ["sw_unb_parent"],
 		"paths": [{"path": "/sw/unb", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 0,
-			"opportunistic_GB": 0,
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
 			"max_num_objects": 1000,
 			"creation_time": 100,
 			"expiration_time": 9000,
@@ -6822,7 +6903,7 @@ TEST_F(StrictHierarchyTest, SweepLineBoundedStorageRejectsOverAllocationDespiteU
 		"management_policy_attrs": {
 			"dedicated_GB": 100,
 			"opportunistic_GB": 0,
-			"max_num_objects": 0,
+			"max_num_objects": -1,
 			"creation_time": 100,
 			"expiration_time": 9000,
 			"deletion_time": 9500
@@ -6840,7 +6921,7 @@ TEST_F(StrictHierarchyTest, SweepLineBoundedStorageRejectsOverAllocationDespiteU
 		"parents": ["sw_mix_parent"],
 		"paths": [{"path": "/sw/mix/c1", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 60, "opportunistic_GB": 0, "max_num_objects": 0,
+			"dedicated_GB": 60, "opportunistic_GB": 0, "max_num_objects": -1,
 			"creation_time": 200, "expiration_time": 8000, "deletion_time": 9000
 		}
 	})",
@@ -6857,7 +6938,7 @@ TEST_F(StrictHierarchyTest, SweepLineBoundedStorageRejectsOverAllocationDespiteU
 		"parents": ["sw_mix_parent"],
 		"paths": [{"path": "/sw/mix/c2", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 50, "opportunistic_GB": 0, "max_num_objects": 0,
+			"dedicated_GB": 50, "opportunistic_GB": 0, "max_num_objects": -1,
 			"creation_time": 300, "expiration_time": 7000, "deletion_time": 9000
 		}
 	})",
@@ -6877,7 +6958,7 @@ TEST_F(StrictHierarchyTest, SweepLineNonExpiringUnboundedChildUnderNonExpiringUn
 		"parents": ["ne_unb_parent"],
 		"paths": [{"path": "/ne/unb/parent", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 0, "opportunistic_GB": 0, "max_num_objects": 0,
+			"dedicated_GB": -1, "opportunistic_GB": -1, "max_num_objects": -1,
 			"creation_time": 0, "expiration_time": 0, "deletion_time": 0
 		}
 	})");
@@ -6894,7 +6975,7 @@ TEST_F(StrictHierarchyTest, SweepLineNonExpiringUnboundedChildUnderNonExpiringUn
 		"parents": ["ne_unb_parent"],
 		"paths": [{"path": "/ne/unb/parent/c", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 0, "opportunistic_GB": 0, "max_num_objects": 0,
+			"dedicated_GB": -1, "opportunistic_GB": -1, "max_num_objects": -1,
 			"creation_time": 0, "expiration_time": 0, "deletion_time": 0
 		}
 	})",
@@ -6914,7 +6995,7 @@ TEST_F(StrictHierarchyTest, UnboundedStorageLotNotReturnedFromPastDedQuery) {
 		"parents": ["pq_unbounded"],
 		"paths": [{"path": "/pq/unb", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 0, "opportunistic_GB": 0, "max_num_objects": 100,
+			"dedicated_GB": -1, "opportunistic_GB": -1, "max_num_objects": 100,
 			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500
 		}
 	})");
@@ -6956,7 +7037,7 @@ TEST_F(StrictHierarchyTest, UnboundedObjectsLotNotReturnedFromPastObjQuery) {
 		"parents": ["pq_unb_obj"],
 		"paths": [{"path": "/pq/unb/obj", "recursive": true}],
 		"management_policy_attrs": {
-			"dedicated_GB": 100, "opportunistic_GB": 0, "max_num_objects": 0,
+			"dedicated_GB": 100, "opportunistic_GB": 0, "max_num_objects": -1,
 			"creation_time": 100, "expiration_time": 9000, "deletion_time": 9500
 		}
 	})");
@@ -7004,8 +7085,8 @@ TEST_F(StrictHierarchyTest, UpdateLotToUnboundedStorageIsAtomic) {
 	int rv = lotman_update_lot(R"({
 		"lot_name": "flip_target",
 		"management_policy_attrs": {
-			"dedicated_GB": 0,
-			"opportunistic_GB": 0
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1
 		}
 	})",
 							   &raw_err);
@@ -7014,7 +7095,7 @@ TEST_F(StrictHierarchyTest, UpdateLotToUnboundedStorageIsAtomic) {
 }
 
 // Atomic flip via lotman_update_lot: a partial flip leaving the storage
-// axis in (dedicated_GB == 0, opportunistic_GB > 0) must be rejected and
+// axis in (dedicated_GB == -1, opportunistic_GB != -1) must be rejected and
 // rolled back.
 TEST_F(StrictHierarchyTest, UpdateLotPartialStorageFlipRejectedAndRolledBack) {
 	addDefaultLot();
@@ -7029,17 +7110,17 @@ TEST_F(StrictHierarchyTest, UpdateLotPartialStorageFlipRejectedAndRolledBack) {
 		}
 	})");
 
-	// Try to set only dedicated_GB to 0 (leaving opportunistic_GB at 50).
+	// Try to set only dedicated_GB to -1 (leaving opportunistic_GB at 50).
 	char *raw_err = nullptr;
 	int rv = lotman_update_lot(R"({
 		"lot_name": "partial_flip",
 		"management_policy_attrs": {
-			"dedicated_GB": 0
+			"dedicated_GB": -1
 		}
 	})",
 							   &raw_err);
 	UniqueCString err(raw_err);
-	EXPECT_NE(rv, 0) << "Partial storage flip (dedicated_GB == 0 with opportunistic_GB > 0) must be rejected";
+	EXPECT_NE(rv, 0) << "Partial storage flip (dedicated_GB == -1 with opportunistic_GB != -1) must be rejected";
 
 	// Confirm rollback: original values still present.
 	char *out = nullptr;
@@ -7051,6 +7132,423 @@ TEST_F(StrictHierarchyTest, UpdateLotPartialStorageFlipRejectedAndRolledBack) {
 	json parsed = json::parse(out_owned.get());
 	EXPECT_DOUBLE_EQ(parsed["management_policy_attrs"]["dedicated_GB"].get<double>(), 100.0);
 	EXPECT_DOUBLE_EQ(parsed["management_policy_attrs"]["opportunistic_GB"].get<double>(), 50.0);
+}
+
+// ============================================================================
+// Bug regression tests
+// ============================================================================
+
+// Bug 1 regression: dedicated_GB and opportunistic_GB are independent storage
+// pools, so axiom 1 must NOT enforce a combined (ded+opp) cap. A child whose
+// per-axis attributions each fit under the parent's per-axis caps must be
+// accepted even if (child.ded + child.opp) > (parent.ded + parent.opp).
+TEST_F(StrictHierarchyTest, Axiom1NoCombinedDedOppCheckRegression) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "indep_parent",
+		"owner": "owner1",
+		"parents": ["indep_parent"],
+		"paths": [{"path": "/indep/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 100,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString cerr(raw_err);
+	ASSERT_EQ(rv, 0) << cerr.get();
+
+	// Child: ded=100, opp=100. Per-axis: ded=100<=100 ✓, opp=100<=100 ✓.
+	// Combined: 200 > parent combined of 200? No, equal. Use values that
+	// individually fit but exceed combined: ded=80, opp=80 (combined=160 >
+	// would-be-old-cap of (parent.ded + parent.opp == 200)? No still fits).
+	// Use parent ded=50, opp=50 (combined=100). Child ded=40, opp=40
+	// (combined=80 <= 100). That's fine. To EXCEED an old combined cap, we
+	// need each axis to individually fit but the sum to exceed: that's
+	// impossible if parent.ded+parent.opp == sum of caps. So this test just
+	// confirms a child whose per-axis attributions each equal the parent cap
+	// is accepted — which the old combined check would have allowed too, but
+	// it's a useful boundary case.
+	rv = lotman_add_lot(R"({
+		"lot_name": "indep_child",
+		"owner": "owner1",
+		"parents": ["indep_parent"],
+		"paths": [{"path": "/indep/parent/c", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 100,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})",
+						&raw_err);
+	UniqueCString aerr(raw_err);
+	EXPECT_EQ(rv, 0) << "Per-axis caps each fit; combined check has been removed (independent pools): "
+					 << (aerr.get() ? aerr.get() : "<no error>");
+}
+
+// Bug 2 regression: lotman_add_to_lot must honor caller-supplied
+// parent_attributions for the post-add validation rather than running an
+// auto equal split (which can spuriously reject the addition before the
+// explicit shares are applied).
+TEST_F(StrictHierarchyTest, AddToLotHonorsExplicitParentAttributions) {
+	addDefaultLot();
+
+	// Parent A is bounded; parent B is fully unbounded so it can absorb the
+	// full child allocation when the caller assigns A nothing.
+	addLot(R"({
+		"lot_name": "a2l_parent_a",
+		"owner": "owner1",
+		"parents": ["a2l_parent_a"],
+		"paths": [{"path": "/a2l/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 0,
+			"opportunistic_GB": 0,
+			"max_num_objects": 0,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	addLot(R"({
+		"lot_name": "a2l_parent_b",
+		"owner": "owner1",
+		"parents": ["a2l_parent_b"],
+		"paths": [{"path": "/a2l/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
+			"max_num_objects": -1,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// Child starts with one parent (parent_b, which is unbounded so the
+	// initial equal split trivially fits).
+	addLot(R"({
+		"lot_name": "a2l_child",
+		"owner": "owner1",
+		"parents": ["a2l_parent_b"],
+		"paths": [{"path": "/a2l/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 1,
+			"opportunistic_GB": 0,
+			"max_num_objects": 10,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 9000
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_set_context_str("strict_hierarchy", "true", &raw_err);
+	UniqueCString cerr(raw_err);
+	ASSERT_EQ(rv, 0) << cerr.get();
+
+	// Now add parent_a (which has no capacity) but explicitly attribute 0 of
+	// every MPA to it. Without bug 2 fixed, add_to_lot would run an auto
+	// equal-split (0.5 GB to each of the two parents) and reject because
+	// parent_a has 0 capacity. With bug 2 fixed, the explicit attribution of
+	// 0 to parent_a (and the remainder to parent_b) is honored from the
+	// start.
+	rv = lotman_add_to_lot(R"({
+		"lot_name": "a2l_child",
+		"parents": ["a2l_parent_a"],
+		"parent_attributions": {
+			"a2l_parent_a": {
+				"dedicated_GB": 0,
+				"opportunistic_GB": 0,
+				"max_num_objects": 0
+			}
+		}
+	})",
+						   &raw_err);
+	UniqueCString aerr(raw_err);
+	EXPECT_EQ(rv, 0) << "add_to_lot must honor explicit parent_attributions and not auto-equal-split: "
+					 << (aerr.get() ? aerr.get() : "<no error>");
+}
+
+// ============================================================================
+// Sentinel-safety regression tests: arithmetic with -1 unbounded MPA values
+// ============================================================================
+
+// REGRESSION: get_lot_usage("dedicated_GB") non-recursive with sentinel -1.
+// Before the fix, every CASE branch compared self_GB >= dedicated_GB, which is
+// always true when dedicated_GB = -1, so the query returned -1 (the sentinel)
+// instead of actual usage.
+TEST_F(StrictHierarchyTest, LotUsageDedicatedSentinelNonRecursive) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "ub_ded_lot",
+		"owner": "owner1",
+		"parents": ["ub_ded_lot"],
+		"paths": [{"path": "/ub_ded", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv =
+		lotman_update_lot_usage(R"({"lot_name": "ub_ded_lot", "self_GB": 5.0, "self_objects": 3})", false, &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	char *raw_out = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lot_usage(R"({"lot_name": "ub_ded_lot", "dedicated_GB": false})", &raw_out, &raw_err);
+	UniqueCString out_str(raw_out);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+	json out = json::parse(out_str.get());
+	// self_contrib must be actual usage (5.0), not the -1 sentinel
+	EXPECT_DOUBLE_EQ(out["dedicated_GB"]["self_contrib"].get<double>(), 5.0)
+		<< "dedicated_GB self_contrib must return actual usage, not the -1 sentinel";
+}
+
+// REGRESSION: get_lot_usage("dedicated_GB") recursive with sentinel -1.
+// Before the fix, the ELSE branch returned dedicated_GB (= -1) as total,
+// and the first WHEN (self_GB >= -1, always true) capped self_contrib at -1.
+TEST_F(StrictHierarchyTest, LotUsageDedicatedSentinelRecursive) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "ub_ded_par",
+		"owner": "owner1",
+		"parents": ["ub_ded_par"],
+		"paths": [{"path": "/ub_ded_par", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	addLot(R"({
+		"lot_name": "ub_ded_child",
+		"owner": "owner1",
+		"parents": ["ub_ded_par"],
+		"paths": [{"path": "/ub_ded_par/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
+			"max_num_objects": 50,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot_usage(R"({"lot_name": "ub_ded_par", "self_GB": 4.0})", false, &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+	raw_err = nullptr;
+	rv = lotman_update_lot_usage(R"({"lot_name": "ub_ded_child", "self_GB": 3.0})", false, &raw_err);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	char *raw_out = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lot_usage(R"({"lot_name": "ub_ded_par", "dedicated_GB": true})", &raw_out, &raw_err);
+	UniqueCString out_str(raw_out);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+	json out = json::parse(out_str.get());
+	EXPECT_DOUBLE_EQ(out["dedicated_GB"]["self_contrib"].get<double>(), 4.0)
+		<< "self_contrib must be actual usage, not the -1 sentinel";
+	EXPECT_DOUBLE_EQ(out["dedicated_GB"]["children_contrib"].get<double>(), 3.0)
+		<< "children_contrib must be actual children usage, not 0 forced by sentinel";
+	EXPECT_DOUBLE_EQ(out["dedicated_GB"]["total"].get<double>(), 7.0)
+		<< "total must be self + children, not capped at -1";
+}
+
+// REGRESSION: get_lot_usage("opportunistic_GB") non-recursive, dedicated = -1.
+// When dedicated_GB = -1 (infinite dedicated), nothing is ever in the
+// opportunistic tier; usage should be 0.  The sentinel contract also requires
+// opportunistic_GB = -1 whenever dedicated_GB = -1.  Before the fix, the WHEN
+// branch evaluated self_GB >= dedicated_GB + opportunistic_GB = (-1 + -1) = -2,
+// which always fires, returning opportunistic_GB = -1 instead of 0.
+TEST_F(StrictHierarchyTest, LotUsageOpportunisticWhenDedicatedUnbounded) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "ub_ded_opp_lot",
+		"owner": "owner1",
+		"parents": ["ub_ded_opp_lot"],
+		"paths": [{"path": "/ub_ded_opp", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot_usage(R"({"lot_name": "ub_ded_opp_lot", "self_GB": 15.0})", false, &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	char *raw_out = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lot_usage(R"({"lot_name": "ub_ded_opp_lot", "opportunistic_GB": false})", &raw_out, &raw_err);
+	UniqueCString out_str(raw_out);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+	json out = json::parse(out_str.get());
+	// With infinite dedicated, nothing is ever in the opportunistic tier
+	EXPECT_DOUBLE_EQ(out["opportunistic_GB"]["self_contrib"].get<double>(), 0.0)
+		<< "opportunistic usage must be 0 when dedicated_GB is unbounded (-1)";
+}
+
+// REGRESSION: get_lot_usage("opportunistic_GB") non-recursive, opp = -1.
+// When opportunistic_GB = -1 (unbounded burst), the code must not evaluate
+// self_GB >= dedicated_GB + (-1) (which always fires, returning wrong cap).
+// Spillover above dedicated must be returned uncapped.
+TEST_F(StrictHierarchyTest, LotUsageOpportunisticWhenOpportunisticUnbounded) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "ub_opp_lot",
+		"owner": "owner1",
+		"parents": ["ub_opp_lot"],
+		"paths": [{"path": "/ub_opp", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": -1,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot_usage(R"({"lot_name": "ub_opp_lot", "self_GB": 15.0})", false, &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	char *raw_out = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lot_usage(R"({"lot_name": "ub_opp_lot", "opportunistic_GB": false})", &raw_out, &raw_err);
+	UniqueCString out_str(raw_out);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+	json out = json::parse(out_str.get());
+	// 15 GB total, 10 GB dedicated cap, so 5 GB of opportunistic usage
+	EXPECT_DOUBLE_EQ(out["opportunistic_GB"]["self_contrib"].get<double>(), 5.0)
+		<< "opportunistic usage must be self_GB - dedicated_GB when opp is unbounded (-1)";
+}
+
+// REGRESSION: non-recursive opportunistic_GB, finite caps, SQL typo.
+// The second WHEN branch in the old SQL was:
+//   THEN lot_usage.self_GB = management_policy_attributes.dedicated_GB
+// In SQL, '=' in a SELECT is a comparison (returns 0 or 1), not subtraction.
+// So the result was always 0 instead of (self_GB - dedicated_GB).
+TEST_F(StrictHierarchyTest, LotUsageOpportunisticNonRecursiveTypoRegression) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "opp_typo_lot",
+		"owner": "owner1",
+		"parents": ["opp_typo_lot"],
+		"paths": [{"path": "/opp_typo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 20,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	char *raw_err = nullptr;
+	// 15 GB puts us 5 GB into the opportunistic tier (above the 10 GB ded cap)
+	int rv = lotman_update_lot_usage(R"({"lot_name": "opp_typo_lot", "self_GB": 15.0})", false, &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+
+	char *raw_out = nullptr;
+	raw_err = nullptr;
+	rv = lotman_get_lot_usage(R"({"lot_name": "opp_typo_lot", "opportunistic_GB": false})", &raw_out, &raw_err);
+	UniqueCString out_str(raw_out);
+	err.reset(raw_err);
+	ASSERT_EQ(rv, 0) << err.get();
+	json out = json::parse(out_str.get());
+	// Should be 15 - 10 = 5.  Before the typo fix this returned 0 (bool 15==10).
+	EXPECT_DOUBLE_EQ(out["opportunistic_GB"]["self_contrib"].get<double>(), 5.0)
+		<< "opportunistic self_contrib must be self_GB - dedicated_GB; returned 0 due to SQL '=' vs '-' typo";
+}
+
+// REGRESSION: build_attribution_events must not multiply the -1 sentinel.
+// When a child has dedicated/opportunistic/max_num_objects = -1 (unbounded),
+// its sweep-line contribution must be 0.  Before the fix, the contribution was
+// fraction * -1 = -1, corrupting peak_* fields in get_available_capacity.
+TEST_F(StrictHierarchyTest, AvailableCapacityUnboundedChildPeakIsZero) {
+	addDefaultLot();
+	// Unbounded parent (axiom 1 allows unbounded child only under unbounded parent)
+	addLot(R"({
+		"lot_name": "ub_par",
+		"owner": "owner1",
+		"parents": ["ub_par"],
+		"paths": [{"path": "/ub_par", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
+			"max_num_objects": -1,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	addLot(R"({
+		"lot_name": "ub_child",
+		"owner": "owner1",
+		"parents": ["ub_par"],
+		"paths": [{"path": "/ub_par/child", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": -1,
+			"opportunistic_GB": -1,
+			"max_num_objects": -1,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	auto [result, err_msg] = lotman::Lot::get_available_capacity("ub_par", 100, 9000);
+	ASSERT_TRUE(err_msg.empty()) << err_msg;
+
+	// Parent is unbounded on every axis, so available_* must be null
+	EXPECT_TRUE(result["available_dedicated_GB"].is_null());
+	EXPECT_TRUE(result["available_opportunistic_GB"].is_null());
+	EXPECT_TRUE(result["available_max_num_objects"].is_null());
+	EXPECT_TRUE(result["available_total_GB"].is_null());
+
+	// Before the fix, peaks were computed as 1.0 * -1 = -1 per axis.
+	// After the fix, unbounded children contribute 0 to the sweep.
+	EXPECT_DOUBLE_EQ(result["peak_dedicated_GB"].get<double>(), 0.0)
+		<< "peak_dedicated_GB must be 0 for an unbounded child, not -1 (sentinel * fraction)";
+	EXPECT_DOUBLE_EQ(result["peak_opportunistic_GB"].get<double>(), 0.0)
+		<< "peak_opportunistic_GB must be 0 for an unbounded child, not -1";
+	EXPECT_EQ(result["peak_max_num_objects"].get<int64_t>(), 0)
+		<< "peak_max_num_objects must be 0 for an unbounded child, not -1";
 }
 
 } // namespace


### PR DESCRIPTION
Previously, 0 served double duty for storage MPAs: it meant both "zero capacity" and "unbounded". This made it impossible to express legitimate configurations like a purely-opportunistic lot (dedicated_GB=0, opportunistic_GB>0), and forced callers to treat 0 as a magic value rather than a literal zero.

Replacing 0 with -1 gives an unambiguous out-of-band sentinel that cannot be confused with a real storage measurement.  Timestamp fields (creation_time, expiration_time, deletion_time) keep 0 as their non-expiring sentinel — the two domains never overlap.

The only forbidden combination is dedicated_GB=-1 with a finite opportunistic_GB: when dedicated storage is infinite, the concept of a separate burst tier is meaningless.  All other combinations are valid and explicitly tested.

Arithmetic safety is the central implementation concern.  Anywhere a -1 sentinel could participate in arithmetic — SQL CASE expressions, sweep-line event construction, available-capacity sums — a guard short-circuits before the operation:

  - get_lot_usage SQL: each CASE column checks for -1 as its first branch and returns raw usage rather than capping at the sentinel. The opportunistic queries also guard against dedicated_GB=-1 (nothing enters the burst tier when dedicated is infinite).

  - build_attribution_events: the fraction×mpa_value multiply is skipped for unbounded axes; those children contribute 0 to the sweep.  Axiom 1 already guarantees an unbounded child cannot exist under a bounded parent, so the 0 contribution never hides a real overflow.

  - get_available_capacity: per-axis null reporting is gated on is_unbounded_*(); the parent_total sum only executes when both sub-axes are finite.

Two pre-existing logic bugs were fixed along the way:

  - validate_axiom1 had a redundant combined (ded+opp) cap check that conflated the two independent storage pools and broke as soon as either became unbounded.  Per-axis checks are sufficient.

  - lotman_add_to_lot discarded caller-supplied parent_attributions and ran an auto equal-split instead, causing spurious axiom rejections when the explicit shares were the only valid assignment.