### PR TITLE
Require ancestor consent for dynamic path ownership

### DIFF
--- a/src/lotman.cpp
+++ b/src/lotman.cpp
@@ -449,7 +449,8 @@ int lotman_update_lot(const char *lotman_JSON_str, char **err_msg) {
 			}
 
 			if (update_JSON_obj.contains("parents")) {
-				if (!lot.update_parents_in_txn(update_JSON_obj["parents"], txn_error)) {
+				if (!lot.update_parents_in_txn(update_JSON_obj["parents"], txn_error,
+											   /*revalidate_paths=*/false)) {
 					txn_error = "Failed on call to lot.update_parents: " + txn_error;
 					return false;
 				}
@@ -526,6 +527,19 @@ int lotman_update_lot(const char *lotman_JSON_str, char **err_msg) {
 			if (update_JSON_obj.contains("parent_attributions")) {
 				if (!lot.update_attributions_in_txn(update_JSON_obj["parent_attributions"], txn_error)) {
 					txn_error = "Failed on call to lot.update_attributions: " + txn_error;
+					return false;
+				}
+			}
+
+			// Final descendancy revalidation against the fully-committed
+			// state of this transaction. update_parents_in_txn was asked to
+			// skip its inline revalidation so that simultaneous parent +
+			// path edits are evaluated against the final ancestry rather
+			// than an intermediate state. We only need to revalidate when
+			// the caller actually touched parents or paths;
+			// revalidate_paths_in_txn itself is a no-op for the default lot.
+			if (update_JSON_obj.contains("parents") || update_JSON_obj.contains("paths")) {
+				if (!lot.revalidate_paths_in_txn(txn_error)) {
 					return false;
 				}
 			}

--- a/src/lotman.h
+++ b/src/lotman.h
@@ -71,9 +71,22 @@ int lotman_add_lot(const char *lotman_JSON_str, char **err_msg);
 		{"path": "/path/to/associate", "recursive": bool, "exclude": bool}
 		When "recursive" is true, all subdirectories of the path are also attributed to the lot. When false,
 		only non-directory objects below the path should be attributed, but any subdirectories should not be.
-		When "exclude" is true, this path is excluded from the lot's tracking. This allows for patterns like
-		"track everything under /foo recursively, except /foo/bar". The "exclude" field is optional and
-		defaults to false if not specified.
+
+		Path-to-lot resolution is dynamic: when several live lots' paths could match a directory, the
+		lot whose path is the longest prefix of the query path "wins" (deepest descendant). This means
+		a sublot whose path is a strict subpath of an ancestor's recursive path automatically claims its
+		subtree without requiring an explicit "exclude" row on the ancestor — and reverts ownership back
+		to the ancestor when the sublot is removed or expires.
+
+		Descendancy rule (enforced when adding/updating non-excluded paths): if another live lot's
+		recursive path is a strict prefix of the candidate path, the candidate's lot must be a recursive
+		descendant of that other lot. Symmetrically, a recursive candidate path that would cover an
+		existing lot's path requires that other lot to be a recursive descendant of the candidate.
+		Same-path collisions during overlapping time windows are always rejected.
+
+		When "exclude" is true, this path row is an escape hatch: it is ignored by both path resolution
+		and the descendancy/temporal-overlap check. Prefer the dynamic-ownership model above over
+		explicit exclusions. The "exclude" field is optional and defaults to false if not specified.
 	"management_policy_attrs":
 		REQUIRED: A JSON object containing the collection of attributes used for creating policies for the
 		lot. The object has the following structure:

--- a/src/lotman_db.cpp
+++ b/src/lotman_db.cpp
@@ -1001,9 +1001,13 @@ std::pair<bool, std::string> Lot::check_path_temporal_overlap(const std::string 
 		"     OR (?2 = 0 AND ?3 = 0) "
 		"     OR (?2 < mpa.expiration_time AND mpa.creation_time < ?3)) "
 		"AND ( "
-		"  p.path = ?4 "													 // (1) exact
-		"  OR (p.recursive = 1 AND p.path != ?4 AND ?4 LIKE p.path || '%') " // (2) prefix-in
-		"  OR (?5 = 1 AND p.path != ?4 AND p.path LIKE ?4 || '%') " // (3) prefix-out (only if candidate recursive)
+		// Prefix matching uses substr() rather than LIKE so that path strings
+		// containing SQLite wildcard characters ('%' or '_') compare literally.
+		// LIKE with '|| %' would otherwise classify e.g. '/foo_bar/' as a
+		// prefix of '/fooXbar/anything/'.
+		"  p.path = ?4 "																	  // (1) exact
+		"  OR (p.recursive = 1 AND p.path != ?4 AND substr(?4, 1, length(p.path)) = p.path) " // (2) prefix-in
+		"  OR (?5 = 1 AND p.path != ?4 AND substr(p.path, 1, length(?4)) = ?4) " // (3) prefix-out (candidate recursive)
 		");";
 	std::map<std::string, std::vector<int>> str_map{{lot_name, {1}}, {normalized_path, {4}}};
 	std::map<int64_t, std::vector<int>> int_map{
@@ -1083,18 +1087,31 @@ std::pair<bool, std::string> Lot::is_recursive_ancestor(const std::string &ances
 		auto &storage = db::StorageManager::get_storage();
 		using namespace sqlite_orm;
 
-		// BFS up from `descendant` looking for `ancestor`. The parents table
-		// maps child→parent edges; self-parent rows (lot_name == parent) are
+		// Prefetch every (child -> parent) edge in a single query, then BFS
+		// in memory. The previous implementation issued one SELECT per visited
+		// node, producing O(depth) round-trips per ancestry check;
+		// check_path_temporal_overlap calls this once per candidate conflict,
+		// multiplying that cost. Self-parent rows (lot_name == parent) are
 		// ignored to avoid trivial loops.
+		std::unordered_map<std::string, std::vector<std::string>> parents_of;
+		for (const auto &edge : storage.get_all<db::Parent>()) {
+			if (edge.lot_name == edge.parent) {
+				continue;
+			}
+			parents_of[edge.lot_name].push_back(edge.parent);
+		}
+
 		std::vector<std::string> frontier{descendant};
 		std::unordered_set<std::string> visited;
 		visited.insert(descendant);
 		while (!frontier.empty()) {
 			std::vector<std::string> next;
 			for (const auto &node : frontier) {
-				auto parents = storage.select(
-					&db::Parent::parent, where(c(&db::Parent::lot_name) == node and c(&db::Parent::parent) != node));
-				for (auto &p : parents) {
+				auto it = parents_of.find(node);
+				if (it == parents_of.end()) {
+					continue;
+				}
+				for (const auto &p : it->second) {
 					if (p == ancestor) {
 						return std::make_pair(true, "");
 					}

--- a/src/lotman_db.cpp
+++ b/src/lotman_db.cpp
@@ -16,6 +16,7 @@
 #include <sqlite3.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <unordered_set>
 
 using namespace sqlite_orm;
 
@@ -836,21 +837,13 @@ std::pair<bool, std::string> Lot::write_new() {
 			storage.replace(parent_record);
 		}
 
-		// Temporal overlap check: ensure no other lot claims the same path
-		// during an overlapping time period before inserting paths.
-		for (const auto &path_json : paths) {
-			std::string path_str = path_json.at("path").get<std::string>();
-			std::string normalized = ensure_trailing_slash(path_str);
-			bool exclude = path_json.contains("exclude") ? path_json["exclude"].get<bool>() : false;
-
-			if (!exclude) {
-				auto overlap = check_path_temporal_overlap(lot_name, normalized, man_policy_attr.creation_time,
-														   man_policy_attr.expiration_time);
-				if (!overlap.first) {
-					return overlap;
-				}
-			}
-		}
+		// NOTE: Path overlap (descendancy) checks are intentionally NOT
+		// performed here. They are run by store_lot() AFTER insertion
+		// adjustment so that any parent rewiring done by insertion_check is
+		// visible to the descendancy walk. Performing the check here would
+		// reject legitimate "reverse insertion" cases where the new lot is
+		// being introduced as the parent of an existing lot whose path the
+		// new lot will recursively cover.
 
 		for (const auto &path : paths) {
 			storage.replace(db::create_path_record(lot_name, path));
@@ -984,38 +977,141 @@ std::pair<bool, std::string> Lot::store_updates(const std::string &update_stmt,
 }
 
 std::pair<bool, std::string> Lot::check_path_temporal_overlap(const std::string &lot_name,
-															  const std::string &normalized_path, int64_t creation_time,
-															  int64_t expiration_time) {
-	// Single JOIN query replaces the previous N+1 pattern (one SELECT for
-	// candidate lots, plus one get_pointer per candidate). The non-expiring
-	// sentinel (all timestamps = 0) is treated as an interval covering all
-	// time, so a sentinel lot on either side of the comparison always
-	// overlaps the other.
-	std::string query = "SELECT p.lot_name, mpa.creation_time, mpa.expiration_time "
-						"FROM paths p "
-						"JOIN management_policy_attributes mpa ON p.lot_name = mpa.lot_name "
-						"WHERE p.path = ?1 AND p.lot_name != ?2 AND p.exclude = 0 "
-						"AND ((mpa.creation_time = 0 AND mpa.expiration_time = 0) "
-						"     OR (?3 = 0 AND ?4 = 0) "
-						"     OR (?3 < mpa.expiration_time AND mpa.creation_time < ?4)) "
-						"LIMIT 1;";
-	std::map<std::string, std::vector<int>> str_map{{normalized_path, {1}}, {lot_name, {2}}};
-	std::map<int64_t, std::vector<int>> int_map{{creation_time, {3}}, {expiration_time, {4}}};
-	auto rp = db::SQL_get_matches_multi_col(query, 3, str_map, int_map);
-
+															  const std::string &normalized_path, bool recursive,
+															  int64_t creation_time, int64_t expiration_time) {
+	// Find every live, non-excluded path on a different lot that potentially
+	// conflicts with the candidate path. Three classes of conflict are
+	// considered (see header docstring for the full rule statement):
+	//   (1) EXACT: another lot owns exactly `normalized_path`.
+	//   (2) PREFIX-IN: another lot owns a strict prefix of `normalized_path`
+	//       with `recursive=1`.
+	//   (3) PREFIX-OUT: the candidate is recursive AND another lot owns a
+	//       strict suffix-extension of `normalized_path` (any recursive flag).
+	//
+	// SQL filters narrow the candidate set; classification + descendancy
+	// resolution are done in C++ for clarity. The non-expiring sentinel
+	// (creation=expiration=0) represents an interval covering all time on
+	// either side of the comparison.
+	std::string query =
+		"SELECT p.lot_name, p.path, p.recursive, mpa.creation_time, mpa.expiration_time "
+		"FROM paths p "
+		"JOIN management_policy_attributes mpa ON p.lot_name = mpa.lot_name "
+		"WHERE p.lot_name != ?1 AND p.exclude = 0 "
+		"AND ((mpa.creation_time = 0 AND mpa.expiration_time = 0) "
+		"     OR (?2 = 0 AND ?3 = 0) "
+		"     OR (?2 < mpa.expiration_time AND mpa.creation_time < ?3)) "
+		"AND ( "
+		"  p.path = ?4 "													 // (1) exact
+		"  OR (p.recursive = 1 AND p.path != ?4 AND ?4 LIKE p.path || '%') " // (2) prefix-in
+		"  OR (?5 = 1 AND p.path != ?4 AND p.path LIKE ?4 || '%') " // (3) prefix-out (only if candidate recursive)
+		");";
+	std::map<std::string, std::vector<int>> str_map{{lot_name, {1}}, {normalized_path, {4}}};
+	std::map<int64_t, std::vector<int>> int_map{
+		{creation_time, {2}}, {expiration_time, {3}}, {static_cast<int64_t>(recursive ? 1 : 0), {5}}};
+	auto rp = db::SQL_get_matches_multi_col(query, 5, str_map, int_map);
 	if (!rp.second.empty()) {
 		return std::make_pair(false, "Temporal overlap check failed: " + rp.second);
 	}
 
-	if (!rp.first.empty()) {
-		const auto &row = rp.first[0];
-		return std::make_pair(false, "Path '" + normalized_path + "' has a temporal overlap with lot '" + row[0] +
-										 "'. Time ranges (treated as half-open intervals [start, end)) overlap: [" +
-										 std::to_string(creation_time) + ", " + std::to_string(expiration_time) +
-										 ") vs [" + row[1] + ", " + row[2] + ").");
+	for (const auto &row : rp.first) {
+		const std::string &other_lot = row[0];
+		const std::string &other_path = row[1];
+		bool other_recursive = (!row[2].empty() && row[2] != "0");
+
+		if (other_path == normalized_path) {
+			// (1) Exact collision is always rejected.
+			return std::make_pair(false, "Path '" + normalized_path + "' has a temporal overlap with lot '" +
+											 other_lot +
+											 "'. Time ranges (treated as half-open intervals [start, end)) overlap: [" +
+											 std::to_string(creation_time) + ", " + std::to_string(expiration_time) +
+											 ") vs [" + row[3] + ", " + row[4] + ").");
+		}
+
+		// At this point other_path != normalized_path, so it is either a
+		// strict prefix of the candidate or a strict suffix-extension.
+		if (other_path.size() < normalized_path.size()) {
+			// (2) PREFIX-IN: other lot recursively owns a parent of the
+			// candidate path. Allowed only if the candidate lot is a
+			// recursive descendant of the other lot. The SQL guarantees
+			// other_recursive=1 here, but assert defensively.
+			if (!other_recursive) {
+				continue;
+			}
+			auto anc_rp = is_recursive_ancestor(other_lot, lot_name);
+			if (!anc_rp.second.empty()) {
+				return std::make_pair(false, "Descendancy lookup failed while validating path '" + normalized_path +
+												 "' against lot '" + other_lot + "': " + anc_rp.second);
+			}
+			if (!anc_rp.first) {
+				return std::make_pair(
+					false, "Descendancy violation: path '" + normalized_path + "' falls under lot '" + other_lot +
+							   "' which recursively owns the strict prefix '" + other_path +
+							   "' during an overlapping time window. The candidate lot '" + lot_name +
+							   "' must be a sublot (recursive descendant) of '" + other_lot + "' to claim this path.");
+			}
+		} else {
+			// (3) PREFIX-OUT: the candidate is recursive and the other lot
+			// owns a strict subpath. Allowed only if the other lot is a
+			// recursive descendant of the candidate lot. The SQL guarantees
+			// the candidate's recursive flag is true here.
+			if (!recursive) {
+				continue;
+			}
+			auto anc_rp = is_recursive_ancestor(lot_name, other_lot);
+			if (!anc_rp.second.empty()) {
+				return std::make_pair(false, "Descendancy lookup failed while validating path '" + normalized_path +
+												 "' against lot '" + other_lot + "': " + anc_rp.second);
+			}
+			if (!anc_rp.first) {
+				return std::make_pair(
+					false, "Descendancy violation: candidate recursive path '" + normalized_path + "' on lot '" +
+							   lot_name + "' would cover existing path '" + other_path + "' on lot '" + other_lot +
+							   "' during an overlapping time window. '" + other_lot +
+							   "' must be a sublot (recursive descendant) of '" + lot_name + "' for this assignment.");
+			}
+		}
 	}
 
 	return std::make_pair(true, "");
+}
+
+std::pair<bool, std::string> Lot::is_recursive_ancestor(const std::string &ancestor, const std::string &descendant) {
+	if (ancestor == descendant) {
+		return std::make_pair(false, "");
+	}
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+
+		// BFS up from `descendant` looking for `ancestor`. The parents table
+		// maps child→parent edges; self-parent rows (lot_name == parent) are
+		// ignored to avoid trivial loops.
+		std::vector<std::string> frontier{descendant};
+		std::unordered_set<std::string> visited;
+		visited.insert(descendant);
+		while (!frontier.empty()) {
+			std::vector<std::string> next;
+			for (const auto &node : frontier) {
+				auto parents = storage.select(
+					&db::Parent::parent, where(c(&db::Parent::lot_name) == node and c(&db::Parent::parent) != node));
+				for (auto &p : parents) {
+					if (p == ancestor) {
+						return std::make_pair(true, "");
+					}
+					if (visited.insert(p).second) {
+						next.push_back(p);
+					}
+				}
+			}
+			frontier = std::move(next);
+		}
+		return std::make_pair(false, "");
+	} catch (const std::exception &e) {
+		// Surface the underlying error to the caller; "ancestor unknown" is
+		// not a safe stand-in because it would be reported as a descendancy
+		// violation, which is misleading.
+		return std::make_pair(false, std::string("storage error: ") + e.what());
+	}
 }
 
 std::pair<bool, std::string> Lot::store_new_parents(const std::vector<Lot> &new_parents) {

--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -1771,7 +1771,9 @@ bool lotman::Lot::update_paths_in_txn(const json &update_arr, std::string &txn_e
 			auto path_record = rows[0];
 
 			// Apply field updates
-			path_record.recursive = update_obj["recursive"].get<int>();
+			int new_recursive = update_obj["recursive"].get<int>();
+			bool recursive_changed = (path_record.recursive != new_recursive);
+			path_record.recursive = new_recursive;
 			bool exclude_changed_to_false = false;
 			if (update_obj.contains("exclude")) {
 				int new_exclude = update_obj["exclude"].get<int>();
@@ -1781,9 +1783,16 @@ bool lotman::Lot::update_paths_in_txn(const json &update_arr, std::string &txn_e
 				path_record.exclude = new_exclude;
 			}
 
-			// Check temporal overlap if: (1) path changes, OR (2) exclude flips true→false
-			// In case (2), a previously-excluded path becomes active and might conflict
-			if (current_path != new_path || exclude_changed_to_false) {
+			// Re-check temporal overlap if any state change can introduce a
+			// new conflict against the rest of the DB:
+			//   (1) the path string itself changed,
+			//   (2) exclude flipped true -> false (a previously dormant row
+			//       becomes active), or
+			//   (3) the recursive flag toggled. Under the dynamic-ownership
+			//       rules a flip can introduce or relieve PREFIX-IN /
+			//       PREFIX-OUT conflicts even when the path string and
+			//       exclude flag are unchanged.
+			if (current_path != new_path || exclude_changed_to_false || recursive_changed) {
 				// Check temporal overlap for the path (if not excluded)
 				if (!path_record.exclude) {
 					auto this_mpa = storage.get_pointer<db::ManagementPolicyAttributes>(lot_name);

--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -322,6 +322,29 @@ std::pair<bool, std::string> lotman::Lot::store_lot(const json &parent_attributi
 				}
 			}
 
+			// Path overlap (descendancy) check is performed AFTER any
+			// insertion adjustment so the parent table reflects the final
+			// hierarchy that this transaction is committing. This is what
+			// permits "reverse insertion" of an ancestor lot that
+			// recursively covers an existing child lot's path.
+			if (lot_name != "default") {
+				for (const auto &path_json : paths) {
+					bool exclude = path_json.contains("exclude") ? path_json["exclude"].get<bool>() : false;
+					if (exclude) {
+						continue;
+					}
+					std::string normalized = ensure_trailing_slash(path_json.at("path").get<std::string>());
+					bool recursive = path_json.at("recursive").get<bool>();
+					auto overlap =
+						check_path_temporal_overlap(lot_name, normalized, recursive, man_policy_attr.creation_time,
+													man_policy_attr.expiration_time);
+					if (!overlap.first) {
+						txn_error = overlap.second;
+						return false;
+					}
+				}
+			}
+
 			return true;
 		});
 
@@ -1381,6 +1404,45 @@ bool lotman::Lot::reload_and_recompute_attributions(std::string &txn_error, cons
 	}
 }
 
+// Non-transactional helper: re-runs check_path_temporal_overlap for every
+// non-excluded path on this lot. Used after parent-edge or MPA-window changes
+// (and at the end of lotman_update_lot's outer transaction) so any path whose
+// legitimacy depended on the previous state is re-checked. The default lot
+// is skipped: it is the path-of-last-resort and its `/default` row is never
+// legitimized by ancestry, so revalidation is meaningless for it.
+// Caller MUST hold an active storage.transaction().
+bool lotman::Lot::revalidate_paths_in_txn(std::string &txn_error) {
+	if (lot_name == "default") {
+		return true;
+	}
+	try {
+		auto &storage = db::StorageManager::get_storage();
+		using namespace sqlite_orm;
+
+		auto mpa_ptr = storage.get_pointer<db::ManagementPolicyAttributes>(lot_name);
+		if (!mpa_ptr) {
+			// Lot has no MPA (shouldn't happen for a real lot), nothing to check.
+			return true;
+		}
+
+		auto lot_paths =
+			storage.get_all<db::Path>(where(c(&db::Path::lot_name) == lot_name and c(&db::Path::exclude) == false));
+		for (const auto &p : lot_paths) {
+			auto overlap = check_path_temporal_overlap(lot_name, p.path, p.recursive != 0, mpa_ptr->creation_time,
+													   mpa_ptr->expiration_time);
+			if (!overlap.first) {
+				txn_error =
+					"Revalidation of '" + lot_name + "' against the post-update state failed: " + overlap.second;
+				return false;
+			}
+		}
+		return true;
+	} catch (const std::exception &e) {
+		txn_error = std::string("Failed to revalidate paths: ") + e.what();
+		return false;
+	}
+}
+
 // Non-transactional helper: stores parents, reloads state, recomputes attributions, validates.
 // Caller MUST hold an active storage.transaction().
 bool lotman::Lot::add_parents_impl(const std::vector<Lot> &parents, std::string &txn_error,
@@ -1467,8 +1529,9 @@ bool lotman::Lot::add_paths_in_txn(const std::vector<json> &paths, std::string &
 				std::string normalized = ensure_trailing_slash(path_str);
 
 				bool exclude = path_json.contains("exclude") ? path_json["exclude"].get<bool>() : false;
+				bool recursive = path_json.at("recursive").get<bool>();
 				if (!exclude) {
-					auto overlap = check_path_temporal_overlap(lot_name, normalized, this_mpa->creation_time,
+					auto overlap = check_path_temporal_overlap(lot_name, normalized, recursive, this_mpa->creation_time,
 															   this_mpa->expiration_time);
 					if (!overlap.first) {
 						txn_error = overlap.second;
@@ -1533,6 +1596,12 @@ std::pair<bool, std::string> lotman::Lot::remove_parents(const std::vector<std::
 
 			if (lot_name != "default") {
 				if (!reload_and_recompute_attributions(txn_error)) {
+					return false;
+				}
+				// After parent edges shrink, re-check this lot's paths. A path
+				// that was legitimate only because a removed ancestor recursively
+				// covered it must now be rejected.
+				if (!revalidate_paths_in_txn(txn_error)) {
 					return false;
 				}
 			}
@@ -1618,7 +1687,7 @@ std::pair<bool, std::string> lotman::Lot::update_parents(const json &update_arr)
 	return std::make_pair(true, "");
 }
 
-bool lotman::Lot::update_parents_in_txn(const json &update_arr, std::string &txn_error) {
+bool lotman::Lot::update_parents_in_txn(const json &update_arr, std::string &txn_error, bool revalidate_paths) {
 	// First, perform a cycle check on the whole update arr, and fail if any introduce a cycle
 	// Cycle check takes in three arguments -- The start node (in this case, lot_name), and vectors of parents/children
 	// of the start node as strings
@@ -1660,6 +1729,15 @@ bool lotman::Lot::update_parents_in_txn(const json &update_arr, std::string &txn
 	if (lot_name != "default") {
 		if (!reload_and_recompute_attributions(txn_error)) {
 			return false;
+		}
+		// Parent edge swap may invalidate paths that depended on the old
+		// ancestry for a (b) PREFIX-IN match. Re-validate. Skipped when
+		// the caller (e.g. the lotman_update_lot dispatcher) plans to run
+		// its own end-of-transaction revalidation against the final state.
+		if (revalidate_paths) {
+			if (!revalidate_paths_in_txn(txn_error)) {
+				return false;
+			}
 		}
 	}
 	return true;
@@ -1712,8 +1790,8 @@ bool lotman::Lot::update_paths_in_txn(const json &update_arr, std::string &txn_e
 					if (this_mpa) {
 						// Use new_path for case (1), current_path for case (2)
 						std::string path_to_check = (current_path != new_path) ? new_path : current_path;
-						auto overlap = check_path_temporal_overlap(lot_name, path_to_check, this_mpa->creation_time,
-																   this_mpa->expiration_time);
+						auto overlap = check_path_temporal_overlap(lot_name, path_to_check, path_record.recursive != 0,
+																   this_mpa->creation_time, this_mpa->expiration_time);
 						if (!overlap.first) {
 							txn_error = overlap.second;
 							return false;
@@ -1846,7 +1924,8 @@ bool lotman::Lot::update_man_policy_attrs_in_txn(const std::string &update_key, 
 		auto lot_paths =
 			storage.get_all<db::Path>(where(c(&db::Path::lot_name) == lot_name and c(&db::Path::exclude) == false));
 		for (const auto &p : lot_paths) {
-			auto overlap = check_path_temporal_overlap(lot_name, p.path, mpa.creation_time, mpa.expiration_time);
+			auto overlap =
+				check_path_temporal_overlap(lot_name, p.path, p.recursive != 0, mpa.creation_time, mpa.expiration_time);
 			if (!overlap.first) {
 				txn_error = "MPA update on '" + lot_name + "' would create path conflict: " + overlap.second;
 				return false;

--- a/src/lotman_internal.h
+++ b/src/lotman_internal.h
@@ -427,7 +427,12 @@ class Lot {
 	// per-step axiom revalidation), but does NOT open its own transaction.
 	// Returns false and sets txn_error on failure to trigger rollback.
 	bool update_owner_in_txn(const std::string &update_val, std::string &txn_error);
-	bool update_parents_in_txn(const json &update_arr, std::string &txn_error);
+	// `revalidate_paths` controls whether this lot's paths are re-checked
+	// against the new ancestry within this call. Standalone callers want
+	// true; the lotman_update_lot dispatcher passes false and runs a
+	// single end-of-transaction revalidation so that simultaneous
+	// path-and-parent edits validate against the final committed state.
+	bool update_parents_in_txn(const json &update_arr, std::string &txn_error, bool revalidate_paths = true);
 	bool update_paths_in_txn(const json &update_arr, std::string &txn_error);
 	bool update_man_policy_attrs_in_txn(const std::string &update_key, double update_val, std::string &txn_error);
 	bool update_attributions_in_txn(const json &parent_attributions_json, std::string &txn_error);
@@ -437,6 +442,16 @@ class Lot {
 	// back to a pure equal split across all parents.
 	bool add_parents_in_txn(const std::vector<Lot> &parents, std::string &txn_error,
 							const json &parent_attributions_json = json());
+
+	// Re-run check_path_temporal_overlap for every non-excluded path on this
+	// lot against the current DB state. Used after parent-edge or MPA-window
+	// changes (and at the end of lotman_update_lot's outer transaction) so
+	// simultaneous edits validate against the final committed state. The
+	// default lot is a no-op (it is always the path-of-last-resort and never
+	// has its paths legitimized by ancestry). Caller MUST hold an active
+	// storage.transaction(). Returns false and sets txn_error on the first
+	// violation.
+	bool revalidate_paths_in_txn(std::string &txn_error);
 
   private:
 	std::pair<bool, std::string> write_new();
@@ -452,9 +467,33 @@ class Lot {
 
 	// Check whether a path conflicts with another lot's claim during overlapping time ranges.
 	// Caller MUST be inside an active storage.transaction().
+	//
+	// Conflict rules (the candidate path is the new/updated path on `lot_name`):
+	//   - EXACT collision: another live lot owns exactly `normalized_path` (any
+	//     recursive flag) → reject.
+	//   - PREFIX-IN: another live lot owns a strict prefix of `normalized_path`
+	//     with `recursive=1` → allowed only if `lot_name` is a recursive
+	//     descendant of that lot. (Dynamic-ownership rule: the deepest sublot
+	//     dynamically claims the subpath.)
+	//   - PREFIX-OUT: `recursive` is true on the candidate AND another live lot
+	//     owns a strict prefix-suffix path under `normalized_path` → allowed
+	//     only if that lot is a recursive descendant of `lot_name`.
+	//
+	// Excluded rows (`exclude=1`) on either side are ignored (escape hatch).
+	// The `recursive` flag describes the candidate path being checked.
 	static std::pair<bool, std::string> check_path_temporal_overlap(const std::string &lot_name,
-																	const std::string &normalized_path,
+																	const std::string &normalized_path, bool recursive,
 																	int64_t creation_time, int64_t expiration_time);
+
+	// Returns (true, "") if `descendant` is reachable from `ancestor` via the
+	// parents table (i.e., `ancestor` appears among `descendant`'s recursive
+	// parents). Returns (false, "") if no such path exists or if
+	// `ancestor == descendant`. On a storage error, returns (false, <reason>)
+	// so the caller can surface a precise diagnostic instead of misreporting
+	// a descendancy violation. Caller MUST be inside an active
+	// storage.transaction() (or otherwise hold the storage).
+	static std::pair<bool, std::string> is_recursive_ancestor(const std::string &ancestor,
+															  const std::string &descendant);
 
 	// Non-transactional helpers for composing inside an outer transaction.
 	// Callers MUST hold an active storage.transaction().

--- a/src/schemas.h
+++ b/src/schemas.h
@@ -84,7 +84,7 @@ inline json new_lot_schema = []() {
                     },
                     "exclude": {
                         "type": "boolean",
-                        "description": "If true, this path is excluded from the lot's tracking"
+                        "description": "Escape hatch: when true, this path row is ignored by both path-to-lot resolution and the descendancy/temporal overlap check. Prefer the dynamic-ownership model (a sublot whose path is a strict subpath of an ancestor's recursive path automatically claims its subtree) over explicit exclusions."
                     }
                 },
                 "required": ["path", "recursive"]
@@ -342,7 +342,7 @@ inline json lot_additions_schema = []() {
                     },
                     "exclude": {
                         "type": "boolean",
-                        "description": "If true, this path is excluded from the lot's tracking"
+                        "description": "Escape hatch: when true, this path row is ignored by both path-to-lot resolution and the descendancy/temporal overlap check. Prefer the dynamic-ownership model (a sublot whose path is a strict subpath of an ancestor's recursive path automatically claims its subtree) over explicit exclusions."
                     }
                 },
                 "required": ["path", "recursive"]

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(lotman-gtest main.cpp orm_tests.cpp migration_tests.cpp strict_hierarchy_tests.cpp reclamation_tests.cpp ../src/lotman.cpp ../src/lotman_db.cpp ../src/lotman_internal.cpp)
+add_executable(lotman-gtest main.cpp orm_tests.cpp migration_tests.cpp strict_hierarchy_tests.cpp reclamation_tests.cpp dynamic_ownership_tests.cpp ../src/lotman.cpp ../src/lotman_db.cpp ../src/lotman_internal.cpp)
 if( NOT LOTMAN_EXTERNAL_GTEST )
     add_dependencies(lotman-gtest gtest)
     include_directories("${PROJECT_SOURCE_DIR}/vendor/gtest/googletest/include")

--- a/test/dynamic_ownership_tests.cpp
+++ b/test/dynamic_ownership_tests.cpp
@@ -739,4 +739,209 @@ TEST_F(DynamicOwnershipTest, ViolationMessageIdentifiesAncestor) {
 		<< "A genuine descendancy denial should not contain a storage-error fragment: " << err;
 }
 
+// F17 (PR #51 review, comment 1): toggling the `recursive` flag on an
+// existing path is itself a state change that can introduce a PREFIX-OUT
+// conflict, even when the path string and exclude flag are untouched.
+// Behavior-locking guard ensuring such a flip is rejected. NOTE: with the
+// current public-API surface, `lotman_update_lot` runs an end-of-txn
+// revalidation that catches this bug regardless of the per-row inline
+// check. The corresponding source fix (also re-checking on
+// `recursive_changed` in update_paths_in_txn) is therefore defense-in-
+// depth — it produces a clearer per-row error and protects against
+// regressions if a future caller of update_paths_in_txn skips the
+// end-of-txn backstop. This test guards the externally-observable
+// behavior; if either layer of defense is broken in isolation it still
+// passes, but if both regress it will fail.
+TEST_F(DynamicOwnershipTest, FlippingRecursiveTrueRetriggersDescendancyCheck) {
+	// lot1 owns /foo NON-recursively, so lot2 (unrelated) is free to claim
+	// /foo/bar at this moment: there is no PREFIX-IN conflict because lot1
+	// is non-recursive.
+	addLot(R"({
+		"lot_name": "lot1",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo", "recursive": false}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Now flip lot1's /foo to recursive. lot2 is unrelated, so this would
+	// create a PREFIX-OUT conflict (lot1's recursive /foo would cover
+	// lot2's /foo/bar without lot2 being a sublot of lot1).
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot(R"({
+		"lot_name": "lot1",
+		"paths": [{"current": "/foo", "new": "/foo", "recursive": true}]
+	})",
+							   &raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0) << "Expected the recursive=true flip on /foo to be rejected because unrelated lot2 owns /foo/bar";
+	EXPECT_NE(std::string(err.get() ? err.get() : "").find("Descendancy violation"), std::string::npos)
+		<< "err=" << (err.get() ? err.get() : "");
+}
+
+// F18 (PR #51 review, comment 2): SQL prefix matching must treat path
+// strings literally. SQLite's LIKE treats '_' as a single-character
+// wildcard and '%' as any-string, so paths containing those characters
+// would falsely match unrelated paths. Regression guard for the prior
+// `?4 LIKE p.path || '%'` formulation; the fix uses substr() instead.
+TEST_F(DynamicOwnershipTest, PathWithUnderscoreNotTreatedAsWildcard) {
+	// lot1 recursively owns /foo_bar/. Under LIKE matching, the prefix
+	// expression '/foo_bar/%' would match '/fooXbar/baz/' because '_'
+	// matches any single character. Under literal substr matching it does
+	// not, so an unrelated lot may legally claim /fooXbar/baz/.
+	addLot(R"({
+		"lot_name": "lot1",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo_bar/", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	std::string err;
+	int rv = tryAddLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/fooXbar/baz/", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+					   err);
+	EXPECT_EQ(rv, 0) << "/fooXbar/baz/ is not a true subpath of /foo_bar/; '_' must compare literally. err=" << err;
+
+	// Sanity: a *real* descendant (literal '_' match) is still rejected
+	// when the descendancy rule isn't satisfied.
+	std::string err2;
+	int rv2 = tryAddLot(R"({
+		"lot_name": "lot3",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo_bar/baz/", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						err2);
+	EXPECT_NE(rv2, 0) << "Genuine subpath of recursive lot1 must still trigger descendancy check";
+	EXPECT_NE(err2.find("Descendancy violation"), std::string::npos) << "err=" << err2;
+}
+
+// F19 (PR #51 review, comment 3): is_recursive_ancestor was reimplemented
+// to prefetch all parent edges in a single query and BFS in memory.
+// Functional sanity test for a deep ancestry chain (5 levels) to confirm
+// the rewrite preserves correctness across multi-hop ancestry.
+TEST_F(DynamicOwnershipTest, DeepAncestryChainResolvesCorrectly) {
+	// Build chain: a -> b -> c -> d -> e (default -> a, a -> b, ...)
+	// "x -> y" here means y has x as parent.
+	auto addChainLot = [&](const char *name, const char *parent) {
+		std::string body = R"({"lot_name": ")";
+		body += name;
+		body += R"(", "owner": "owner1", "parents": [")";
+		body += parent;
+		body += R"("], "paths": [], "management_policy_attrs": {)";
+		body += R"("dedicated_GB":10,"opportunistic_GB":5,"max_num_objects":100,)";
+		body += R"("creation_time":100,"expiration_time":9000,"deletion_time":9500}})";
+		addLot(body.c_str());
+	};
+	// Root with a recursive path that the deep descendant will try to claim under.
+	addLot(R"({
+		"lot_name": "root_chain",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/chain", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+	addChainLot("a", "root_chain");
+	addChainLot("b", "a");
+	addChainLot("c", "b");
+	addChainLot("d", "c");
+
+	// e is 5 hops below root_chain. is_recursive_ancestor must walk the
+	// full chain to confirm e descends from root_chain and accept the
+	// deeply-nested recursive subpath.
+	std::string err;
+	int rv = tryAddLot(R"({
+		"lot_name": "e",
+		"owner": "owner1",
+		"parents": ["d"],
+		"paths": [{"path": "/chain/x/y/z", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+					   err);
+	EXPECT_EQ(rv, 0) << "Deep descendant of root_chain must be allowed under /chain. err=" << err;
+
+	// Negative control: an unrelated lot at the same depth must be rejected.
+	std::string err2;
+	int rv2 = tryAddLot(R"({
+		"lot_name": "intruder",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/chain/x/y/w", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+						err2);
+	EXPECT_NE(rv2, 0) << "Unrelated lot must still be rejected under deep recursive root. err=" << err2;
+	EXPECT_NE(err2.find("Descendancy violation"), std::string::npos) << "err=" << err2;
+}
+
 } // namespace

--- a/test/dynamic_ownership_tests.cpp
+++ b/test/dynamic_ownership_tests.cpp
@@ -1,0 +1,742 @@
+// Tests covering the dynamic-ownership / descendancy rule for path resources.
+//
+// Background: Lotman previously enforced exclusive path ownership via an
+// exact-path temporal-overlap check; carve-outs were expressed via explicit
+// `exclude` rows. The dynamic-ownership model lets a sublot whose path is a
+// strict subpath of an ancestor's recursive path automatically claim its
+// subtree without an explicit exclusion row. The descendancy rule is
+// enforced when adding/updating non-excluded paths:
+//   - Same-path collisions during overlapping windows are rejected.
+//   - If another live lot's recursive path is a strict prefix of the
+//     candidate path, the candidate must be a recursive descendant of that
+//     other lot.
+//   - If the candidate path is recursive and would cover an existing lot's
+//     path, that other lot must be a recursive descendant of the candidate.
+//   - `exclude=1` rows on either side bypass the check (escape hatch).
+
+#include "../src/lotman.h"
+#include "test_utils.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+namespace {
+
+class DynamicOwnershipTest : public ::testing::Test {
+  protected:
+	std::string tmp_dir;
+
+	void SetUp() override {
+		tmp_dir = create_temp_directory("lotman_dyn_test");
+		char *raw_err = nullptr;
+		int rv = lotman_set_context_str("lot_home", tmp_dir.c_str(), &raw_err);
+		UniqueCString err(raw_err);
+		ASSERT_EQ(rv, 0) << err.get();
+		rv = lotman_set_context_str("caller", "owner1", &raw_err);
+		err.reset(raw_err);
+		ASSERT_EQ(rv, 0) << err.get();
+		rv = lotman_set_context_str("strict_hierarchy", "false", &raw_err);
+		err.reset(raw_err);
+		ASSERT_EQ(rv, 0) << err.get();
+
+		// Common scaffold: default lot + a root that recursively owns /foo.
+		addLot(R"({
+			"lot_name": "default",
+			"owner": "owner1",
+			"parents": ["default"],
+			"paths": [{"path": "/default", "recursive": true}],
+			"management_policy_attrs": {
+				"dedicated_GB": 1000,
+				"opportunistic_GB": 500,
+				"max_num_objects": 10000,
+				"creation_time": 0,
+				"expiration_time": 0,
+				"deletion_time": 0
+			}
+		})");
+	}
+
+	void TearDown() override {
+		std::filesystem::remove_all(tmp_dir);
+	}
+
+	void addLot(const char *json_str) {
+		char *raw_err = nullptr;
+		int rv = lotman_add_lot(json_str, &raw_err);
+		UniqueCString err(raw_err);
+		ASSERT_EQ(rv, 0) << "addLot failed: " << (err.get() ? err.get() : "unknown");
+	}
+
+	int tryAddLot(const char *json_str, std::string &err_out) {
+		char *raw_err = nullptr;
+		int rv = lotman_add_lot(json_str, &raw_err);
+		if (raw_err) {
+			err_out.assign(raw_err);
+			free(raw_err);
+		} else {
+			err_out.clear();
+		}
+		return rv;
+	}
+
+	std::string resolveDir(const char *dir, int64_t query_time) {
+		char **lots = nullptr;
+		char *raw_err = nullptr;
+		int rv = lotman_get_lots_from_dir(dir, false, query_time, &lots, &raw_err);
+		UniqueCString err(raw_err);
+		if (rv != 0 || !lots || !lots[0]) {
+			lotman_free_string_list(lots);
+			return std::string("<error:") + (err.get() ? err.get() : "unknown") + ">";
+		}
+		std::string result = lots[0];
+		lotman_free_string_list(lots);
+		return result;
+	}
+
+	// Helper: build a recursive lot owning /foo with parent=default.
+	void addLotFooRecursive(const char *name = "lot1") {
+		std::string body = R"({
+			"lot_name": ")";
+		body += name;
+		body += R"(",
+			"owner": "owner1",
+			"parents": ["default"],
+			"paths": [{"path": "/foo", "recursive": true}],
+			"management_policy_attrs": {
+				"dedicated_GB": 100,
+				"opportunistic_GB": 50,
+				"max_num_objects": 1000,
+				"creation_time": 100,
+				"expiration_time": 9000,
+				"deletion_time": 9500
+			}
+		})";
+		addLot(body.c_str());
+	}
+};
+
+// F1: forward sublot allowed — sublot of an ancestor with recursive coverage
+// claims a strict subpath without needing an exclude row, and resolution
+// picks the correct lot for each query path.
+TEST_F(DynamicOwnershipTest, ForwardSublotAllowedAndResolves) {
+	addLotFooRecursive("lot1");
+
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["lot1"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	EXPECT_EQ(resolveDir("/foo/other", 500), "lot1");
+	EXPECT_EQ(resolveDir("/foo/bar", 500), "lot2");
+	EXPECT_EQ(resolveDir("/foo/bar/baz", 500), "lot2");
+	EXPECT_EQ(resolveDir("/foo", 500), "lot1");
+}
+
+// F2: a candidate whose path falls inside an unrelated lot's recursive
+// coverage (overlapping in time) must be rejected.
+TEST_F(DynamicOwnershipTest, ForwardUnrelatedRejected) {
+	addLotFooRecursive("lot1");
+
+	// lot2 has parent=default, so it's NOT a descendant of lot1.
+	std::string err;
+	int rv = tryAddLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+					   err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(err.find("Descendancy violation"), std::string::npos) << "err=" << err;
+	EXPECT_NE(err.find("lot1"), std::string::npos) << "err=" << err;
+}
+
+// F3: a sublot may not claim the EXACT same path as an ancestor's recursive
+// path during overlapping windows.
+TEST_F(DynamicOwnershipTest, SamePathAsAncestorRejected) {
+	addLotFooRecursive("lot1");
+
+	std::string err;
+	int rv = tryAddLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["lot1"],
+		"paths": [{"path": "/foo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+					   err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(err.find("temporal overlap"), std::string::npos) << "err=" << err;
+}
+
+// F4: reverse insertion — lot2 already owns /foo/bar; later add lot1 with
+// `/foo` recursive AND list lot2 as a child so the insertion adjustment
+// rewires lot2.parent → lot1 inside the same transaction. The path check
+// runs AFTER insertion adjustment, so descendancy is satisfied.
+TEST_F(DynamicOwnershipTest, ReverseInsertionAllowedWithChildEdge) {
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	addLot(R"({
+		"lot_name": "lot1",
+		"owner": "owner1",
+		"parents": ["default"],
+		"children": ["lot2"],
+		"paths": [{"path": "/foo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	EXPECT_EQ(resolveDir("/foo", 500), "lot1");
+	EXPECT_EQ(resolveDir("/foo/bar", 500), "lot2");
+	EXPECT_EQ(resolveDir("/foo/other", 500), "lot1");
+}
+
+// F5: reverse insertion without the child edge is rejected.
+TEST_F(DynamicOwnershipTest, ReverseInsertionRejectedWithoutChildEdge) {
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	std::string err;
+	int rv = tryAddLot(R"({
+		"lot_name": "lot1",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})",
+					   err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(err.find("Descendancy violation"), std::string::npos) << "err=" << err;
+}
+
+// F6: multi-ancestor coverage — when more than one live, non-excluded
+// recursive owner of a parent path overlaps the candidate's window, the
+// candidate must descend from EVERY one of them. Two unrelated lots can
+// both legally own `/foo` recursively as long as their windows don't
+// overlap; a candidate sublot at `/foo/bar` whose window straddles BOTH
+// owners' windows must therefore descend from both.
+TEST_F(DynamicOwnershipTest, MultiAncestorMustDescendFromAll) {
+	// lot1 owns /foo recursively in window [1, 100).
+	addLot(R"({
+		"lot_name": "lot1",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 1,
+			"expiration_time": 100,
+			"deletion_time": 150
+		}
+	})");
+	// lot2 owns the same /foo recursively in disjoint window [200, 300).
+	// (Disjoint windows on the same path are allowed under the existing
+	// EXACT-overlap rule, so this addition itself is legal.)
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 200,
+			"expiration_time": 300,
+			"deletion_time": 350
+		}
+	})");
+
+	// Candidate sublot at /foo/bar whose window [50, 250) overlaps both
+	// owners. With only lot1 as parent, it must be rejected because lot2's
+	// /foo row also overlaps and lot2 is not an ancestor.
+	std::string err;
+	int rv = tryAddLot(R"({
+		"lot_name": "sublot",
+		"owner": "owner1",
+		"parents": ["lot1"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 50,
+			"expiration_time": 250,
+			"deletion_time": 300
+		}
+	})",
+					   err);
+	EXPECT_NE(rv, 0) << "sublot should be rejected: lot2 covers /foo in overlapping window and is not an ancestor";
+	EXPECT_NE(err.find("Descendancy violation"), std::string::npos) << "err=" << err;
+	EXPECT_NE(err.find("lot2"), std::string::npos) << "err=" << err;
+
+	// Same candidate, but now declaring BOTH lot1 and lot2 as parents,
+	// must succeed.
+	std::string err2;
+	int rv2 = tryAddLot(R"({
+		"lot_name": "sublot",
+		"owner": "owner1",
+		"parents": ["lot1", "lot2"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 50,
+			"expiration_time": 250,
+			"deletion_time": 300
+		}
+	})",
+						err2);
+	ASSERT_EQ(rv2, 0) << "Adding sublot under both lot1 and lot2 should succeed: " << err2;
+	// Resolution: in lot1's window, /foo/bar resolves to sublot; in lot2's
+	// window, also sublot.
+	EXPECT_EQ(resolveDir("/foo/bar", 75), "sublot");
+	EXPECT_EQ(resolveDir("/foo/bar", 225), "sublot");
+}
+
+// F6b (renamed): non-overlapping ancestor windows do NOT trigger the
+// must-descend-from-all rule. lot1 owns /foo in [100, 9000); a second,
+// unrelated owner of /foo lives strictly after lot1's deletion_time and
+// therefore does not constrain a sublot whose window overlaps lot1 only.
+TEST_F(DynamicOwnershipTest, NonOverlappingAncestorWindowSkipsRule) {
+	addLotFooRecursive("lot1");
+
+	addLot(R"({
+		"lot_name": "lotLate",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 9500,
+			"expiration_time": 9999,
+			"deletion_time": 10000
+		}
+	})");
+
+	// sublot's window is fully inside lot1's window and disjoint from
+	// lotLate's; therefore lotLate's /foo must NOT trigger a descendancy
+	// failure even though sublot is not a descendant of lotLate.
+	addLot(R"({
+		"lot_name": "sublot",
+		"owner": "owner1",
+		"parents": ["lot1"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+	EXPECT_EQ(resolveDir("/foo/bar", 500), "sublot");
+}
+
+// F7: no covering ancestor exists — lot2 with /foo/bar should be allowed
+// regardless of hierarchy when nobody recursively owns /foo.
+TEST_F(DynamicOwnershipTest, NoCoveringAncestorAllowed) {
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+	EXPECT_EQ(resolveDir("/foo/bar", 500), "lot2");
+	// Nobody owns /foo, so it should resolve to default.
+	EXPECT_EQ(resolveDir("/foo", 500), "default");
+}
+
+// F8: non-recursive ancestor + descendant subpath: no descendancy required.
+TEST_F(DynamicOwnershipTest, NonRecursiveAncestorNoRequirement) {
+	addLot(R"({
+		"lot_name": "lot1",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo", "recursive": false}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	// lot2 unrelated (parent=default), claims /foo/bar — should be allowed
+	// because lot1's /foo is non-recursive.
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+	EXPECT_EQ(resolveDir("/foo", 500), "lot1");
+	EXPECT_EQ(resolveDir("/foo/bar", 500), "lot2");
+	EXPECT_EQ(resolveDir("/foo/other", 500), "default") << "non-recursive lot1 should not cover /foo/other";
+}
+
+// F9: default lot fallback — paths with no covering lot resolve to default
+// without requiring descendancy from default.
+TEST_F(DynamicOwnershipTest, DefaultLotIsFallbackOnly) {
+	EXPECT_EQ(resolveDir("/anything/else", 500), "default");
+
+	// A lot whose path doesn't overlap default's /default coverage and is
+	// unrelated to default should still be addable.
+	addLot(R"({
+		"lot_name": "lotX",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/elsewhere", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+}
+
+// F10: removing a sublot reverts ownership to the ancestor.
+TEST_F(DynamicOwnershipTest, SublotRemovalRevertsOwnership) {
+	addLotFooRecursive("lot1");
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["lot1"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+	EXPECT_EQ(resolveDir("/foo/bar", 500), "lot2");
+
+	char *raw_err = nullptr;
+	int rv = lotman_remove_lots_recursive("lot2", &raw_err);
+	UniqueCString err(raw_err);
+	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
+	EXPECT_EQ(resolveDir("/foo/bar", 500), "lot1");
+}
+
+// F11: removing a parent edge that legitimized a path must reject mid-txn.
+TEST_F(DynamicOwnershipTest, ParentRemovalRejectedWhenItInvalidatesPath) {
+	addLotFooRecursive("lot1");
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["lot1"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Adding default as a second parent first so the removal of lot1 leaves
+	// lot2 with at least one parent.
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot(R"({
+		"lot_name": "lot2",
+		"parents": [{"current": "lot1", "new": "default"}]
+	})",
+							   &raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0) << "Expected rejection because lot2's path /foo/bar would no longer have lot1 as ancestor";
+	EXPECT_NE(std::string(err.get() ? err.get() : "").find("Descendancy violation"), std::string::npos);
+}
+
+// F12: exclude=1 escape hatch — an excluded row continues to bypass the
+// descendancy check. This is a regression guard for the "keep exclude as
+// escape hatch" decision.
+TEST_F(DynamicOwnershipTest, ExcludeRowBypassesDescendancyRule) {
+	addLotFooRecursive("lot1");
+
+	// lot2 unrelated, but with exclude=1 — the descendancy check should be
+	// skipped for excluded rows even though /foo/bar falls under lot1's
+	// recursive coverage.
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo/bar", "recursive": true, "exclude": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+	// Resolution still returns lot1 since lot2's row is excluded.
+	EXPECT_EQ(resolveDir("/foo/bar", 500), "lot1");
+}
+
+// F13: temporal stagger preserved — when windows don't overlap, no
+// descendancy required even for unrelated lots.
+TEST_F(DynamicOwnershipTest, TemporalStaggerPreserved) {
+	addLot(R"({
+		"lot_name": "lot1",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 100,
+			"expiration_time": 200,
+			"deletion_time": 300
+		}
+	})");
+
+	// Unrelated lot2 with window strictly after lot1 — allowed.
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 300,
+			"expiration_time": 400,
+			"deletion_time": 500
+		}
+	})");
+	EXPECT_EQ(resolveDir("/foo/bar", 350), "lot2");
+	EXPECT_EQ(resolveDir("/foo/bar", 150), "lot1") << "lot1 still covers in its window";
+}
+
+// F14: MPA expansion re-validates path overlaps. lot2 unrelated owns
+// /foo/bar in [200, 300). lot1 lives [400, 500) recursively owning /foo.
+// Expanding lot1's expiration to 600 — still no overlap. Expanding to
+// e.g. 250 (so lot1 now overlaps lot2's window) must reject.
+TEST_F(DynamicOwnershipTest, MpaExpansionRevalidates) {
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 300,
+			"deletion_time": 350
+		}
+	})");
+	addLot(R"({
+		"lot_name": "lot1",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 400,
+			"expiration_time": 500,
+			"deletion_time": 600
+		}
+	})");
+
+	// Expand lot1's creation_time backward to 100 so it overlaps lot2's
+	// [200, 300) window. Note: expansion of creation_time backward (i.e.
+	// decreasing it) requires admin_override under "alive" contraction
+	// policy, but with policy="none" (default) it is permitted.
+	char *raw_err = nullptr;
+	int rv = lotman_update_lot(R"({
+		"lot_name": "lot1",
+		"management_policy_attrs": {"creation_time": 100}
+	})",
+							   &raw_err);
+	UniqueCString err(raw_err);
+	EXPECT_NE(rv, 0) << "Expected rejection: lot1 expansion would now cover unrelated lot2's /foo/bar";
+	EXPECT_NE(std::string(err.get() ? err.get() : "").find("path conflict"), std::string::npos);
+}
+
+// F15: PREFIX-OUT vs. unrelated non-recursive subpath. lot1 (unrelated)
+// owns /foo/bar NON-recursively. A second unrelated lot2 attempts to
+// recursively claim the parent /foo. Even though deepest-prefix resolution
+// could in principle keep lot1 as the owner of the single point /foo/bar
+// while lot2 picks up everything else under /foo, we INTENTIONALLY reject
+// this. Lotman's philosophy is that owners must consent (via a parent edge)
+// before another lot reshapes the policy environment around their paths;
+// reshaping the children of /foo/bar to be tracked by an unrelated lot2
+// without lot1's consent would silently change lot1's neighborhood. This
+// test locks in the conservative rejection.
+TEST_F(DynamicOwnershipTest, RecursiveCoverOverNonRecursiveSubpathRejected) {
+	addLot(R"({
+		"lot_name": "lot1",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo/bar", "recursive": false}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 9000,
+			"deletion_time": 9500
+		}
+	})");
+
+	std::string err;
+	int rv = tryAddLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 100,
+			"opportunistic_GB": 50,
+			"max_num_objects": 1000,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+					   err);
+	EXPECT_NE(rv, 0);
+	EXPECT_NE(err.find("Descendancy violation"), std::string::npos) << "err=" << err;
+	EXPECT_NE(err.find("/foo/bar"), std::string::npos) << "err=" << err;
+}
+
+// F16: Diagnostic precision — when a descendancy violation is reported,
+// the message must name the conflicting ancestor lot specifically (not a
+// generic storage error). This guards against the previous behavior in
+// which a transient SQLite error inside is_recursive_ancestor was silently
+// reinterpreted as "not an ancestor", producing a misleading violation
+// message that pointed at no useful lot.
+TEST_F(DynamicOwnershipTest, ViolationMessageIdentifiesAncestor) {
+	addLotFooRecursive("lot1");
+
+	std::string err;
+	int rv = tryAddLot(R"({
+		"lot_name": "intruder",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo/sub", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})",
+					   err);
+	ASSERT_NE(rv, 0);
+	EXPECT_NE(err.find("Descendancy violation"), std::string::npos) << err;
+	EXPECT_NE(err.find("'lot1'"), std::string::npos) << "Expected the offending ancestor lot1 to be named: " << err;
+	EXPECT_EQ(err.find("storage error"), std::string::npos)
+		<< "A genuine descendancy denial should not contain a storage-error fragment: " << err;
+}
+
+} // namespace

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -2232,14 +2232,17 @@ TEST_F(LotManTest, PathExclusionTest) {
 	EXPECT_EQ(final_paths_json[0]["path"], "/test/path/");
 
 	// Edge case: Test exclusion path that is a prefix of another valid path
-	// e.g., exclude /data/cache but /data/cachedata should NOT be excluded
+	// e.g., exclude /pdata/cache but /pdata/cachedata should NOT be excluded.
+	// Uses a /pdata root rather than /data so the recursive coverage does
+	// not collide with exclusion_lot's existing /data/storage claim under
+	// the dynamic-ownership descendancy rule.
 	const char *prefix_lot = R"({
 		"lot_name": "prefix_test_lot",
 		"owner": "owner1",
 		"parents": ["lot1"],
 		"paths": [
-			{"path": "/data", "recursive": true, "exclude": false},
-			{"path": "/data/cache", "recursive": true, "exclude": true}
+			{"path": "/pdata", "recursive": true, "exclude": false},
+			{"path": "/pdata/cache", "recursive": true, "exclude": true}
 		],
 		"management_policy_attrs": {
 			"dedicated_GB": 5,
@@ -2255,28 +2258,28 @@ TEST_F(LotManTest, PathExclusionTest) {
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << "Failed to add prefix test lot: " << err_msg.get();
 
-	// /data/cache should be excluded
+	// /pdata/cache should be excluded
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/cache", false, 150, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/pdata/cache", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
-	EXPECT_STREQ(lots_output[0], "default") << "/data/cache should be excluded";
+	EXPECT_STREQ(lots_output[0], "default") << "/pdata/cache should be excluded";
 	lotman_free_string_list(lots_output);
 
-	// /data/cachedata should NOT be excluded (different path, just happens to have "cache" prefix)
+	// /pdata/cachedata should NOT be excluded (different path, just happens to have "cache" prefix)
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/cachedata", false, 150, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/pdata/cachedata", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
-	EXPECT_STREQ(lots_output[0], "prefix_test_lot") << "/data/cachedata should NOT be excluded (different path)";
+	EXPECT_STREQ(lots_output[0], "prefix_test_lot") << "/pdata/cachedata should NOT be excluded (different path)";
 	lotman_free_string_list(lots_output);
 
-	// /data/cache/subdir should be excluded (under recursive exclusion)
+	// /pdata/cache/subdir should be excluded (under recursive exclusion)
 	lots_output = nullptr;
-	rv = lotman_get_lots_from_dir("/data/cache/subdir", false, 150, &lots_output, &raw_err);
+	rv = lotman_get_lots_from_dir("/pdata/cache/subdir", false, 150, &lots_output, &raw_err);
 	err_msg.reset(raw_err);
 	ASSERT_EQ(rv, 0) << err_msg.get();
-	EXPECT_STREQ(lots_output[0], "default") << "/data/cache/subdir should be excluded";
+	EXPECT_STREQ(lots_output[0], "default") << "/pdata/cache/subdir should be excluded";
 	lotman_free_string_list(lots_output);
 }
 

--- a/test/strict_hierarchy_tests.cpp
+++ b/test/strict_hierarchy_tests.cpp
@@ -5281,11 +5281,15 @@ TEST_F(StrictHierarchyTest, UpdateParentsRecomputesAttributions) {
 		}
 	})");
 
-	// Move child from parent_a to parent_b via update_lot
+	// Move child from parent_a to parent_b via update_lot. Under the
+	// dynamic-ownership rule the child's path must also be moved out of
+	// parent_a's recursive coverage and into parent_b's, so we update
+	// `paths` in the same call.
 	raw_err = nullptr;
 	rv = lotman_update_lot(R"({
 		"lot_name": "child",
-		"parents": [{"current": "parent_a", "new": "parent_b"}]
+		"parents": [{"current": "parent_a", "new": "parent_b"}],
+		"paths": [{"current": "/root/data/a/child", "new": "/root/data/b/child", "recursive": true}]
 	})",
 						   &raw_err);
 	err.reset(raw_err);


### PR DESCRIPTION
Dynamic path resolution lets the deepest live sublot own a subtree, but that only works if hierarchy edges remain the source of authority.  The old exact-path overlap check allowed a lot to carve out a subpath beneath another lot's recursive coverage without being in that lot's parent chain, which made ownership resolution disagree with the declared hierarchy.

Treat recursive prefix coverage as a consent boundary.  When a live path claim overlaps another lot's recursive coverage, the claiming lot must be a recursive descendant of every overlapping covering lot; when a recursive claim would cover an existing subpath, the covered lot must descend from the claimant.  Parent, path, and MPA updates revalidate against the final transaction state so legitimate simultaneous rewires can succeed while removing an authority edge cannot leave a stale path claim behind.

Storage lookup errors in ancestry checks are now reported as lookup failures rather than folded into "not an ancestor", keeping enforcement diagnostics precise and avoiding fail-open ambiguity.