### PR TITLE
Introduce reclamation as a terminal storage-attribution ledger fact

### DIFF
--- a/src/lotman.cpp
+++ b/src/lotman.cpp
@@ -42,6 +42,36 @@ const char *lotman_version() {
 	return version.c_str();
 }
 
+namespace {
+// Returns 0 if `lot_name` is not reclaimed (or the lot does not exist; in
+// which case the caller's lot_exists check handles the not-found error).
+// Returns -1 with err_msg populated when the lot has a reclamation row whose
+// reclaimed_at <= now -- mutating APIs must reject in that case so the
+// historical accounting record is preserved.
+//
+// TODO: Do functions like this need a temporal signature so someone can check reclamation in the future?
+int reject_if_reclaimed(const std::string &lot_name, const char *op, char **err_msg) {
+	auto now = std::chrono::system_clock::now();
+	int64_t now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch().count();
+	auto rp = lotman::Lot::is_reclaimed(lot_name, now_ms);
+	if (!rp.second.empty()) {
+		if (err_msg) {
+			std::string msg = std::string("Failure on call to is_reclaimed while attempting ") + op + ": " + rp.second;
+			*err_msg = strdup(msg.c_str());
+		}
+		return -1;
+	}
+	if (rp.first) {
+		if (err_msg) {
+			std::string msg = "Lot '" + lot_name + "' is reclaimed and cannot be modified (operation: " + op + ").";
+			*err_msg = strdup(msg.c_str());
+		}
+		return -1;
+	}
+	return 0;
+}
+} // namespace
+
 int lotman_add_lot(const char *lotman_JSON_str, char **err_msg) {
 	try {
 		json lot_JSON_obj = json::parse(lotman_JSON_str);
@@ -96,6 +126,19 @@ int lotman_add_lot(const char *lotman_JSON_str, char **err_msg) {
 		json parent_attributions;
 		if (lot_JSON_obj.contains("parent_attributions") && !lot_JSON_obj["parent_attributions"].is_null()) {
 			parent_attributions = lot_JSON_obj["parent_attributions"];
+		}
+
+		// Reclamation is a terminal ledger fact: a reclaimed lot's subtree has
+		// been "released" back to the default lot. Adding a live child under a
+		// reclaimed parent would resurrect that subtree and violate the
+		// invariant that reclaimed storage is hoovered into default. Reject.
+		for (const auto &parent_name : lot.parents) {
+			if (parent_name == lot.lot_name) {
+				continue; // Self-parent is a root marker, not an actual ancestor edge.
+			}
+			if (reject_if_reclaimed(parent_name, "lotman_add_lot", err_msg) != 0) {
+				return -1;
+			}
 		}
 
 		// Check for context and make sure caller is allowed to add the lot as specified
@@ -283,6 +326,72 @@ int lotman_remove_lots_recursive(const char *lot_name, char **err_msg) {
 	}
 }
 
+int lotman_reclaim_lot(const char *lot_name, int64_t reclaimed_at, const char *reason, char **err_msg) {
+	try {
+		if (!lot_name) {
+			if (err_msg) {
+				*err_msg = strdup("lot_name must not be a null pointer.");
+			}
+			return -1;
+		}
+		if (reclaimed_at <= 0) {
+			if (err_msg) {
+				*err_msg = strdup("reclaimed_at must be a positive Unix timestamp in milliseconds.");
+			}
+			return -1;
+		}
+		std::string lot_name_s{lot_name};
+		std::string reason_s = reason ? std::string{reason} : std::string{};
+
+		auto rp = lotman::Lot::lot_exists(lot_name_s);
+		if (!rp.first) {
+			if (err_msg) {
+				if (rp.second.empty()) {
+					*err_msg = strdup("Lot does not exist, so it cannot be reclaimed.");
+				} else {
+					std::string int_err = rp.second;
+					std::string ext_err = "Function call to lotman::Lot::lot_exists failed: ";
+					*err_msg = strdup((ext_err + int_err).c_str());
+				}
+			}
+			return -1;
+		}
+
+		lotman::Lot lot(lot_name_s);
+
+		// Authorization: caller must own the lot, defined the same way as
+		// lotman_remove_lots_recursive (caller owns at least one of its parents,
+		// or owns it via self-parent). Authorization to the root authorizes the
+		// cascade.
+		lot.get_parents(true, true);
+		rp = lot.check_context_for_parents(lot.recursive_parents, true);
+		if (!rp.first) {
+			if (err_msg) {
+				std::string int_err = rp.second;
+				std::string ext_err = "Error while checking context for parents: ";
+				*err_msg = strdup((ext_err + int_err).c_str());
+			}
+			return -1;
+		}
+
+		auto reclaim_rp = lot.reclaim_lot_with_descendants(reclaimed_at, reason_s);
+		if (reclaim_rp.first == LOTMAN_RECLAIM_ERROR) {
+			if (err_msg) {
+				std::string int_err = reclaim_rp.second;
+				std::string ext_err = "Failed to reclaim lot: ";
+				*err_msg = strdup((ext_err + int_err).c_str());
+			}
+			return LOTMAN_RECLAIM_ERROR;
+		}
+		return reclaim_rp.first;
+	} catch (std::exception &exc) {
+		if (err_msg) {
+			*err_msg = strdup(exc.what());
+		}
+		return LOTMAN_RECLAIM_ERROR;
+	}
+}
+
 int lotman_update_lot(const char *lotman_JSON_str, char **err_msg) {
 	try {
 		json update_JSON_obj = json::parse(lotman_JSON_str);
@@ -319,6 +428,10 @@ int lotman_update_lot(const char *lotman_JSON_str, char **err_msg) {
 				std::string ext_err = "Error while checking context for parents: ";
 				*err_msg = strdup((ext_err + int_err).c_str());
 			}
+			return -1;
+		}
+
+		if (reject_if_reclaimed(lot.lot_name, "lotman_update_lot", err_msg) != 0) {
 			return -1;
 		}
 
@@ -474,6 +587,10 @@ int lotman_rm_parents_from_lot(const char *lotman_JSON_str, char **err_msg) {
 			return -1;
 		}
 
+		if (reject_if_reclaimed(lot.lot_name, "lotman_rm_parents_from_lot", err_msg) != 0) {
+			return -1;
+		}
+
 		rp = lot.remove_parents(subtraction_JSON_obj["parents"]);
 		if (!rp.first) {
 			if (err_msg) {
@@ -553,6 +670,10 @@ int lotman_rm_paths_from_lots(const char *lotman_JSON_str, char **err_msg) {
 					return -1;
 				}
 
+				if (reject_if_reclaimed(matching_lot_name, "lotman_rm_paths_from_lots", err_msg) != 0) {
+					return -1;
+				}
+
 				removals.push_back({matching_lot_name, path_str});
 			}
 		}
@@ -628,6 +749,10 @@ int lotman_add_to_lot(const char *lotman_JSON_str, char **err_msg) {
 				std::string ext_err = "Error while checking context for parents: ";
 				*err_msg = strdup((ext_err + int_err).c_str());
 			}
+			return -1;
+		}
+
+		if (reject_if_reclaimed(lot.lot_name, "lotman_add_to_lot", err_msg) != 0) {
 			return -1;
 		}
 
@@ -1113,6 +1238,10 @@ int lotman_update_lot_usage(const char *update_JSON_str, bool deltaMode, char **
 			return -1;
 		}
 
+		if (reject_if_reclaimed(lot.lot_name, "lotman_update_lot_usage", err_msg) != 0) {
+			return -1;
+		}
+
 		for (const auto &pair : update_usage_JSON.items()) {
 			if (pair.key() != "lot_name") {
 				rp = lot.update_self_usage(pair.key(), pair.value(), deltaMode);
@@ -1245,7 +1374,7 @@ int lotman_check_db_health(char **err_msg) {
 	return -1;
 }
 
-int lotman_get_lots_past_exp(const bool recursive, char ***output, char **err_msg) {
+int lotman_get_lots_past_exp(const bool recursive, const bool include_reclaimed, char ***output, char **err_msg) {
 	try {
 		auto rp_bool_str = lotman::Lot::update_db_children_usage();
 		if (!rp_bool_str.first) {
@@ -1257,7 +1386,7 @@ int lotman_get_lots_past_exp(const bool recursive, char ***output, char **err_ms
 			return -1;
 		}
 
-		auto rp = lotman::Lot::get_lots_past_exp(recursive);
+		auto rp = lotman::Lot::get_lots_past_exp(recursive, include_reclaimed);
 		if (!rp.second.empty()) {
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -1292,7 +1421,7 @@ int lotman_get_lots_past_exp(const bool recursive, char ***output, char **err_ms
 	}
 }
 
-int lotman_get_lots_past_del(const bool recursive, char ***output, char **err_msg) {
+int lotman_get_lots_past_del(const bool recursive, const bool include_reclaimed, char ***output, char **err_msg) {
 	try {
 		auto rp_bool_str = lotman::Lot::update_db_children_usage();
 		if (!rp_bool_str.first) {
@@ -1304,7 +1433,7 @@ int lotman_get_lots_past_del(const bool recursive, char ***output, char **err_ms
 			return -1;
 		}
 
-		auto rp = lotman::Lot::get_lots_past_del(recursive);
+		auto rp = lotman::Lot::get_lots_past_del(recursive, include_reclaimed);
 		if (!rp.second.empty()) {
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -1340,8 +1469,8 @@ int lotman_get_lots_past_del(const bool recursive, char ***output, char **err_ms
 	}
 }
 
-int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_children, char ***output,
-							 const bool hierarchical, char **err_msg) {
+int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_children, const bool include_reclaimed,
+							 char ***output, const bool hierarchical, char **err_msg) {
 	try {
 		auto rp_bool_str = lotman::Lot::update_db_children_usage();
 		if (!rp_bool_str.first) {
@@ -1353,7 +1482,7 @@ int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_ch
 			return -1;
 		}
 
-		auto rp = lotman::Lot::get_lots_past_opp(recursive_quota, recursive_children, hierarchical);
+		auto rp = lotman::Lot::get_lots_past_opp(recursive_quota, recursive_children, include_reclaimed, hierarchical);
 		if (!rp.second.empty()) {
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -1389,8 +1518,8 @@ int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_ch
 	}
 }
 
-int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_children, char ***output,
-							 const bool hierarchical, char **err_msg) {
+int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_children, const bool include_reclaimed,
+							 char ***output, const bool hierarchical, char **err_msg) {
 	try {
 		auto rp_bool_str = lotman::Lot::update_db_children_usage();
 		if (!rp_bool_str.first) {
@@ -1402,7 +1531,7 @@ int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_ch
 			return -1;
 		}
 
-		auto rp = lotman::Lot::get_lots_past_ded(recursive_quota, recursive_children, hierarchical);
+		auto rp = lotman::Lot::get_lots_past_ded(recursive_quota, recursive_children, include_reclaimed, hierarchical);
 		if (!rp.second.empty()) {
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -1438,8 +1567,8 @@ int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_ch
 	}
 }
 
-int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_children, char ***output,
-							 const bool hierarchical, char **err_msg) {
+int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_children, const bool include_reclaimed,
+							 char ***output, const bool hierarchical, char **err_msg) {
 	try {
 		auto rp_bool_str = lotman::Lot::update_db_children_usage();
 		if (!rp_bool_str.first) {
@@ -1451,7 +1580,7 @@ int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_ch
 			return -1;
 		}
 
-		auto rp = lotman::Lot::get_lots_past_obj(recursive_quota, recursive_children, hierarchical);
+		auto rp = lotman::Lot::get_lots_past_obj(recursive_quota, recursive_children, include_reclaimed, hierarchical);
 		if (!rp.second.empty()) {
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -1749,6 +1878,26 @@ int lotman_get_lot_as_json(const char *lot_name, const bool recursive, char **ou
 				return -1;
 			}
 			output_obj["parent_attributions"] = rp_attr.first;
+		}
+
+		// Reclamation: emit the ledger row when one exists. Future-dated
+		// reclamations are still surfaced here so callers can see scheduled
+		// reclaim events; runtime filters elsewhere apply `reclaimed_at <= now`.
+		try {
+			auto &storage = lotman::db::StorageManager::get_storage();
+			auto reclaim_row = storage.get_pointer<lotman::db::Reclamation>(lot_name);
+			if (reclaim_row) {
+				json r;
+				r["reclaimed_at"] = reclaim_row->reclaimed_at;
+				r["reason"] = reclaim_row->reclaimed_reason;
+				output_obj["reclamation"] = r;
+			}
+		} catch (const std::exception &e) {
+			if (err_msg) {
+				std::string msg = std::string("Failure on reclamation lookup: ") + e.what();
+				*err_msg = strdup(msg.c_str());
+			}
+			return -1;
 		}
 
 		// Copy the object to output

--- a/src/lotman.h
+++ b/src/lotman.h
@@ -815,7 +815,7 @@ int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_ch
 
 	RETURNS: Returns 0 on success. Any other values indicate an error.
 
-	INPUTS:
+	INPUTS (in declaration order):
 	recursive_quota:
 		A boolean indicating whether quotas should be treated recursively, ie whether the usage of a lot's children
 		should be counted against its own usage (recursive_quota = true) or whether only a lot's personal usage
@@ -827,6 +827,15 @@ int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_ch
 		NOTE: The children generated when recursive_children is true will include all recursive children of the lot,
 		not just immediate children.
 
+	include_reclaimed:
+		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
+		`reclaimed_at <= now`) should be included in the result. Cleanup loops should typically
+		pass false to avoid repeatedly processing lots that have already been reclaimed.
+		NOTE: When hierarchical = true, reclaimed parents are excluded from the result
+		unconditionally (regardless of include_reclaimed) because their storage has been
+		released to the default lot and they cannot meaningfully be "past" their own quota.
+		include_reclaimed only governs post-filtering on the non-hierarchical path.
+
 	output:
 		A reference to a char ** for storing an array of lots passed their opportunistic storage quota.
 		NOTE: Requires the use of lotman_free_string_list to free the memory allocated for this array.
@@ -837,11 +846,6 @@ int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_ch
 		(usage exceeding the child's own threshold). Results are returned depth-ordered
 		(deepest/leaf lots first). When true, recursive_quota and recursive_children
 		are not used by the hierarchical query path.
-
-	include_reclaimed:
-		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
-		`reclaimed_at <= now`) should be included in the result. Cleanup loops should typically
-		pass false to avoid repeatedly processing lots that have already been reclaimed.
 
 	err_msg:
 		A reference to a char array that can store any error messages.
@@ -857,7 +861,7 @@ int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_ch
 
 	RETURNS: Returns 0 on success. Any other values indicate an error.
 
-	INPUTS:
+	INPUTS (in declaration order):
 	recursive_quota:
 		A boolean indicating whether quotas should be treated recursively, ie whether the usage of a lot's children
 		should be counted against its own usage (recursive_quota = true) or whether only a lot's personal usage
@@ -869,6 +873,15 @@ int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_ch
 		NOTE: The children generated when recursive_children is true will include all recursive children of the lot,
 		not just immediate children.
 
+	include_reclaimed:
+		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
+		`reclaimed_at <= now`) should be included in the result. Cleanup loops should typically
+		pass false to avoid repeatedly processing lots that have already been reclaimed.
+		NOTE: When hierarchical = true, reclaimed parents are excluded from the result
+		unconditionally (regardless of include_reclaimed) because their storage has been
+		released to the default lot and they cannot meaningfully be "past" their own quota.
+		include_reclaimed only governs post-filtering on the non-hierarchical path.
+
 	output:
 		A reference to a char ** for storing an array of lots passed their dedicated storage quota.
 		NOTE: Requires the use of lotman_free_string_list to free the memory allocated for this array.
@@ -879,11 +892,6 @@ int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_ch
 		(usage exceeding the child's own threshold). Results are returned depth-ordered
 		(deepest/leaf lots first). When true, recursive_quota and recursive_children
 		are not used by the hierarchical query path.
-
-	include_reclaimed:
-		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
-		`reclaimed_at <= now`) should be included in the result. Cleanup loops should typically
-		pass false to avoid repeatedly processing lots that have already been reclaimed.
 
 	err_msg:
 		A reference to a char array that can store any error messages.
@@ -899,7 +907,7 @@ int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_ch
 
 	RETURNS: Returns 0 on success. Any other values indicate an error.
 
-	INPUTS:
+	INPUTS (in declaration order):
 	recursive_quota:
 		A boolean indicating whether quotas should be treated recursively, ie whether the usage of a lot's children
 		should be counted against its own usage (recursive_quota = true) or whether only a lot's personal usage
@@ -911,6 +919,15 @@ int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_ch
 		NOTE: The children generated when recursive_children is true will include all recursive children of the lot,
 		not just immediate children.
 
+	include_reclaimed:
+		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
+		`reclaimed_at <= now`) should be included in the result. Cleanup loops should typically
+		pass false to avoid repeatedly processing lots that have already been reclaimed.
+		NOTE: When hierarchical = true, reclaimed parents are excluded from the result
+		unconditionally (regardless of include_reclaimed) because their storage has been
+		released to the default lot and they cannot meaningfully be "past" their own quota.
+		include_reclaimed only governs post-filtering on the non-hierarchical path.
+
 	output:
 		A reference to a char ** for storing an array of lots passed their max object count quota.
 		NOTE: Requires the use of lotman_free_string_list to free the memory allocated for this array.
@@ -921,11 +938,6 @@ int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_ch
 		(usage exceeding the child's own threshold). Results are returned depth-ordered
 		(deepest/leaf lots first). When true, recursive_quota and recursive_children
 		are not used by the hierarchical query path.
-
-	include_reclaimed:
-		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
-		`reclaimed_at <= now`) should be included in the result. Cleanup loops should typically
-		pass false to avoid repeatedly processing lots that have already been reclaimed.
 
 	err_msg:
 		A reference to a char array that can store any error messages.

--- a/src/lotman.h
+++ b/src/lotman.h
@@ -696,7 +696,59 @@ void lotman_free_string_list(char **str_list);
 		The array to be freed.
 */
 
-int lotman_get_lots_past_exp(const bool recursive, char ***output, char **err_msg);
+#ifndef LOTMAN_RECLAIM_ERROR
+#define LOTMAN_RECLAIM_ERROR -1
+#endif
+#ifndef LOTMAN_RECLAIM_OK
+#define LOTMAN_RECLAIM_OK 0
+#endif
+#ifndef LOTMAN_RECLAIM_ALREADY_RECLAIMED
+#define LOTMAN_RECLAIM_ALREADY_RECLAIMED 1
+#endif
+
+int lotman_reclaim_lot(const char *lot_name, int64_t reclaimed_at, const char *reason, char **err_msg);
+/**
+	DESCRIPTION: Records a reclamation ledger entry for the named lot and every descendant in its
+		subtree, marking them as reclaimed by the storage provider. LotMan does NOT delete reclaimed
+		lots or modify their MPAs/usage; the reclamation is purely a fact recorded in a `reclamations`
+		ledger table. The intent is to let the caller (typically a storage provider's cleanup loop)
+		record the moment it is no longer attributing the underlying bytes/objects to the lot, so
+		subsequent calls to `lotman_get_lots_past_*` (with include_reclaimed=false) skip the lot,
+		capacity and Axiom-2 calculations exclude it, dir-based usage updates suppress its self-write,
+		and most mutating APIs reject writes against it. The default lot may not be reclaimed.
+
+		Already-reclaimed lots in the subtree are treated as no-ops, regardless of the existing
+		(reclaimed_at, reason) tuple. The existing ledger row is never overwritten. This lets a
+		cascade continue when one descendant has already been reclaimed while still recording rows
+		for any unreclaimed descendants. If a real write/storage error occurs for any unreclaimed
+		lot, the entire batch rolls back.
+
+		Authorization: caller must own the named lot in the same sense as `lotman_remove_lots_recursive`
+		(ownership of any of its parents). Authorization to the root authorizes the cascade.
+
+	RETURNS: Returns LOTMAN_RECLAIM_OK (0) when at least one reclamation row was added,
+		LOTMAN_RECLAIM_ALREADY_RECLAIMED (1) when every target already had a reclamation row and
+		no new row was added, or LOTMAN_RECLAIM_ERROR (-1) on validation, authorization, or storage
+		failure.
+
+	INPUTS:
+	lot_name:
+		The root of the subtree to reclaim. The named lot and every descendant get one ledger
+		row each. Must not be the default lot.
+
+	reclaimed_at:
+		A Unix timestamp in milliseconds. Must be > 0. May be in the future to schedule a
+		reclamation; reclamation-aware filters use `reclaimed_at <= now` so future-dated rows
+		do not take effect until their time arrives.
+
+	reason:
+		Free-form text recorded alongside the ledger row. May be empty. Not validated.
+
+	err_msg:
+		A reference to a char array that can store any error messages.
+*/
+
+int lotman_get_lots_past_exp(const bool recursive, const bool include_reclaimed, char ***output, char **err_msg);
 /**
 	DESCRIPTION: A function for determining all lots in the database that are past their expiration.
 		The function can determine which lots meet this criteria either by looking at the expiration
@@ -711,6 +763,12 @@ int lotman_get_lots_past_exp(const bool recursive, char ***output, char **err_ms
 		passed (recursive = false) or it should contain all lots who may also have an expired parent
 		(recursive = true).
 
+	include_reclaimed:
+		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
+		`reclaimed_at <= now`) should be included in the result. When false (the typical use
+		case for cleanup loops), reclaimed lots are filtered out so the loop will not repeatedly
+		process lots that the storage provider has already cleaned up.
+
 	output:
 		A reference to a char ** for storing an array of expired lot names.
 		NOTE: Requires the use of lotman_free_string_list to free the memory allocated for this array.
@@ -719,7 +777,7 @@ int lotman_get_lots_past_exp(const bool recursive, char ***output, char **err_ms
 		A reference to a char array that can store any error messages.
 */
 
-int lotman_get_lots_past_del(const bool recursive, char ***output, char **err_msg);
+int lotman_get_lots_past_del(const bool recursive, const bool include_reclaimed, char ***output, char **err_msg);
 /**
 	DESCRIPTION: A function for determining all lots in the database that are past their deletion time.
 		The function can determine which lots meet this criteria either by looking at the deletion time
@@ -734,6 +792,11 @@ int lotman_get_lots_past_del(const bool recursive, char ***output, char **err_ms
 		passed (recursive = false) or it should contain all lots who may also have a parent passed its
 		deletion time (recursive = true).
 
+	include_reclaimed:
+		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
+		`reclaimed_at <= now`) should be included in the result. Cleanup loops should typically
+		pass false so they do not repeatedly process lots that have already been reclaimed.
+
 	output:
 		A reference to a char ** for storing an array of lots passed their deletion time.
 		NOTE: Requires the use of lotman_free_string_list to free the memory allocated for this array.
@@ -742,8 +805,8 @@ int lotman_get_lots_past_del(const bool recursive, char ***output, char **err_ms
 		A reference to a char array that can store any error messages.
 */
 
-int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_children, char ***output,
-							 const bool hierarchical, char **err_msg);
+int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_children, const bool include_reclaimed,
+							 char ***output, const bool hierarchical, char **err_msg);
 /**
 	DESCRIPTION: A function for determining all lots in the database that are past their opportunistic storage.
 		The function can determine which lots meet this criteria either by looking at the opportunistic storage
@@ -775,12 +838,17 @@ int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_ch
 		(deepest/leaf lots first). When true, recursive_quota and recursive_children
 		are not used by the hierarchical query path.
 
+	include_reclaimed:
+		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
+		`reclaimed_at <= now`) should be included in the result. Cleanup loops should typically
+		pass false to avoid repeatedly processing lots that have already been reclaimed.
+
 	err_msg:
 		A reference to a char array that can store any error messages.
 */
 
-int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_children, char ***output,
-							 const bool hierarchical, char **err_msg);
+int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_children, const bool include_reclaimed,
+							 char ***output, const bool hierarchical, char **err_msg);
 /**
 	DESCRIPTION: A function for determining all lots in the database that are past their dedicated storage.
 		The function can determine which lots meet this criteria either by looking at the dedicated storage
@@ -812,12 +880,17 @@ int lotman_get_lots_past_ded(const bool recursive_quota, const bool recursive_ch
 		(deepest/leaf lots first). When true, recursive_quota and recursive_children
 		are not used by the hierarchical query path.
 
+	include_reclaimed:
+		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
+		`reclaimed_at <= now`) should be included in the result. Cleanup loops should typically
+		pass false to avoid repeatedly processing lots that have already been reclaimed.
+
 	err_msg:
 		A reference to a char array that can store any error messages.
 */
 
-int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_children, char ***output,
-							 const bool hierarchical, char **err_msg);
+int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_children, const bool include_reclaimed,
+							 char ***output, const bool hierarchical, char **err_msg);
 /**
 	DESCRIPTION: A function for determining all lots in the database that are past their object storage quota.
 		The function can determine which lots meet this criteria either by looking at the object storage quota
@@ -839,7 +912,7 @@ int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_ch
 		not just immediate children.
 
 	output:
-		A reference to a char ** for storing an array of lots passed their opportunistic storage quota.
+		A reference to a char ** for storing an array of lots passed their max object count quota.
 		NOTE: Requires the use of lotman_free_string_list to free the memory allocated for this array.
 
 	hierarchical:
@@ -848,6 +921,11 @@ int lotman_get_lots_past_obj(const bool recursive_quota, const bool recursive_ch
 		(usage exceeding the child's own threshold). Results are returned depth-ordered
 		(deepest/leaf lots first). When true, recursive_quota and recursive_children
 		are not used by the hierarchical query path.
+
+	include_reclaimed:
+		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
+		`reclaimed_at <= now`) should be included in the result. Cleanup loops should typically
+		pass false to avoid repeatedly processing lots that have already been reclaimed.
 
 	err_msg:
 		A reference to a char array that can store any error messages.
@@ -865,6 +943,10 @@ int lotman_get_available_capacity(const char *parent_lot_name, int64_t start_tim
 		enforcement is performed atomically by Axiom 2 inside the lot-creation transaction
 		when strict_hierarchy is enabled, so another caller may legitimately claim capacity
 		between this query and the subsequent create.
+
+		Reclaimed children (rows in the `reclamations` ledger whose `reclaimed_at <= now`) are
+		silently excluded from the sweep -- their attributed capacity is treated as freed and
+		no longer counted against the parent.
 
 	RETURNS: Returns 0 on success. Any other values indicate an error.
 
@@ -971,6 +1053,11 @@ for the 'recursive' flag. When recursive is true, each MPA will contain a JSON o
 		Values are absolute MPA shares (not fractions), so a create-then-read round-trip is symmetric. Unbounded
 		child axes (-1 sentinel) propagate to each parent as -1. For self-parent-only lots (i.e. lots with no
 		non-self parents), this field is an empty object.
+	"reclamation":
+		OPTIONAL. Present only when a reclamation ledger row exists for the lot. A JSON object of the
+		form {"reclaimed_at": <int64 ms>, "reason": <string>}. When `reclaimed_at <= now`, the lot is
+		effectively reclaimed; when `reclaimed_at > now`, the row represents a scheduled reclamation
+		that has not yet taken effect.
 }
 */
 
@@ -989,6 +1076,12 @@ int lotman_get_lots_from_dir(const char *dir, const bool recursive, int64_t quer
 	recursive:
 		A boolean indicating whether only the lot tracking the path should be returned (recursive = false),
 		or whether all parent lots should also be returned (recursive = true).
+
+	query_time:
+		A Unix timestamp in milliseconds used to filter active path/lot rows: a lot is considered active
+		when its MPA window contains `query_time` and any reclamation row for it has `reclaimed_at >
+		query_time`. Passing the current wall-clock time yields the live-as-of-now view; reclaimed lots
+		are therefore filtered out.
 
 	output:
 		A reference to a char ** for storing the output array.

--- a/src/lotman_db.cpp
+++ b/src/lotman_db.cpp
@@ -904,6 +904,9 @@ std::pair<bool, std::string> Lot::delete_lot_from_db() {
 		// Remove dangling parent references from other lots that had this lot as a parent
 		storage.remove_all<db::Parent>(where(c(&db::Parent::parent) == lot_name));
 
+		// Remove the reclamation ledger entry, if any.
+		storage.remove_all<db::Reclamation>(where(c(&db::Reclamation::lot_name) == lot_name));
+
 		return std::make_pair(true, "");
 	} catch (const std::exception &e) {
 		return std::make_pair(false, std::string("Failed to delete lot: ") + e.what());

--- a/src/lotman_db.h
+++ b/src/lotman_db.h
@@ -130,6 +130,27 @@ struct ParentChildAttribution {
 };
 
 /**
+ * A ledger entry recording that a lot has been (or will be at `reclaimed_at`)
+ * reclaimed by the storage provider. The presence of a row -- combined with
+ * `reclaimed_at <= now` -- indicates that LotMan should treat the lot as a
+ * historical record only. The accounting tie between the lot's paths and
+ * the lot itself is severed: capacity / Axiom-2 sweeps ignore reclaimed
+ * children, dir-based usage updates skip the reclaimed lot's self-write
+ * (parent subtraction math is unchanged), and most mutating APIs reject
+ * writes against a reclaimed lot. Removing the lot also removes its
+ * reclamation row.
+ *
+ * The PK on `lot_name` enforces at most one reclamation row per lot.
+ * `reclaimed_at` is milliseconds since epoch (matching MPA timestamps).
+ * `reclaimed_reason` is opaque free-form text (may be empty).
+ */
+struct Reclamation {
+	std::string lot_name;
+	int64_t reclaimed_at;
+	std::string reclaimed_reason;
+};
+
+/**
  * Creates the sqlite_orm storage definition.
  * This defines the schema mapping between C++ structs and SQLite tables.
  */
@@ -168,7 +189,10 @@ inline auto create_storage(const std::string &db_path) {
 				   make_column("mpa_key", &ParentChildAttribution::mpa_key),
 				   make_column("fraction", &ParentChildAttribution::fraction),
 				   primary_key(&ParentChildAttribution::child_lot_name, &ParentChildAttribution::parent_lot_name,
-							   &ParentChildAttribution::mpa_key)));
+							   &ParentChildAttribution::mpa_key)),
+		make_table("reclamations", make_column("lot_name", &Reclamation::lot_name, primary_key()),
+				   make_column("reclaimed_at", &Reclamation::reclaimed_at),
+				   make_column("reclaimed_reason", &Reclamation::reclaimed_reason)));
 }
 
 // Type alias for the storage type

--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -75,6 +75,12 @@ std::vector<SweepEvent> build_attribution_events(const std::string &parent_lot_n
 	std::vector<SweepEvent> events;
 	bool has_window = (start_time < end_time);
 
+	// Compute "now" once for reclamation filtering. A child whose reclamation
+	// row's reclaimed_at <= now is treated as if it no longer holds capacity
+	// (its accounting tie has been severed by the storage provider).
+	auto now_tp = std::chrono::system_clock::now();
+	int64_t now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now_tp).time_since_epoch().count();
+
 	// Get all children of this parent (non-self)
 	auto child_names = storage.select(&db::Parent::lot_name, where(c(&db::Parent::parent) == parent_lot_name and
 																   c(&db::Parent::lot_name) != parent_lot_name));
@@ -83,6 +89,12 @@ std::vector<SweepEvent> build_attribution_events(const std::string &parent_lot_n
 		auto child_mpa = storage.get_pointer<db::ManagementPolicyAttributes>(child_name);
 		if (!child_mpa)
 			continue;
+
+		// Skip reclaimed children: their attributed capacity is treated as freed.
+		auto reclaim_row = storage.get_pointer<db::Reclamation>(child_name);
+		if (reclaim_row && reclaim_row->reclaimed_at <= now_ms) {
+			continue;
+		}
 
 		// Non-expiring children (sentinel: all timestamps are 0) are treated
 		// as if they span (-infinity, +infinity), so they are always present
@@ -333,6 +345,19 @@ std::pair<bool, std::string> lotman::Lot::lot_exists(const std::string &lot_name
 	}
 }
 
+std::pair<bool, std::string> lotman::Lot::is_reclaimed(const std::string &lot_name, int64_t query_time) {
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		auto row = storage.get_pointer<db::Reclamation>(lot_name);
+		if (!row) {
+			return std::make_pair(false, "");
+		}
+		return std::make_pair(row->reclaimed_at <= query_time, "");
+	} catch (const std::exception &e) {
+		return std::make_pair(false, std::string("is_reclaimed failed: ") + e.what());
+	}
+}
+
 std::pair<bool, std::string> lotman::Lot::check_if_root() {
 	try {
 		auto &storage = db::StorageManager::get_storage();
@@ -521,6 +546,62 @@ std::pair<bool, std::string> lotman::Lot::destroy_lot_recursive() {
 	}
 
 	return std::make_pair(true, "");
+}
+
+std::pair<int, std::string> lotman::Lot::reclaim_lot_with_descendants(int64_t reclaimed_at, const std::string &reason) {
+	if (lot_name == "default") {
+		return std::make_pair(-1, "The default lot cannot be reclaimed.");
+	}
+
+	// Collect the subtree.
+	auto rp_lotvec_str = this->get_children(true);
+	if (!rp_lotvec_str.second.empty()) {
+		std::string int_err = rp_lotvec_str.second;
+		std::string ext_err = "Failed to get lot children: ";
+		return std::make_pair(-1, ext_err + int_err);
+	}
+
+	std::vector<std::string> targets;
+	targets.reserve(recursive_children.size() + 1);
+	targets.push_back(lot_name);
+	for (const auto &child : recursive_children) {
+		if (child.lot_name != lot_name) {
+			targets.push_back(child.lot_name);
+		}
+	}
+
+	auto &storage = db::StorageManager::get_storage();
+	std::string txn_error;
+	bool inserted_any = false;
+	bool skipped_existing = false;
+	bool committed = storage.transaction([&] {
+		for (const auto &name : targets) {
+			try {
+				auto existing = storage.get_pointer<db::Reclamation>(name);
+				if (existing) {
+					// Existing reclamation rows are authoritative ledger facts. Do not
+					// overwrite them; skip this lot and continue the cascade.
+					skipped_existing = true;
+					continue;
+				}
+				db::Reclamation row{name, reclaimed_at, reason};
+				storage.replace(row);
+				inserted_any = true;
+			} catch (const std::exception &e) {
+				txn_error = std::string("Failed to reclaim lot '") + name + "': " + e.what();
+				return false;
+			}
+		}
+		return true;
+	});
+
+	if (!committed) {
+		return std::make_pair(-1, txn_error.empty() ? "Transaction failed" : txn_error);
+	}
+	if (!inserted_any && skipped_existing) {
+		return std::make_pair(1, "All target lots already had reclamation rows; no new row was added.");
+	}
+	return std::make_pair(0, "");
 }
 
 std::pair<std::vector<Lot>, std::string> lotman::Lot::get_parents(const bool recursive, const bool get_self) {
@@ -813,7 +894,9 @@ std::pair<std::string, std::string> lotman::Lot::get_lot_from_dir(const std::str
 
 		std::string query = "SELECT p.lot_name FROM paths p "
 							"JOIN management_policy_attributes mpa ON p.lot_name = mpa.lot_name "
+							"LEFT JOIN reclamations r ON r.lot_name = p.lot_name "
 							"WHERE p.path = ?1 AND mpa.creation_time <= ?2 AND mpa.expiration_time > ?2 "
+							"AND (r.lot_name IS NULL OR r.reclaimed_at > ?2) "
 							"LIMIT 1;";
 		std::map<std::string, std::vector<int>> str_map{{normalized_path, {1}}};
 		std::map<int64_t, std::vector<int>> int_map{{query_time, {2}}};
@@ -2163,6 +2246,20 @@ std::pair<bool, std::string> lotman::Lot::update_usage_by_dirs(const json &updat
 			return std::make_pair(false, err);
 		}
 
+		// If the lot has been reclaimed (reclaimed_at <= query_time), the
+		// accounting tie between its paths and the lot is severed: skip the
+		// self_* writes here. Parent subtraction math (computed in JSON_math)
+		// has already run, so the live parent's accounting is unaffected.
+		auto reclaimed = lotman::Lot::is_reclaimed(lot.lot_name, query_time);
+		if (!reclaimed.second.empty()) {
+			std::string int_err = reclaimed.second;
+			std::string ext_err = "Failed to check if lot is reclaimed: ";
+			return std::make_pair(false, ext_err + int_err);
+		}
+		if (reclaimed.first) {
+			continue;
+		}
+
 		if (lot.usage.self_GB_update_staged) {
 			auto rp_bool_str = lot.update_self_usage("self_GB", lot.usage.self_GB, deltaMode);
 			if (!rp_bool_str.first) {
@@ -2205,6 +2302,37 @@ std::pair<bool, std::string> lotman::Lot::update_usage_by_dirs(const json &updat
 	return std::make_pair(true, "");
 }
 
+// Helper: if include_reclaimed is false, filter out any lot whose reclamation
+// row exists with reclaimed_at <= now. Centralizes the post-filter applied to
+// every get_lots_past_* result so that cleanup loops do not repeatedly process
+// already-reclaimed lots.
+static void filter_reclaimed_in_place(std::vector<std::string> &lots, bool include_reclaimed) {
+	if (include_reclaimed || lots.empty()) {
+		return;
+	}
+	auto now = std::chrono::system_clock::now();
+	int64_t now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch().count();
+	auto new_end = std::remove_if(lots.begin(), lots.end(), [&](const std::string &name) {
+		auto rp = lotman::Lot::is_reclaimed(name, now_ms);
+		if (!rp.second.empty()) {
+			// On lookup error, conservatively leave the lot in.
+			return false;
+		}
+		return rp.first;
+	});
+	lots.erase(new_end, lots.end());
+}
+
+std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_exp(const bool recursive,
+																				const bool include_reclaimed) {
+	auto rp_inner = get_lots_past_exp(recursive);
+	if (!rp_inner.second.empty()) {
+		return rp_inner;
+	}
+	filter_reclaimed_in_place(rp_inner.first, include_reclaimed);
+	return rp_inner;
+}
+
 std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_exp(const bool recursive) {
 	std::vector<std::string> expired_lots;
 	auto now = std::chrono::system_clock::now();
@@ -2232,7 +2360,6 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_exp(
 				return std::make_pair(std::vector<std::string>(), ext_err + int_err);
 			}
 
-			std::vector<std::string> tmp;
 			for (const auto &child : _lot.recursive_children) {
 				tmp.push_back(child.lot_name);
 			}
@@ -2246,6 +2373,16 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_exp(
 	}
 
 	return std::make_pair(expired_lots, "");
+}
+
+std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_del(const bool recursive,
+																				const bool include_reclaimed) {
+	auto rp_inner = get_lots_past_del(recursive);
+	if (!rp_inner.second.empty()) {
+		return rp_inner;
+	}
+	filter_reclaimed_in_place(rp_inner.first, include_reclaimed);
+	return rp_inner;
 }
 
 std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_del(const bool recursive) {
@@ -2288,6 +2425,17 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_del(
 	}
 
 	return std::make_pair(deletion_lots, "");
+}
+
+std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_opp(const bool recursive_quota,
+																				const bool recursive_children,
+																				const bool include_reclaimed) {
+	auto rp_inner = get_lots_past_opp(recursive_quota, recursive_children);
+	if (!rp_inner.second.empty()) {
+		return rp_inner;
+	}
+	filter_reclaimed_in_place(rp_inner.first, include_reclaimed);
+	return rp_inner;
 }
 
 std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_opp(const bool recursive_quota,
@@ -2362,6 +2510,17 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_opp(
 }
 
 std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_ded(const bool recursive_quota,
+																				const bool recursive_children,
+																				const bool include_reclaimed) {
+	auto rp_inner = get_lots_past_ded(recursive_quota, recursive_children);
+	if (!rp_inner.second.empty()) {
+		return rp_inner;
+	}
+	filter_reclaimed_in_place(rp_inner.first, include_reclaimed);
+	return rp_inner;
+}
+
+std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_ded(const bool recursive_quota,
 																				const bool recursive_children) {
 	std::vector<std::string> lots_past_ded;
 	if (recursive_quota) {
@@ -2425,6 +2584,17 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_ded(
 	}
 
 	return std::make_pair(lots_past_ded, "");
+}
+
+std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_obj(const bool recursive_quota,
+																				const bool recursive_children,
+																				const bool include_reclaimed) {
+	auto rp_inner = get_lots_past_obj(recursive_quota, recursive_children);
+	if (!rp_inner.second.empty()) {
+		return rp_inner;
+	}
+	filter_reclaimed_in_place(rp_inner.first, include_reclaimed);
+	return rp_inner;
 }
 
 std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_obj(const bool recursive_quota,
@@ -2585,27 +2755,47 @@ get_lots_past_threshold_hierarchical(const std::string &self_usage_col, const st
 	//     under an unbounded parent (rejected by axiom 1 otherwise);
 	//     defensively we treat their overflow contribution as 0 so they can
 	//     never push a parent past its own quota.
+	//
+	// Reclamation handling:
+	//   * Reclaimed parents are excluded from the result entirely. A reclaimed
+	//     lot's storage has been released to the default lot, so it can no
+	//     longer be "past" its own quota.
+	//   * Reclaimed children contribute 0 overage to a live parent, since
+	//     their usage no longer accrues to the parent subtree (it has been
+	//     hoovered up by the default lot per the reclamation ledger fact).
+	//   * "Reclaimed" is evaluated as of `now_ms`; future-dated rows do not
+	//     yet apply, mirroring the rest of the reclamation filtering.
+	auto now = std::chrono::system_clock::now();
+	int64_t now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch().count();
+
 	std::string query = "SELECT p_usage.lot_name "
 						"FROM lot_usage p_usage "
 						"JOIN management_policy_attributes p_mpa ON p_usage.lot_name = p_mpa.lot_name "
+						"LEFT JOIN reclamations p_rec ON p_rec.lot_name = p_usage.lot_name "
 						"WHERE NOT (" +
 						parent_unbounded_predicate +
 						") "
+						"AND (p_rec.lot_name IS NULL OR p_rec.reclaimed_at > ?1) "
 						"AND p_usage." +
 						self_usage_col +
 						" + COALESCE("
 						"    (SELECT SUM(CASE WHEN (" +
-						child_unbounded_predicate + ") THEN 0 ELSE MAX(0, (" + child_usage_expr + ") - (" +
-						child_threshold_expr +
+						child_unbounded_predicate +
+						") THEN 0 "
+						"                     WHEN (c_rec.lot_name IS NOT NULL AND c_rec.reclaimed_at <= ?1) THEN 0 "
+						"                     ELSE MAX(0, (" +
+						child_usage_expr + ") - (" + child_threshold_expr +
 						")) END) "
 						"     FROM parents c_par "
 						"     JOIN lot_usage c_usage ON c_par.lot_name = c_usage.lot_name "
 						"     JOIN management_policy_attributes c_mpa ON c_par.lot_name = c_mpa.lot_name "
+						"     LEFT JOIN reclamations c_rec ON c_rec.lot_name = c_par.lot_name "
 						"     WHERE c_par.parent = p_usage.lot_name AND c_par.lot_name != c_par.parent), 0"
 						") >= " +
 						parent_threshold_expr + ";";
 
-	auto rp = lotman::db::SQL_get_matches(query);
+	std::map<int64_t, std::vector<int>> int_map{{now_ms, {1}}};
+	auto rp = lotman::db::SQL_get_matches(query, std::map<std::string, std::vector<int>>(), int_map);
 	if (!rp.second.empty()) {
 		return std::make_pair(std::vector<std::string>(), "Failure on " + error_context + ": " + rp.second);
 	}
@@ -2615,35 +2805,56 @@ get_lots_past_threshold_hierarchical(const std::string &self_usage_col, const st
 	return std::make_pair(lots, "");
 }
 
-std::pair<std::vector<std::string>, std::string>
-lotman::Lot::get_lots_past_ded(const bool recursive_quota, const bool recursive_children, const bool hierarchical) {
+std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_ded(const bool recursive_quota,
+																				const bool recursive_children,
+																				const bool include_reclaimed,
+																				const bool hierarchical) {
 	if (!hierarchical) {
-		return get_lots_past_ded(recursive_quota, recursive_children);
+		return get_lots_past_ded(recursive_quota, recursive_children, include_reclaimed);
 	}
-	return get_lots_past_threshold_hierarchical("self_GB", "c_usage.self_GB + c_usage.children_GB",
-												"c_mpa.dedicated_GB", "p_mpa.dedicated_GB", "p_mpa.dedicated_GB = -1",
-												"c_mpa.dedicated_GB = -1", "adjusted dedicated query");
+	auto rp_h = get_lots_past_threshold_hierarchical(
+		"self_GB", "c_usage.self_GB + c_usage.children_GB", "c_mpa.dedicated_GB", "p_mpa.dedicated_GB",
+		"p_mpa.dedicated_GB = -1", "c_mpa.dedicated_GB = -1", "adjusted dedicated query");
+	if (!rp_h.second.empty()) {
+		return rp_h;
+	}
+	filter_reclaimed_in_place(rp_h.first, include_reclaimed);
+	return rp_h;
 }
 
-std::pair<std::vector<std::string>, std::string>
-lotman::Lot::get_lots_past_opp(const bool recursive_quota, const bool recursive_children, const bool hierarchical) {
+std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_opp(const bool recursive_quota,
+																				const bool recursive_children,
+																				const bool include_reclaimed,
+																				const bool hierarchical) {
 	if (!hierarchical) {
-		return get_lots_past_opp(recursive_quota, recursive_children);
+		return get_lots_past_opp(recursive_quota, recursive_children, include_reclaimed);
 	}
-	return get_lots_past_threshold_hierarchical(
+	auto rp_h = get_lots_past_threshold_hierarchical(
 		"self_GB", "c_usage.self_GB + c_usage.children_GB", "c_mpa.dedicated_GB + c_mpa.opportunistic_GB",
 		"p_mpa.dedicated_GB + p_mpa.opportunistic_GB", "p_mpa.dedicated_GB = -1 OR p_mpa.opportunistic_GB = -1",
 		"c_mpa.dedicated_GB = -1 OR c_mpa.opportunistic_GB = -1", "adjusted opportunistic query");
+	if (!rp_h.second.empty()) {
+		return rp_h;
+	}
+	filter_reclaimed_in_place(rp_h.first, include_reclaimed);
+	return rp_h;
 }
 
-std::pair<std::vector<std::string>, std::string>
-lotman::Lot::get_lots_past_obj(const bool recursive_quota, const bool recursive_children, const bool hierarchical) {
+std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_obj(const bool recursive_quota,
+																				const bool recursive_children,
+																				const bool include_reclaimed,
+																				const bool hierarchical) {
 	if (!hierarchical) {
-		return get_lots_past_obj(recursive_quota, recursive_children);
+		return get_lots_past_obj(recursive_quota, recursive_children, include_reclaimed);
 	}
-	return get_lots_past_threshold_hierarchical(
+	auto rp_h = get_lots_past_threshold_hierarchical(
 		"self_objects", "c_usage.self_objects + c_usage.children_objects", "c_mpa.max_num_objects",
 		"p_mpa.max_num_objects", "p_mpa.max_num_objects = -1", "c_mpa.max_num_objects = -1", "adjusted objects query");
+	if (!rp_h.second.empty()) {
+		return rp_h;
+	}
+	filter_reclaimed_in_place(rp_h.first, include_reclaimed);
+	return rp_h;
 }
 
 std::pair<json, std::string> lotman::Lot::get_available_capacity(const std::string &parent_lot_name, int64_t start_time,
@@ -2746,6 +2957,7 @@ lotman::Lot::get_lots_from_dir(const std::string &dir_input, const bool recursiv
 	std::string lots_from_dir_query =
 		"SELECT p.lot_name FROM paths p "
 		"JOIN management_policy_attributes mpa ON p.lot_name = mpa.lot_name "
+		"LEFT JOIN reclamations r ON r.lot_name = p.lot_name "
 		"WHERE "
 		"(p.path = ?1 OR ?2 LIKE p.path || '%') " // Exact match or subdirectory of stored path
 		"AND "
@@ -2756,6 +2968,10 @@ lotman::Lot::get_lots_from_dir(const std::string &dir_input, const bool recursiv
 		// timestamp triple as the non-expiring sentinel.
 		"AND ((mpa.creation_time = 0 AND mpa.expiration_time = 0 AND mpa.deletion_time = 0) "
 		"     OR (mpa.creation_time <= ?4 AND mpa.expiration_time > ?4)) "
+		// Reclaimed lots have severed their accounting tie to their paths; treat
+		// them as if the path was not associated with any lot (so the result
+		// falls back to the default lot, matching get_lot_from_dir's behavior).
+		"AND (r.lot_name IS NULL OR r.reclaimed_at > ?4) "
 		"AND NOT EXISTS ( " // Ensure no longer exclusion overrides this inclusion
 		"    SELECT 1 FROM paths e "
 		"    WHERE e.lot_name = p.lot_name "			  // Same lot
@@ -2786,6 +3002,18 @@ lotman::Lot::get_lots_from_dir(const std::string &dir_input, const bool recursiv
 		Lot lot(matching_lots_vec[0]);
 		lot.get_parents(true, false);
 		for (auto &parent : lot.recursive_parents) {
+			// Skip parents that are reclaimed at query_time. The base lot's
+			// own reclamation status is already enforced by the SQL above; we
+			// must apply the same filter to appended ancestors so reclaimed
+			// lots never surface through the recursive parent expansion.
+			auto rec_rp = is_reclaimed(parent.lot_name, query_time);
+			if (!rec_rp.second.empty()) {
+				return std::make_pair(std::vector<std::string>(), "Failure checking reclamation for parent '" +
+																	  parent.lot_name + "': " + rec_rp.second);
+			}
+			if (rec_rp.first) {
+				continue;
+			}
 			matching_lots_vec.push_back(parent.lot_name);
 		}
 	}

--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -570,34 +570,61 @@ std::pair<int, std::string> lotman::Lot::reclaim_lot_with_descendants(int64_t re
 		}
 	}
 
-	auto &storage = db::StorageManager::get_storage();
-	std::string txn_error;
+	// Use a raw INSERT OR IGNORE rather than sqlite_orm's `replace` (which
+	// compiles to INSERT OR REPLACE). The reclamations table is an immutable
+	// ledger: once a row exists for a lot, nothing -- not a retry, not a
+	// concurrent writer -- may overwrite it. INSERT OR IGNORE makes that
+	// invariant a property of the SQL primitive, not of a get-then-write
+	// check that could race. We use sqlite3_changes() to learn whether each
+	// statement actually inserted a row, which doubles as our "skipped
+	// existing" signal. We use BEGIN IMMEDIATE so any conflicting writer is
+	// serialized at the start of the cascade rather than after partial work.
+	db::PooledConnection conn(db::PooledConnection::TransactionType::Immediate);
+	if (!conn.valid()) {
+		return std::make_pair(-1, "Failed to acquire DB connection for reclaim: " + conn.error());
+	}
+
+	const std::string insert_sql =
+		"INSERT OR IGNORE INTO reclamations (lot_name, reclaimed_at, reclaimed_reason) VALUES (?1, ?2, ?3);";
+	auto [stmt, prep_err] = db::PreparedStatementCache::get_or_prepare(conn.get(), insert_sql);
+	if (!stmt) {
+		conn.rollback();
+		return std::make_pair(-1, "Failed to prepare reclaim insert: " + prep_err);
+	}
+	db::CachedStmtGuard stmt_guard(conn.get(), insert_sql, stmt);
+
 	bool inserted_any = false;
 	bool skipped_existing = false;
-	bool committed = storage.transaction([&] {
-		for (const auto &name : targets) {
-			try {
-				auto existing = storage.get_pointer<db::Reclamation>(name);
-				if (existing) {
-					// Existing reclamation rows are authoritative ledger facts. Do not
-					// overwrite them; skip this lot and continue the cascade.
-					skipped_existing = true;
-					continue;
-				}
-				db::Reclamation row{name, reclaimed_at, reason};
-				storage.replace(row);
-				inserted_any = true;
-			} catch (const std::exception &e) {
-				txn_error = std::string("Failed to reclaim lot '") + name + "': " + e.what();
-				return false;
-			}
+	for (const auto &name : targets) {
+		sqlite3_reset(stmt);
+		sqlite3_clear_bindings(stmt);
+		if (sqlite3_bind_text(stmt, 1, name.c_str(), static_cast<int>(name.size()), SQLITE_TRANSIENT) != SQLITE_OK ||
+			sqlite3_bind_int64(stmt, 2, reclaimed_at) != SQLITE_OK ||
+			sqlite3_bind_text(stmt, 3, reason.c_str(), static_cast<int>(reason.size()), SQLITE_TRANSIENT) !=
+				SQLITE_OK) {
+			stmt_guard.discard();
+			conn.rollback();
+			return std::make_pair(-1, std::string("Failed to bind reclaim insert for lot '") + name + "'");
 		}
-		return true;
-	});
-
-	if (!committed) {
-		return std::make_pair(-1, txn_error.empty() ? "Transaction failed" : txn_error);
+		int rc = sqlite3_step(stmt);
+		if (rc != SQLITE_DONE) {
+			stmt_guard.discard();
+			conn.rollback();
+			return std::make_pair(-1, std::string("Failed to execute reclaim insert for lot '") + name +
+										  "': sqlite errno " + std::to_string(rc));
+		}
+		if (sqlite3_changes(conn.get()) > 0) {
+			inserted_any = true;
+		} else {
+			// Row already existed: ledger fact preserved, cascade continues.
+			skipped_existing = true;
+		}
 	}
+
+	if (!conn.commit()) {
+		return std::make_pair(-1, "Failed to commit reclaim transaction: " + conn.error());
+	}
+
 	if (!inserted_any && skipped_existing) {
 		return std::make_pair(1, "All target lots already had reclamation rows; no new row was added.");
 	}

--- a/src/lotman_internal.h
+++ b/src/lotman_internal.h
@@ -271,10 +271,20 @@ class Lot {
 														  const bool assign_policy_to_children);
 	void init_self_usage();
 	static std::pair<bool, std::string> lot_exists(const std::string &lot_name);
+	// Returns {true, ""} iff a reclamation row exists for `lot_name` and its
+	// `reclaimed_at` is at or before `query_time` (ms since epoch). A future
+	// reclaimed_at is treated as not-yet-reclaimed. The error string is non-
+	// empty only on lookup failure (in which case the bool is false).
+	static std::pair<bool, std::string> is_reclaimed(const std::string &lot_name, int64_t query_time);
 	std::pair<bool, std::string> check_if_root();
 	std::pair<bool, std::string> store_lot(const json &parent_attributions_json = json());
 	std::pair<bool, std::string> destroy_lot();
 	std::pair<bool, std::string> destroy_lot_recursive();
+	// Reclaim this lot and all descendants atomically. Already-reclaimed lots are
+	// skipped without overwriting their existing ledger row. Returns 0 when at
+	// least one row was added, 1 when every target was already reclaimed, and -1
+	// on real failure. Caller is responsible for authorizing against the root.
+	std::pair<int, std::string> reclaim_lot_with_descendants(int64_t reclaimed_at, const std::string &reason);
 
 	std::pair<std::vector<Lot>, std::string> get_children(const bool recursive = false, const bool get_self = false);
 
@@ -327,6 +337,19 @@ class Lot {
 															bool include_self = false);
 	std::pair<bool, std::string> check_context_for_children(const std::vector<Lot> &children,
 															bool include_self = false);
+	static std::pair<std::vector<std::string>, std::string> get_lots_past_exp(const bool recursive,
+																			  const bool include_reclaimed);
+	static std::pair<std::vector<std::string>, std::string> get_lots_past_del(const bool recursive,
+																			  const bool include_reclaimed);
+	static std::pair<std::vector<std::string>, std::string>
+	get_lots_past_opp(const bool recursive_quota, const bool recursive_children, const bool include_reclaimed);
+	static std::pair<std::vector<std::string>, std::string>
+	get_lots_past_ded(const bool recursive_quota, const bool recursive_children, const bool include_reclaimed);
+	static std::pair<std::vector<std::string>, std::string>
+	get_lots_past_obj(const bool recursive_quota, const bool recursive_children, const bool include_reclaimed);
+
+	// Internal "no-filter" overloads kept for the include_reclaimed=true path
+	// and reused by the include_reclaimed-aware overloads above.
 	static std::pair<std::vector<std::string>, std::string> get_lots_past_exp(const bool recursive);
 	static std::pair<std::vector<std::string>, std::string> get_lots_past_del(const bool recursive);
 	static std::pair<std::vector<std::string>, std::string> get_lots_past_opp(const bool recursive_quota,
@@ -341,12 +364,18 @@ class Lot {
 	// NOTE: When hierarchical=true, recursive_quota and recursive_children are
 	// not used — the hierarchical SQL query has its own built-in logic.
 	// They are only forwarded to the non-hierarchical path when hierarchical=false.
-	static std::pair<std::vector<std::string>, std::string>
-	get_lots_past_opp(const bool recursive_quota, const bool recursive_children, const bool hierarchical);
-	static std::pair<std::vector<std::string>, std::string>
-	get_lots_past_ded(const bool recursive_quota, const bool recursive_children, const bool hierarchical);
-	static std::pair<std::vector<std::string>, std::string>
-	get_lots_past_obj(const bool recursive_quota, const bool recursive_children, const bool hierarchical);
+	static std::pair<std::vector<std::string>, std::string> get_lots_past_opp(const bool recursive_quota,
+																			  const bool recursive_children,
+																			  const bool include_reclaimed,
+																			  const bool hierarchical);
+	static std::pair<std::vector<std::string>, std::string> get_lots_past_ded(const bool recursive_quota,
+																			  const bool recursive_children,
+																			  const bool include_reclaimed,
+																			  const bool hierarchical);
+	static std::pair<std::vector<std::string>, std::string> get_lots_past_obj(const bool recursive_quota,
+																			  const bool recursive_children,
+																			  const bool include_reclaimed,
+																			  const bool hierarchical);
 
 	// Strict hierarchy validation methods
 	static std::pair<bool, std::string> validate_axiom1(const std::string &child_lot_name);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(lotman-gtest main.cpp orm_tests.cpp migration_tests.cpp strict_hierarchy_tests.cpp ../src/lotman.cpp ../src/lotman_db.cpp ../src/lotman_internal.cpp)
+add_executable(lotman-gtest main.cpp orm_tests.cpp migration_tests.cpp strict_hierarchy_tests.cpp reclamation_tests.cpp ../src/lotman.cpp ../src/lotman_db.cpp ../src/lotman_internal.cpp)
 if( NOT LOTMAN_EXTERNAL_GTEST )
     add_dependencies(lotman-gtest gtest)
     include_directories("${PROJECT_SOURCE_DIR}/vendor/gtest/googletest/include")

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1265,7 +1265,7 @@ TEST_F(LotManTest, LotsQueryTest) {
 	char **raw_output = nullptr;
 
 	// Check for lots past expiration
-	auto rv = lotman_get_lots_past_exp(true, &raw_output, &raw_err);
+	auto rv = lotman_get_lots_past_exp(true, /*include_reclaimed=*/true, &raw_output, &raw_err);
 	UniqueCString err_msg(raw_err);
 	UniqueStringList output(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();
@@ -1281,7 +1281,7 @@ TEST_F(LotManTest, LotsQueryTest) {
 	// Check for lots past deletion
 	raw_output = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_del(true, &raw_output, &raw_err);
+	rv = lotman_get_lots_past_del(true, /*include_reclaimed=*/true, &raw_output, &raw_err);
 	err_msg.reset(raw_err);
 	UniqueStringList output2(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();
@@ -1297,7 +1297,7 @@ TEST_F(LotManTest, LotsQueryTest) {
 	// Check for lots past opportunistic storage limit
 	raw_output = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_opp(true, true, &raw_output, false, &raw_err);
+	rv = lotman_get_lots_past_opp(true, true, /*include_reclaimed=*/true, &raw_output, false, &raw_err);
 	err_msg.reset(raw_err);
 	UniqueStringList output3(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();
@@ -1313,7 +1313,7 @@ TEST_F(LotManTest, LotsQueryTest) {
 	// Check for lots past dedicated storage limit
 	raw_output = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_ded(true, true, &raw_output, false, &raw_err);
+	rv = lotman_get_lots_past_ded(true, true, /*include_reclaimed=*/true, &raw_output, false, &raw_err);
 	err_msg.reset(raw_err);
 	UniqueStringList output4(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();
@@ -1329,7 +1329,7 @@ TEST_F(LotManTest, LotsQueryTest) {
 	// Check for lots past object storage limit
 	raw_output = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_obj(true, true, &raw_output, false, &raw_err);
+	rv = lotman_get_lots_past_obj(true, true, /*include_reclaimed=*/true, &raw_output, false, &raw_err);
 	err_msg.reset(raw_err);
 	UniqueStringList output5(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();

--- a/test/reclamation_tests.cpp
+++ b/test/reclamation_tests.cpp
@@ -1,0 +1,1003 @@
+/**
+ * Reclamation Ledger Tests for LotMan
+ *
+ * These tests cover the dedicated `reclamations` table introduced as a
+ * pure ledger of "this lot has been reclaimed" facts. They exercise the
+ * `lotman_reclaim_lot` C API plus the reclamation-aware filters added to
+ * the various read/write paths.
+ *
+ * Coverage includes:
+ *   * Happy-path reclaim writes a row, cascades to descendants, and emits
+ *     a `reclamation` block via `lotman_get_lot_as_json`.
+ *   * Re-reclaim of an already-reclaimed lot returns the already-reclaimed
+ *     status and leaves the original row untouched.
+ *   * Cascades skip already-reclaimed descendants and continue reclaiming
+ *     unreclaimed lots.
+ *   * Authorization (caller must own the root).
+ *   * Argument validation (null lot, non-existent lot, default lot,
+ *     non-positive `reclaimed_at`).
+ *   * Mutation guards on `update_lot`, `update_lot_usage`, `add_to_lot`,
+ *     `rm_parents_from_lot`, `rm_paths_from_lots`.
+ *   * `update_lot_usage_by_dir` silently skips reclaimed lots.
+ *   * `lotman_get_lots_from_dir` excludes reclaimed lots.
+ *   * The five `past_*` queries respect the `include_reclaimed` flag.
+ *   * Future-dated reclamations remain "scheduled" until the wall-clock
+ *     reaches `reclaimed_at` (filters use `reclaimed_at <= now`).
+ *   * `lotman_remove_lot` cleans up the reclamation row.
+ */
+
+#include "../src/lotman.h"
+#include "../src/lotman_db.h"
+#include "test_utils.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include <set>
+#include <string>
+#include <vector>
+
+using json = nlohmann::json;
+
+namespace {
+
+constexpr int64_t PAST_TS = 1; // Always in the past relative to wall-clock.
+// A long way into the future (year ~2286): use as "scheduled" reclamation.
+constexpr int64_t FUTURE_TS = 9999999999999LL;
+
+class ReclamationTest : public ::testing::Test {
+  protected:
+	std::string tmp_dir;
+
+	void SetUp() override {
+		tmp_dir = create_temp_directory("lotman_reclaim_test");
+		char *raw_err = nullptr;
+		ASSERT_EQ(lotman_set_context_str("lot_home", tmp_dir.c_str(), &raw_err), 0) << (raw_err ? raw_err : "");
+		free(raw_err);
+		raw_err = nullptr;
+		ASSERT_EQ(lotman_set_context_str("caller", "owner1", &raw_err), 0) << (raw_err ? raw_err : "");
+		free(raw_err);
+		raw_err = nullptr;
+		ASSERT_EQ(lotman_set_context_str("strict_hierarchy", "false", &raw_err), 0) << (raw_err ? raw_err : "");
+		free(raw_err);
+		raw_err = nullptr;
+		ASSERT_EQ(lotman_set_context_str("contraction_policy", "none", &raw_err), 0) << (raw_err ? raw_err : "");
+		free(raw_err);
+	}
+
+	void TearDown() override {
+		std::filesystem::remove_all(tmp_dir);
+	}
+
+	void addLot(const std::string &lot_json) {
+		char *raw_err = nullptr;
+		int rv = lotman_add_lot(lot_json.c_str(), &raw_err);
+		UniqueCString err(raw_err);
+		ASSERT_EQ(rv, 0) << "addLot failed: " << (err.get() ? err.get() : "");
+	}
+
+	void addDefaultLot() {
+		addLot(R"({
+			"lot_name": "default",
+			"owner": "owner1",
+			"parents": ["default"],
+			"paths": [{"path": "/default", "recursive": true}],
+			"management_policy_attrs": {
+				"dedicated_GB": 1000,
+				"opportunistic_GB": 500,
+				"max_num_objects": 10000,
+				"creation_time": 100,
+				"expiration_time": 9999999999999,
+				"deletion_time": 9999999999999
+			}
+		})");
+	}
+
+	// Build a small tree: parent → mid → leaf, all owned by owner1, all with
+	// generous, non-expired, non-deleted MPA windows (so they don't leak into
+	// past_exp / past_del queries unless we mean them to).
+	void addParentMidLeaf() {
+		addLot(R"({
+			"lot_name": "parent",
+			"owner": "owner1",
+			"parents": ["parent"],
+			"paths": [{"path": "/parent", "recursive": true}],
+			"management_policy_attrs": {
+				"dedicated_GB": 100, "opportunistic_GB": 50, "max_num_objects": 1000,
+				"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+			}
+		})");
+		addLot(R"({
+			"lot_name": "mid",
+			"owner": "owner1",
+			"parents": ["parent"],
+			"paths": [{"path": "/parent/mid", "recursive": true}],
+			"management_policy_attrs": {
+				"dedicated_GB": 50, "opportunistic_GB": 25, "max_num_objects": 500,
+				"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+			}
+		})");
+		addLot(R"({
+			"lot_name": "leaf",
+			"owner": "owner1",
+			"parents": ["mid"],
+			"paths": [{"path": "/parent/mid/leaf", "recursive": true}],
+			"management_policy_attrs": {
+				"dedicated_GB": 10, "opportunistic_GB": 5, "max_num_objects": 100,
+				"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+			}
+		})");
+	}
+
+	bool hasReclamationRow(const std::string &lot_name) {
+		char *raw_err = nullptr;
+		char *raw_out = nullptr;
+		int rv = lotman_get_lot_as_json(lot_name.c_str(), false, &raw_out, &raw_err);
+		UniqueCString err(raw_err);
+		UniqueCString out(raw_out);
+		EXPECT_EQ(rv, 0) << "get_lot_as_json failed for " << lot_name << ": " << (err.get() ? err.get() : "");
+		if (rv != 0 || !out.get())
+			return false;
+		auto parsed = json::parse(std::string(out.get()), nullptr, false);
+		if (parsed.is_discarded())
+			return false;
+		return parsed.contains("reclamation");
+	}
+
+	json getReclamationRow(const std::string &lot_name) {
+		char *raw_err = nullptr;
+		char *raw_out = nullptr;
+		int rv = lotman_get_lot_as_json(lot_name.c_str(), false, &raw_out, &raw_err);
+		UniqueCString err(raw_err);
+		UniqueCString out(raw_out);
+		EXPECT_EQ(rv, 0) << "get_lot_as_json failed for " << lot_name << ": " << (err.get() ? err.get() : "");
+		if (rv != 0 || !out.get())
+			return json();
+		auto parsed = json::parse(std::string(out.get()), nullptr, false);
+		if (parsed.is_discarded() || !parsed.contains("reclamation"))
+			return json();
+		return parsed["reclamation"];
+	}
+
+	int reclaim(const std::string &lot_name, int64_t ts, const std::string &reason, std::string *err_out = nullptr) {
+		char *raw_err = nullptr;
+		int rv = lotman_reclaim_lot(lot_name.c_str(), ts, reason.c_str(), &raw_err);
+		UniqueCString err(raw_err);
+		if (err_out)
+			*err_out = err.get() ? err.get() : "";
+		return rv;
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Argument validation
+// ---------------------------------------------------------------------------
+
+TEST_F(ReclamationTest, RejectsNullLotName) {
+	addDefaultLot();
+	char *raw_err = nullptr;
+	int rv = lotman_reclaim_lot(nullptr, PAST_TS, "test", &raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(err.get(), nullptr);
+}
+
+TEST_F(ReclamationTest, RejectsNonPositiveReclaimedAt) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	EXPECT_NE(reclaim("parent", 0, "test", &err), 0);
+	EXPECT_FALSE(err.empty());
+	EXPECT_NE(reclaim("parent", -1, "test", &err), 0);
+	EXPECT_FALSE(err.empty());
+	// And no row should have been created.
+	EXPECT_FALSE(hasReclamationRow("parent"));
+}
+
+TEST_F(ReclamationTest, RejectsUnknownLot) {
+	addDefaultLot();
+	std::string err;
+	EXPECT_NE(reclaim("does_not_exist", PAST_TS, "test", &err), 0);
+	EXPECT_FALSE(err.empty());
+}
+
+TEST_F(ReclamationTest, RejectsDefaultLot) {
+	addDefaultLot();
+	std::string err;
+	EXPECT_NE(reclaim("default", PAST_TS, "test", &err), 0);
+	EXPECT_FALSE(err.empty());
+	EXPECT_FALSE(hasReclamationRow("default"));
+}
+
+TEST_F(ReclamationTest, RequiresOwnerCaller) {
+	addDefaultLot();
+	addParentMidLeaf();
+	char *raw_err = nullptr;
+	ASSERT_EQ(lotman_set_context_str("caller", "stranger", &raw_err), 0);
+	free(raw_err);
+	std::string err;
+	EXPECT_NE(reclaim("parent", PAST_TS, "denied", &err), 0);
+	EXPECT_FALSE(err.empty());
+	EXPECT_FALSE(hasReclamationRow("parent"));
+}
+
+// ---------------------------------------------------------------------------
+// Happy path + cascade
+// ---------------------------------------------------------------------------
+
+TEST_F(ReclamationTest, ReclaimCascadesToAllDescendants) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("parent", PAST_TS, "EXPIRED", &err), 0) << err;
+	EXPECT_TRUE(hasReclamationRow("parent"));
+	EXPECT_TRUE(hasReclamationRow("mid"));
+	EXPECT_TRUE(hasReclamationRow("leaf"));
+}
+
+TEST_F(ReclamationTest, ReclaimLeafOnlyDoesNotTouchAncestors) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", PAST_TS, "EXPIRED", &err), 0) << err;
+	EXPECT_FALSE(hasReclamationRow("parent"));
+	EXPECT_FALSE(hasReclamationRow("mid"));
+	EXPECT_TRUE(hasReclamationRow("leaf"));
+}
+
+TEST_F(ReclamationTest, GetLotAsJsonEmitsReclamationBlock) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", 1234567, "EXPIRED", &err), 0) << err;
+
+	char *raw_err = nullptr;
+	char *raw_out = nullptr;
+	ASSERT_EQ(lotman_get_lot_as_json("leaf", false, &raw_out, &raw_err), 0);
+	UniqueCString cleanup_err(raw_err);
+	UniqueCString out(raw_out);
+	auto parsed = json::parse(std::string(out.get()));
+	ASSERT_TRUE(parsed.contains("reclamation"));
+	EXPECT_EQ(parsed["reclamation"]["reclaimed_at"].get<int64_t>(), 1234567);
+	EXPECT_EQ(parsed["reclamation"]["reason"].get<std::string>(), "EXPIRED");
+
+	// A non-reclaimed sibling has no `reclamation` key.
+	raw_err = nullptr;
+	char *raw_out2 = nullptr;
+	ASSERT_EQ(lotman_get_lot_as_json("parent", false, &raw_out2, &raw_err), 0);
+	UniqueCString cleanup_err2(raw_err);
+	UniqueCString out2(raw_out2);
+	auto parsed2 = json::parse(std::string(out2.get()));
+	EXPECT_FALSE(parsed2.contains("reclamation"));
+}
+
+// ---------------------------------------------------------------------------
+// Rereclaim semantics
+// ---------------------------------------------------------------------------
+
+TEST_F(ReclamationTest, IdempotentReReclaimWithMatchingTuple) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", 42, "EXPIRED", &err), LOTMAN_RECLAIM_OK) << err;
+	EXPECT_EQ(reclaim("leaf", 42, "EXPIRED", &err), LOTMAN_RECLAIM_ALREADY_RECLAIMED) << err;
+	EXPECT_TRUE(hasReclamationRow("leaf"));
+}
+
+TEST_F(ReclamationTest, ReReclaimWithDifferentTimestampSkipsExistingRow) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", 42, "EXPIRED", &err), LOTMAN_RECLAIM_OK) << err;
+	EXPECT_EQ(reclaim("leaf", 43, "EXPIRED", &err), LOTMAN_RECLAIM_ALREADY_RECLAIMED);
+
+	// Original ledger row must be unchanged.
+	auto row = getReclamationRow("leaf");
+	ASSERT_FALSE(row.is_null());
+	EXPECT_EQ(row["reclaimed_at"].get<int64_t>(), 42);
+	EXPECT_EQ(row["reason"].get<std::string>(), "EXPIRED");
+}
+
+TEST_F(ReclamationTest, ReReclaimWithDifferentReasonSkipsExistingRow) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", 42, "EXPIRED", &err), LOTMAN_RECLAIM_OK) << err;
+	EXPECT_EQ(reclaim("leaf", 42, "DELETED", &err), LOTMAN_RECLAIM_ALREADY_RECLAIMED);
+	auto row = getReclamationRow("leaf");
+	ASSERT_FALSE(row.is_null());
+	EXPECT_EQ(row["reclaimed_at"].get<int64_t>(), 42);
+	EXPECT_EQ(row["reason"].get<std::string>(), "EXPIRED");
+}
+
+TEST_F(ReclamationTest, CascadeSkipsAlreadyReclaimedDescendant) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	// Pre-reclaim the leaf with a specific tuple.
+	ASSERT_EQ(reclaim("leaf", 100, "EXPIRED", &err), LOTMAN_RECLAIM_OK) << err;
+
+	// Now cascade-reclaim from `parent` with a different tuple. The existing
+	// leaf row is skipped, while parent and mid receive new rows.
+	EXPECT_EQ(reclaim("parent", 200, "RECURSIVE", &err), LOTMAN_RECLAIM_OK) << err;
+
+	EXPECT_TRUE(hasReclamationRow("parent"));
+	EXPECT_TRUE(hasReclamationRow("mid"));
+	auto parent_row = getReclamationRow("parent");
+	auto mid_row = getReclamationRow("mid");
+	auto leaf_row = getReclamationRow("leaf");
+	ASSERT_FALSE(parent_row.is_null());
+	ASSERT_FALSE(mid_row.is_null());
+	ASSERT_FALSE(leaf_row.is_null());
+	EXPECT_EQ(parent_row["reclaimed_at"].get<int64_t>(), 200);
+	EXPECT_EQ(mid_row["reclaimed_at"].get<int64_t>(), 200);
+	EXPECT_EQ(leaf_row["reclaimed_at"].get<int64_t>(), 100);
+	EXPECT_EQ(leaf_row["reason"].get<std::string>(), "EXPIRED");
+}
+
+TEST_F(ReclamationTest, ReclaimAllAlreadyReclaimedSubtreeReturnsAlreadyReclaimed) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("parent", 100, "EXPIRED", &err), LOTMAN_RECLAIM_OK) << err;
+
+	EXPECT_EQ(reclaim("parent", 200, "RECURSIVE", &err), LOTMAN_RECLAIM_ALREADY_RECLAIMED);
+
+	auto parent_row = getReclamationRow("parent");
+	auto mid_row = getReclamationRow("mid");
+	auto leaf_row = getReclamationRow("leaf");
+	ASSERT_FALSE(parent_row.is_null());
+	ASSERT_FALSE(mid_row.is_null());
+	ASSERT_FALSE(leaf_row.is_null());
+	EXPECT_EQ(parent_row["reclaimed_at"].get<int64_t>(), 100);
+	EXPECT_EQ(mid_row["reclaimed_at"].get<int64_t>(), 100);
+	EXPECT_EQ(leaf_row["reclaimed_at"].get<int64_t>(), 100);
+}
+
+// ---------------------------------------------------------------------------
+// Mutation guards
+// ---------------------------------------------------------------------------
+
+TEST_F(ReclamationTest, UpdateLotRejectsReclaimedTarget) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot(R"({"lot_name":"leaf","management_policy_attrs":{"dedicated_GB":99}})", &raw_err);
+	UniqueCString eg(raw_err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(eg.get(), nullptr);
+}
+
+TEST_F(ReclamationTest, UpdateLotUsageRejectsReclaimedTarget) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot_usage(R"({"lot_name":"leaf","self_GB":1.0})", false, &raw_err);
+	UniqueCString eg(raw_err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(eg.get(), nullptr);
+}
+
+TEST_F(ReclamationTest, AddToLotRejectsReclaimedTarget) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	char *raw_err = nullptr;
+	int rv = lotman_add_to_lot(R"({"lot_name":"leaf","paths":[{"path":"/extra","recursive":true}]})", &raw_err);
+	UniqueCString eg(raw_err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(eg.get(), nullptr);
+}
+
+TEST_F(ReclamationTest, RmParentsFromLotRejectsReclaimedTarget) {
+	addDefaultLot();
+	addParentMidLeaf();
+	// Give `leaf` a second parent so the rm has something legitimate to do.
+	char *raw_err = nullptr;
+	ASSERT_EQ(lotman_add_to_lot(R"({"lot_name":"leaf","parents":["parent"]})", &raw_err), 0);
+	free(raw_err);
+	raw_err = nullptr;
+
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	int rv = lotman_rm_parents_from_lot(R"({"lot_name":"leaf","parents":["parent"]})", &raw_err);
+	UniqueCString eg(raw_err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(eg.get(), nullptr);
+}
+
+TEST_F(ReclamationTest, RmPathsFromLotsRejectsReclaimedTarget) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	char *raw_err = nullptr;
+	int rv = lotman_rm_paths_from_lots(R"({"paths":["/parent/mid/leaf"]})", &raw_err);
+	UniqueCString eg(raw_err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(eg.get(), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// `update_lot_usage_by_dir` skips reclaimed lots silently
+// ---------------------------------------------------------------------------
+
+TEST_F(ReclamationTest, UpdateLotUsageByDirSkipsReclaimedSilently) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	// A live (`mid`) and a reclaimed (`leaf`) target in one call. Per the
+	// `update_usage_by_dir_schema`, the top-level shape is an array of
+	// {path, includes_subdirs, size_GB?, num_obj?, subdirs?} entries.
+	const char *update = R"([
+		{
+			"path": "/parent/mid",
+			"includes_subdirs": true,
+			"size_GB": 5.0,
+			"num_obj": 1,
+			"subdirs": [
+				{"path": "leaf", "includes_subdirs": false, "size_GB": 7.0, "num_obj": 1, "subdirs": []}
+			]
+		}
+	])";
+
+	int64_t now_ms =
+		std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+			.count();
+
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot_usage_by_dir(update, false, now_ms, &raw_err);
+	UniqueCString eg(raw_err);
+	EXPECT_EQ(rv, 0) << "update_lot_usage_by_dir should silently skip reclaimed lots: " << (eg.get() ? eg.get() : "");
+}
+
+// ---------------------------------------------------------------------------
+// `lotman_get_lots_from_dir` filters reclaimed lots
+// ---------------------------------------------------------------------------
+
+TEST_F(ReclamationTest, GetLotsFromDirExcludesReclaimed) {
+	addDefaultLot();
+	addParentMidLeaf();
+
+	int64_t now_ms =
+		std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+			.count();
+
+	// Sanity: leaf claims its dir before reclaim.
+	char *raw_err = nullptr;
+	char **raw_lots = nullptr;
+	ASSERT_EQ(lotman_get_lots_from_dir("/parent/mid/leaf", false, now_ms, &raw_lots, &raw_err), 0);
+	UniqueCString cleanup_err(raw_err);
+	UniqueStringList lots(raw_lots);
+	std::set<std::string> before;
+	for (int i = 0; lots.get()[i]; ++i)
+		before.insert(lots.get()[i]);
+	EXPECT_TRUE(before.count("leaf")) << "leaf should own its dir before reclaim";
+
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	raw_err = nullptr;
+	char **raw_lots2 = nullptr;
+	ASSERT_EQ(lotman_get_lots_from_dir("/parent/mid/leaf", false, now_ms, &raw_lots2, &raw_err), 0);
+	UniqueCString cleanup_err2(raw_err);
+	UniqueStringList lots2(raw_lots2);
+	std::set<std::string> after;
+	for (int i = 0; lots2.get()[i]; ++i)
+		after.insert(lots2.get()[i]);
+	EXPECT_FALSE(after.count("leaf")) << "leaf should be filtered out after reclaim";
+}
+
+TEST_F(ReclamationTest, GetLotsFromDirIncludesFutureReclaimedUntilDue) {
+	// A future-dated reclaim (reclaimed_at > now) must NOT filter the lot
+	// out yet — it represents a scheduled, not-yet-effective reclamation.
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", FUTURE_TS, "SCHEDULED", &err), 0) << err;
+
+	int64_t now_ms =
+		std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+			.count();
+	char *raw_err = nullptr;
+	char **raw_lots = nullptr;
+	ASSERT_EQ(lotman_get_lots_from_dir("/parent/mid/leaf", false, now_ms, &raw_lots, &raw_err), 0);
+	UniqueCString cleanup_err(raw_err);
+	UniqueStringList lots(raw_lots);
+	std::set<std::string> got;
+	for (int i = 0; lots.get()[i]; ++i)
+		got.insert(lots.get()[i]);
+	EXPECT_TRUE(got.count("leaf")) << "scheduled (future) reclamations must not filter yet";
+}
+
+// ---------------------------------------------------------------------------
+// past_* queries respect include_reclaimed
+// ---------------------------------------------------------------------------
+
+TEST_F(ReclamationTest, PastExpQueryRespectsIncludeReclaimed) {
+	addDefaultLot();
+	// An expired lot (expiration_time well in the past, deletion_time in the future).
+	addLot(R"({
+		"lot_name": "expired",
+		"owner": "owner1",
+		"parents": ["expired"],
+		"paths": [{"path": "/expired", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10, "opportunistic_GB": 5, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 1000, "deletion_time": 9999999999999
+		}
+	})");
+
+	// Sanity: appears in past_exp before reclaim.
+	char *raw_err = nullptr;
+	char **raw_lots = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_exp(false, /*include_reclaimed=*/true, &raw_lots, &raw_err), 0);
+	UniqueCString cleanup_err(raw_err);
+	UniqueStringList lots(raw_lots);
+	std::set<std::string> before;
+	for (int i = 0; lots.get()[i]; ++i)
+		before.insert(lots.get()[i]);
+	ASSERT_TRUE(before.count("expired"));
+
+	// Reclaim it.
+	std::string err;
+	ASSERT_EQ(reclaim("expired", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	// include_reclaimed=true -> still present.
+	raw_err = nullptr;
+	char **raw_lots_inc = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_exp(false, true, &raw_lots_inc, &raw_err), 0);
+	UniqueCString eg1(raw_err);
+	UniqueStringList lots_inc(raw_lots_inc);
+	std::set<std::string> with_inc;
+	for (int i = 0; lots_inc.get()[i]; ++i)
+		with_inc.insert(lots_inc.get()[i]);
+	EXPECT_TRUE(with_inc.count("expired"));
+
+	// include_reclaimed=false -> filtered out.
+	raw_err = nullptr;
+	char **raw_lots_exc = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_exp(false, false, &raw_lots_exc, &raw_err), 0);
+	UniqueCString eg2(raw_err);
+	UniqueStringList lots_exc(raw_lots_exc);
+	std::set<std::string> without;
+	for (int i = 0; lots_exc.get()[i]; ++i)
+		without.insert(lots_exc.get()[i]);
+	EXPECT_FALSE(without.count("expired"));
+}
+
+TEST_F(ReclamationTest, PastDelQueryRespectsIncludeReclaimed) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "deletable",
+		"owner": "owner1",
+		"parents": ["deletable"],
+		"paths": [{"path": "/deletable", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10, "opportunistic_GB": 5, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 500, "deletion_time": 1000
+		}
+	})");
+
+	char *raw_err = nullptr;
+	char **raw_lots = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_del(false, true, &raw_lots, &raw_err), 0);
+	UniqueCString cleanup_err(raw_err);
+	UniqueStringList lots(raw_lots);
+	std::set<std::string> before;
+	for (int i = 0; lots.get()[i]; ++i)
+		before.insert(lots.get()[i]);
+	ASSERT_TRUE(before.count("deletable"));
+
+	std::string err;
+	ASSERT_EQ(reclaim("deletable", PAST_TS, "DELETED", &err), 0) << err;
+
+	raw_err = nullptr;
+	char **raw_lots_exc = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_del(false, false, &raw_lots_exc, &raw_err), 0);
+	UniqueCString eg(raw_err);
+	UniqueStringList lots_exc(raw_lots_exc);
+	std::set<std::string> after;
+	for (int i = 0; lots_exc.get()[i]; ++i)
+		after.insert(lots_exc.get()[i]);
+	EXPECT_FALSE(after.count("deletable"));
+}
+
+TEST_F(ReclamationTest, PastDedQueryRespectsIncludeReclaimed) {
+	addDefaultLot();
+	// A self-parented lot with a tiny dedicated quota that we'll exceed.
+	addLot(R"({
+		"lot_name": "fat",
+		"owner": "owner1",
+		"parents": ["fat"],
+		"paths": [{"path": "/fat", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 1, "opportunistic_GB": 0, "max_num_objects": 1000,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})");
+	char *raw_err = nullptr;
+	ASSERT_EQ(lotman_update_lot_usage(R"({"lot_name":"fat","self_GB":50.0})", false, &raw_err), 0);
+	free(raw_err);
+	raw_err = nullptr;
+
+	char **raw_lots = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_ded(false, false, /*include_reclaimed=*/true, &raw_lots,
+									   /*hierarchical=*/false, &raw_err),
+			  0);
+	UniqueCString cleanup_err(raw_err);
+	UniqueStringList lots(raw_lots);
+	std::set<std::string> before;
+	for (int i = 0; lots.get()[i]; ++i)
+		before.insert(lots.get()[i]);
+	ASSERT_TRUE(before.count("fat"));
+
+	std::string err;
+	ASSERT_EQ(reclaim("fat", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	raw_err = nullptr;
+	char **raw_lots_exc = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_ded(false, false, false, &raw_lots_exc, false, &raw_err), 0);
+	UniqueCString eg(raw_err);
+	UniqueStringList lots_exc(raw_lots_exc);
+	std::set<std::string> after;
+	for (int i = 0; lots_exc.get()[i]; ++i)
+		after.insert(lots_exc.get()[i]);
+	EXPECT_FALSE(after.count("fat"));
+}
+
+TEST_F(ReclamationTest, PastObjQueryRespectsIncludeReclaimed) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "manyobj",
+		"owner": "owner1",
+		"parents": ["manyobj"],
+		"paths": [{"path": "/manyobj", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 50, "max_num_objects": 1,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})");
+	char *raw_err = nullptr;
+	ASSERT_EQ(lotman_update_lot_usage(R"({"lot_name":"manyobj","self_objects":1000})", false, &raw_err), 0);
+	free(raw_err);
+	raw_err = nullptr;
+
+	char **raw_lots = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_obj(false, false, true, &raw_lots, false, &raw_err), 0);
+	UniqueCString cleanup_err(raw_err);
+	UniqueStringList lots(raw_lots);
+	std::set<std::string> before;
+	for (int i = 0; lots.get()[i]; ++i)
+		before.insert(lots.get()[i]);
+	ASSERT_TRUE(before.count("manyobj"));
+
+	std::string err;
+	ASSERT_EQ(reclaim("manyobj", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	raw_err = nullptr;
+	char **raw_lots_exc = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_obj(false, false, false, &raw_lots_exc, false, &raw_err), 0);
+	UniqueCString eg(raw_err);
+	UniqueStringList lots_exc(raw_lots_exc);
+	std::set<std::string> after;
+	for (int i = 0; lots_exc.get()[i]; ++i)
+		after.insert(lots_exc.get()[i]);
+	EXPECT_FALSE(after.count("manyobj"));
+}
+
+TEST_F(ReclamationTest, PastQueriesIncludeFutureScheduledReclamation) {
+	// A future-dated reclamation (reclaimed_at > now) must NOT exclude the
+	// lot from past_* queries until the wall-clock catches up.
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "expired",
+		"owner": "owner1",
+		"parents": ["expired"],
+		"paths": [{"path": "/expired", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10, "opportunistic_GB": 5, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 1000, "deletion_time": 9999999999999
+		}
+	})");
+	std::string err;
+	ASSERT_EQ(reclaim("expired", FUTURE_TS, "SCHEDULED", &err), 0) << err;
+
+	char *raw_err = nullptr;
+	char **raw_lots = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_exp(false, /*include_reclaimed=*/false, &raw_lots, &raw_err), 0);
+	UniqueCString cleanup_err(raw_err);
+	UniqueStringList lots(raw_lots);
+	std::set<std::string> got;
+	for (int i = 0; lots.get()[i]; ++i)
+		got.insert(lots.get()[i]);
+	EXPECT_TRUE(got.count("expired"))
+		<< "future-dated reclamation must not filter past_exp until wall-clock reaches reclaimed_at";
+}
+
+// ---------------------------------------------------------------------------
+// Removal cleans up the reclamation row
+// ---------------------------------------------------------------------------
+
+TEST_F(ReclamationTest, RemoveLotAlsoRemovesReclamationRow) {
+	addDefaultLot();
+	addParentMidLeaf();
+	std::string err;
+	ASSERT_EQ(reclaim("leaf", PAST_TS, "EXPIRED", &err), 0) << err;
+	ASSERT_TRUE(hasReclamationRow("leaf"));
+
+	char *raw_err = nullptr;
+	int rv = lotman_remove_lots_recursive("leaf", &raw_err);
+	UniqueCString eg(raw_err);
+	ASSERT_EQ(rv, 0) << (eg.get() ? eg.get() : "");
+
+	// Lot is gone; ergo, no reclamation row about it can be looked up via
+	// `lotman_get_lot_as_json`. Re-add it with the same name and assert no
+	// stale `reclamation` block is attached.
+	addLot(R"({
+		"lot_name": "leaf",
+		"owner": "owner1",
+		"parents": ["mid"],
+		"paths": [{"path": "/parent/mid/leaf", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10, "opportunistic_GB": 5, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})");
+	EXPECT_FALSE(hasReclamationRow("leaf")) << "Re-created lot must not inherit a stale reclamation row";
+}
+
+// ---------------------------------------------------------------------------
+// Adding a live child under a reclaimed parent is rejected
+// ---------------------------------------------------------------------------
+
+TEST_F(ReclamationTest, AddLotRejectedUnderReclaimedParent) {
+	// Reclamation is a terminal ledger fact: a reclaimed subtree has been
+	// hoovered into the default lot. Adding a live child would resurrect the
+	// subtree and break that invariant.
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "parent",
+		"owner": "owner1",
+		"parents": ["parent"],
+		"paths": [{"path": "/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 50, "max_num_objects": 1000,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})");
+	std::string err;
+	ASSERT_EQ(reclaim("parent", PAST_TS, "EXPIRED", &err), 0) << err;
+	ASSERT_TRUE(hasReclamationRow("parent"));
+
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "graft_attempt",
+		"owner": "owner1",
+		"parents": ["parent"],
+		"paths": [{"path": "/parent/graft", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 1, "opportunistic_GB": 0, "max_num_objects": 10,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})",
+							&raw_err);
+	UniqueCString eg(raw_err);
+	EXPECT_NE(rv, 0) << "lotman_add_lot must reject grafting a live child onto a reclaimed parent";
+	EXPECT_NE(eg.get(), nullptr);
+}
+
+TEST_F(ReclamationTest, AddLotAllowedAlongsideReclaimedSibling) {
+	// Sibling reclamation must not block adding new live siblings under the
+	// same (live) parent.
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "parent",
+		"owner": "owner1",
+		"parents": ["parent"],
+		"paths": [{"path": "/parent", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 50, "max_num_objects": 1000,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})");
+	addLot(R"({
+		"lot_name": "sib_a",
+		"owner": "owner1",
+		"parents": ["parent"],
+		"paths": [{"path": "/parent/a", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10, "opportunistic_GB": 5, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})");
+	std::string err;
+	ASSERT_EQ(reclaim("sib_a", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	char *raw_err = nullptr;
+	int rv = lotman_add_lot(R"({
+		"lot_name": "sib_b",
+		"owner": "owner1",
+		"parents": ["parent"],
+		"paths": [{"path": "/parent/b", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10, "opportunistic_GB": 5, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})",
+							&raw_err);
+	UniqueCString eg(raw_err);
+	EXPECT_EQ(rv, 0) << "Live siblings should be addable even if a sibling is reclaimed: "
+					 << (eg.get() ? eg.get() : "");
+}
+
+// ---------------------------------------------------------------------------
+// Hierarchical past_* must not count reclaimed children's overage and must
+// not return reclaimed parents.
+// ---------------------------------------------------------------------------
+
+TEST_F(ReclamationTest, HierarchicalPastDedExcludesReclaimedChildOverage) {
+	// Parent has a moderate dedicated quota; a live child blows past its own
+	// quota by enough to push the parent past its quota via the hierarchical
+	// adjusted-usage calculation. Once the child is reclaimed, its usage has
+	// been released to the default lot, so it must no longer push the live
+	// parent into the result set.
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "p",
+		"owner": "owner1",
+		"parents": ["p"],
+		"paths": [{"path": "/p", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100, "opportunistic_GB": 0, "max_num_objects": 1000,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})");
+	addLot(R"({
+		"lot_name": "c",
+		"owner": "owner1",
+		"parents": ["p"],
+		"paths": [{"path": "/p/c", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10, "opportunistic_GB": 0, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})");
+	char *raw_err = nullptr;
+	// Child overage = 500 - 10 = 490, which is well past parent's 100 quota.
+	ASSERT_EQ(lotman_update_lot_usage(R"({"lot_name":"c","self_GB":500.0})", false, &raw_err), 0);
+	free(raw_err);
+	raw_err = nullptr;
+
+	// Sanity: hierarchical past_ded surfaces parent before the child is reclaimed.
+	char **raw_lots = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_ded(false, false, /*include_reclaimed=*/true, &raw_lots,
+									   /*hierarchical=*/true, &raw_err),
+			  0);
+	UniqueCString eg1(raw_err);
+	UniqueStringList lots(raw_lots);
+	std::set<std::string> before;
+	for (int i = 0; lots.get()[i]; ++i)
+		before.insert(lots.get()[i]);
+	ASSERT_TRUE(before.count("p")) << "Sanity: child overage should push live parent into hierarchical past_ded";
+
+	std::string err;
+	ASSERT_EQ(reclaim("c", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	raw_err = nullptr;
+	char **raw_lots2 = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_ded(false, false, /*include_reclaimed=*/true, &raw_lots2,
+									   /*hierarchical=*/true, &raw_err),
+			  0);
+	UniqueCString eg2(raw_err);
+	UniqueStringList lots2(raw_lots2);
+	std::set<std::string> after;
+	for (int i = 0; lots2.get()[i]; ++i)
+		after.insert(lots2.get()[i]);
+	EXPECT_FALSE(after.count("p")) << "Reclaimed child's overage must not count against live parent";
+}
+
+TEST_F(ReclamationTest, HierarchicalPastDedExcludesReclaimedParent) {
+	// A reclaimed parent has released its storage to the default lot and can
+	// no longer be "past" its own quota. The hierarchical SQL must drop it
+	// regardless of include_reclaimed (which only governs the post-filter
+	// for non-hierarchical paths).
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "fat_root",
+		"owner": "owner1",
+		"parents": ["fat_root"],
+		"paths": [{"path": "/fat_root", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 1, "opportunistic_GB": 0, "max_num_objects": 1000,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})");
+	char *raw_err = nullptr;
+	ASSERT_EQ(lotman_update_lot_usage(R"({"lot_name":"fat_root","self_GB":50.0})", false, &raw_err), 0);
+	free(raw_err);
+	raw_err = nullptr;
+
+	// Sanity: present before reclaim.
+	char **raw_lots = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_ded(false, false, true, &raw_lots, /*hierarchical=*/true, &raw_err), 0);
+	UniqueCString eg1(raw_err);
+	UniqueStringList lots(raw_lots);
+	std::set<std::string> before;
+	for (int i = 0; lots.get()[i]; ++i)
+		before.insert(lots.get()[i]);
+	ASSERT_TRUE(before.count("fat_root"));
+
+	std::string err;
+	ASSERT_EQ(reclaim("fat_root", PAST_TS, "EXPIRED", &err), 0) << err;
+
+	raw_err = nullptr;
+	char **raw_lots2 = nullptr;
+	// include_reclaimed=true is intentional: hierarchical SQL must still drop
+	// reclaimed parents because the math depends on them being live.
+	ASSERT_EQ(lotman_get_lots_past_ded(false, false, true, &raw_lots2, /*hierarchical=*/true, &raw_err), 0);
+	UniqueCString eg2(raw_err);
+	UniqueStringList lots2(raw_lots2);
+	std::set<std::string> after;
+	for (int i = 0; lots2.get()[i]; ++i)
+		after.insert(lots2.get()[i]);
+	EXPECT_FALSE(after.count("fat_root")) << "Hierarchical past_ded must drop a reclaimed parent unconditionally";
+}
+
+// ---------------------------------------------------------------------------
+// Pre-existing recursive-expansion fix in get_lots_past_exp
+// ---------------------------------------------------------------------------
+
+TEST_F(ReclamationTest, GetLotsPastExpRecursiveIncludesDescendants) {
+	// Regression: the recursive branch of get_lots_past_exp previously
+	// shadowed its accumulator vector, dropping recursive children entirely.
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "exp_root",
+		"owner": "owner1",
+		"parents": ["exp_root"],
+		"paths": [{"path": "/exp_root", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10, "opportunistic_GB": 5, "max_num_objects": 100,
+			"creation_time": 100, "expiration_time": 1000, "deletion_time": 9999999999999
+		}
+	})");
+	addLot(R"({
+		"lot_name": "exp_child",
+		"owner": "owner1",
+		"parents": ["exp_root"],
+		"paths": [{"path": "/exp_root/c", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 5, "opportunistic_GB": 2, "max_num_objects": 50,
+			"creation_time": 100, "expiration_time": 9999999999999, "deletion_time": 9999999999999
+		}
+	})");
+
+	char *raw_err = nullptr;
+	char **raw_lots = nullptr;
+	ASSERT_EQ(lotman_get_lots_past_exp(/*recursive=*/true, /*include_reclaimed=*/true, &raw_lots, &raw_err), 0);
+	UniqueCString cleanup_err(raw_err);
+	UniqueStringList lots(raw_lots);
+	std::set<std::string> got;
+	for (int i = 0; lots.get()[i]; ++i)
+		got.insert(lots.get()[i]);
+	EXPECT_TRUE(got.count("exp_root"));
+	EXPECT_TRUE(got.count("exp_child")) << "Recursive past_exp must include children of expired ancestors";
+}
+
+} // namespace

--- a/test/strict_hierarchy_tests.cpp
+++ b/test/strict_hierarchy_tests.cpp
@@ -1937,7 +1937,7 @@ TEST_F(StrictHierarchyTest, HierarchicalDepthOrderedResults) {
 	// All three lots are past their dedicated quota.
 	// Results should be depth-ordered: deepest (leaf) first.
 	char **raw_output = nullptr;
-	rv = lotman_get_lots_past_ded(false, false, &raw_output, true, &raw_err);
+	rv = lotman_get_lots_past_ded(false, false, /*include_reclaimed=*/true, &raw_output, true, &raw_err);
 	err.reset(raw_err);
 	UniqueStringList output(raw_output);
 	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
@@ -2007,7 +2007,7 @@ TEST_F(StrictHierarchyTest, HierarchicalVsNonHierarchical) {
 
 	// Non-hierarchical: just check raw self_GB vs dedicated_GB
 	char **raw_output = nullptr;
-	rv = lotman_get_lots_past_ded(false, false, &raw_output, false, &raw_err);
+	rv = lotman_get_lots_past_ded(false, false, /*include_reclaimed=*/true, &raw_output, false, &raw_err);
 	err.reset(raw_err);
 	UniqueStringList output_nonhier(raw_output);
 	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
@@ -6286,7 +6286,7 @@ TEST_F(StrictHierarchyTest, NonExpiringLotNotReturnedFromPastExpQuery) {
 	// the past relative to "now"; it should be returned. ne_root must NOT.
 	char **raw_lots = nullptr;
 	raw_err = nullptr;
-	int rv = lotman_get_lots_past_exp(/*recursive=*/false, &raw_lots, &raw_err);
+	int rv = lotman_get_lots_past_exp(/*recursive=*/false, /*include_reclaimed=*/true, &raw_lots, &raw_err);
 	UniqueStringList lots(raw_lots);
 	UniqueCString err(raw_err);
 	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
@@ -6304,7 +6304,7 @@ TEST_F(StrictHierarchyTest, NonExpiringLotNotReturnedFromPastExpQuery) {
 	// Same expectation for past-deletion.
 	raw_lots = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_del(/*recursive=*/false, &raw_lots, &raw_err);
+	rv = lotman_get_lots_past_del(/*recursive=*/false, /*include_reclaimed=*/true, &raw_lots, &raw_err);
 	UniqueStringList del_lots(raw_lots);
 	UniqueCString del_err(raw_err);
 	ASSERT_EQ(rv, 0) << (del_err.get() ? del_err.get() : "");
@@ -7047,7 +7047,7 @@ TEST_F(StrictHierarchyTest, UnboundedStorageLotNotReturnedFromPastDedQuery) {
 
 	char **lots = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_ded(false, false, &lots, false, &raw_err);
+	rv = lotman_get_lots_past_ded(false, false, /*include_reclaimed=*/true, &lots, false, &raw_err);
 	UniqueCString perr(raw_err);
 	ASSERT_EQ(rv, 0) << "lotman_get_lots_past_ded failed: " << (perr.get() ? perr.get() : "<no error>");
 	bool found = false;
@@ -7087,7 +7087,7 @@ TEST_F(StrictHierarchyTest, UnboundedObjectsLotNotReturnedFromPastObjQuery) {
 
 	char **lots = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_obj(false, false, &lots, false, &raw_err);
+	rv = lotman_get_lots_past_obj(false, false, /*include_reclaimed=*/true, &lots, false, &raw_err);
 	UniqueCString perr(raw_err);
 	ASSERT_EQ(rv, 0) << "lotman_get_lots_past_obj failed: " << (perr.get() ? perr.get() : "<no error>");
 	bool found = false;


### PR DESCRIPTION
Reclamation is a new first-class concept in LotMan's accounting model. When a lot is reclaimed it is recorded as a permanent, immutable ledger fact in a dedicated `reclamations` table. The guiding principle is that all storage must always be attributed to *some* active lot: once a lot is reclaimed, its storage attribution is severed and absorbed by the default lot, which exists precisely to hoover up any storage not claimed by an active lot.

A reclamation row is never overwritten. The first write is authoritative; subsequent calls against an already-reclaimed lot return a distinct status code rather than an error so callers can distinguish "nothing to do" from "something went wrong." Reclamation is cascaded to all descendants in a single transaction, with the same skip-existing semantics per node.

Because reclamation is terminal, every mutating API rejects operations against a reclaimed lot. lotman_add_lot additionally rejects reclaimed parents: allowing a live graft onto a reclaimed subtree would silently resurrect severed attribution edges, counting the same storage under the new child and under the default lot simultaneously.

Read paths are updated throughout to respect reclamation:

- Directory-based queries filter reclaimed path owners and fall back to the default lot, consistent with the hoover-up invariant.
- The five past_* threshold queries accept an include_reclaimed flag so callers can choose whether to surface reclaimed lots or not.
- Hierarchical quota queries exclude reclaimed children from the adjusted-usage calculation, since their usage has already transferred to the default lot and counting it again would produce incorrect eviction signals. Reclaimed parents are excluded from results unconditionally.
- The recursive parent expansion in get_lots_from_dir applies the same reclamation filter as the SQL path-matching query.
- The recursive child expansion in get_lots_past_exp previously accumulated results into a shadowed inner vector, silently dropping all recursive children; this is corrected here.

Scheduled reclamations (reclaimed_at > now) are first-class: a row may be written with a future timestamp and the lot remains fully active until the wall-clock reaches that point.