### PR TITLE
Allow deletion without admin_override under contraction policies

### DIFF
--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -3178,9 +3178,18 @@ std::pair<bool, std::string> lotman::Lot::check_contraction_for_deletion(const s
 	}
 
 	if (contraction_policy == "always") {
-		return std::make_pair(false,
-							  "Contraction policy 'always' blocks deletion of lot '" + lot_name +
-								  "'. Deletion is treated as contraction to zero. Set admin_override to bypass.");
+		// Expired lots are deletable by the appropriate caller without admin_override.
+		// Only alive (non-expired) lots require admin_override under the "always" policy.
+		auto alive_rp = is_lot_alive(lot_name);
+		if (!alive_rp.second.empty()) {
+			return std::make_pair(false,
+								  std::string("Failed contraction policy check for deletion: ") + alive_rp.second);
+		}
+		if (alive_rp.first) {
+			return std::make_pair(false,
+								  "Contraction policy 'always' blocks deletion of lot '" + lot_name +
+									  "'. Deletion is treated as contraction to zero. Set admin_override to bypass.");
+		}
 	}
 
 	if (contraction_policy == "alive") {

--- a/test/strict_hierarchy_tests.cpp
+++ b/test/strict_hierarchy_tests.cpp
@@ -1452,6 +1452,8 @@ TEST_F(StrictHierarchyTest, ContractionBypassedWithAdminOverride) {
 
 TEST_F(StrictHierarchyTest, ContractionBlocksDeletionAlwaysPolicy) {
 	addDefaultLot();
+	// Use a far-future expiration_time so the lot is alive at test time.
+	// The 'always' policy should block deletion of alive lots.
 	addLot(R"({
 		"lot_name": "del_always",
 		"owner": "owner1",
@@ -1461,9 +1463,9 @@ TEST_F(StrictHierarchyTest, ContractionBlocksDeletionAlwaysPolicy) {
 			"dedicated_GB": 50,
 			"opportunistic_GB": 25,
 			"max_num_objects": 500,
-			"creation_time": 100,
-			"expiration_time": 9000,
-			"deletion_time": 9500
+			"creation_time": 1,
+			"expiration_time": 99999999999999,
+			"deletion_time": 99999999999999
 		}
 	})");
 
@@ -1474,9 +1476,41 @@ TEST_F(StrictHierarchyTest, ContractionBlocksDeletionAlwaysPolicy) {
 
 	rv = lotman_remove_lots_recursive("del_always", &raw_err);
 	err.reset(raw_err);
-	EXPECT_NE(rv, 0) << "Lot deletion should be blocked by 'always' contraction policy";
+	EXPECT_NE(rv, 0) << "Deletion of an alive lot should be blocked by 'always' contraction policy";
 	std::string err_str(err.get() ? err.get() : "");
 	EXPECT_TRUE(err_str.find("always") != std::string::npos) << "Error: " << err_str;
+}
+
+TEST_F(StrictHierarchyTest, ExpiredLotDeletableWithoutAdminOverrideUnderAlwaysPolicy) {
+	addDefaultLot();
+	// Lot whose expiration_time is in the distant past — it is expired.
+	addLot(R"({
+		"lot_name": "del_expired",
+		"owner": "owner1",
+		"parents": ["del_expired"],
+		"paths": [{"path": "/del_expired/data", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 50,
+			"opportunistic_GB": 25,
+			"max_num_objects": 500,
+			"creation_time": 1,
+			"expiration_time": 2,
+			"deletion_time": 3
+		}
+	})");
+
+	char *raw_err = nullptr;
+	// Use the most restrictive contraction policy without admin_override.
+	int rv = lotman_set_context_str("contraction_policy", "always", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0);
+
+	// The lot is expired, so the appropriate caller should be able to delete it
+	// without needing admin_override, even under the 'always' contraction policy.
+	rv = lotman_remove_lots_recursive("del_expired", &raw_err);
+	err.reset(raw_err);
+	EXPECT_EQ(rv, 0) << "Expired lot should be deletable without admin_override under 'always' policy: "
+					 << (err.get() ? err.get() : "");
 }
 
 // ============================================================================


### PR DESCRIPTION
The contraction policy system exists to protect alive, in-use lots from having their resource allocations silently shrunk. Deletion is the most extreme form of contraction, but that protection becomes friction when applied to lots that have already expired: by the time expiration_time has passed, the lot's resources are no longer guaranteed and its storage is already considered opportunistic. Requiring admin_override to clean up what the system itself considers transient is an obstacle to normal garbage-collection workflows.

The fix threads the same liveness check that the "alive" policy already uses into the "always" policy's deletion gate. Under both policies, "is this lot currently alive?" is now the deciding question for deletion: alive lots remain protected (admin_override still bypasses), while expired lots are deletable by any appropriately-authorized caller. MPA field updates (dedicated_GB reductions, expiration advances, etc.) are unaffected — "always" still blocks those unconditionally, because a field reduction on an alive lot is a genuine mid-flight contraction.

The existing ContractionBlocksDeletionAlwaysPolicy test was inadvertently using a past expiration timestamp (epoch+9s), so its lot was already expired and would have passed under the new rule for the wrong reason. The test is corrected to use a far-future expiration so it validates what it claims to: that alive lots are still blocked. A companion test, ExpiredLotDeletableWithoutAdminOverrideUnderAlwaysPolicy, covers the new behavior directly.