### PR TITLE
Expose query_time on past_exp/past_del; add window-aware `get_lots_for_path`

### DIFF
--- a/src/lotman.cpp
+++ b/src/lotman.cpp
@@ -1388,7 +1388,8 @@ int lotman_check_db_health(char **err_msg) {
 	return -1;
 }
 
-int lotman_get_lots_past_exp(const bool recursive, const bool include_reclaimed, char ***output, char **err_msg) {
+int lotman_get_lots_past_exp(int64_t query_time, const bool recursive, const bool include_reclaimed, char ***output,
+							 char **err_msg) {
 	try {
 		auto rp_bool_str = lotman::Lot::update_db_children_usage();
 		if (!rp_bool_str.first) {
@@ -1400,7 +1401,7 @@ int lotman_get_lots_past_exp(const bool recursive, const bool include_reclaimed,
 			return -1;
 		}
 
-		auto rp = lotman::Lot::get_lots_past_exp(recursive, include_reclaimed);
+		auto rp = lotman::Lot::get_lots_past_exp(query_time, recursive, include_reclaimed);
 		if (!rp.second.empty()) {
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -1435,7 +1436,8 @@ int lotman_get_lots_past_exp(const bool recursive, const bool include_reclaimed,
 	}
 }
 
-int lotman_get_lots_past_del(const bool recursive, const bool include_reclaimed, char ***output, char **err_msg) {
+int lotman_get_lots_past_del(int64_t query_time, const bool recursive, const bool include_reclaimed, char ***output,
+							 char **err_msg) {
 	try {
 		auto rp_bool_str = lotman::Lot::update_db_children_usage();
 		if (!rp_bool_str.first) {
@@ -1447,7 +1449,7 @@ int lotman_get_lots_past_del(const bool recursive, const bool include_reclaimed,
 			return -1;
 		}
 
-		auto rp = lotman::Lot::get_lots_past_del(recursive, include_reclaimed);
+		auto rp = lotman::Lot::get_lots_past_del(query_time, recursive, include_reclaimed);
 		if (!rp.second.empty()) {
 			if (err_msg) {
 				std::string int_err = rp.second;
@@ -1708,6 +1710,114 @@ int lotman_list_all_lots(char ***output, char **err_msg) {
 	}
 }
 
+// Helper: build the JSON object for a single lot. Caller is responsible for
+// ensuring the lot exists and that update_db_children_usage has been invoked
+// once for the batch (so this helper can be called many times in a row from
+// list-returning APIs without re-running expensive work each iteration).
+// Mirrors the field set documented for lotman_get_lot_as_json.
+static std::pair<json, std::string> build_lot_json_obj(const std::string &lot_name, bool recursive) {
+	json output_obj;
+	output_obj["lot_name"] = lot_name;
+
+	lotman::Lot lot(lot_name);
+
+	auto rp_owners = lot.get_owners(recursive);
+	if (!rp_owners.second.empty()) {
+		return {json(), "Failure on call to get_owners: " + rp_owners.second};
+	}
+	if (recursive) {
+		output_obj["owners"] = rp_owners.first;
+	} else {
+		if (rp_owners.first.empty()) {
+			return {json(), "get_owners returned empty result"};
+		}
+		output_obj["owner"] = rp_owners.first[0];
+	}
+
+	auto rp_parents = lot.get_parents(recursive, true);
+	if (!rp_parents.second.empty()) {
+		return {json(), "Failure on call to get_parents: " + rp_parents.second};
+	}
+	std::vector<std::string> tmp;
+	for (const auto &parent : rp_parents.first) {
+		tmp.push_back(parent.lot_name);
+	}
+	output_obj["parents"] = tmp;
+
+	auto rp_children = lot.get_children(recursive, false);
+	if (!rp_children.second.empty()) {
+		return {json(), "Failure on call to get_children: " + rp_children.second};
+	}
+	tmp.clear();
+	for (const auto &child : rp_children.first) {
+		tmp.push_back(child.lot_name);
+	}
+	output_obj["children"] = tmp;
+
+	auto rp_dirs = lot.get_lot_dirs(recursive);
+	if (!rp_dirs.second.empty()) {
+		return {json(), "Failure on call to get_lot_dirs: " + rp_dirs.second};
+	}
+	output_obj["paths"] = rp_dirs.first;
+
+	std::array<std::string, 6> man_pol_keys = {"dedicated_GB",	"opportunistic_GB", "max_num_objects",
+											   "creation_time", "deletion_time",	"expiration_time"};
+	json internal_man_pol_obj;
+	json internal_man_pol_obj_restrictive;
+	for (const auto &key : man_pol_keys) {
+		auto rp_attr = lot.get_restricting_attribute(key, false);
+		if (!rp_attr.second.empty()) {
+			return {json(), "Failure on call to get_restricting_attribute: " + rp_attr.second};
+		}
+		internal_man_pol_obj[key] = rp_attr.first["value"];
+
+		if (recursive) {
+			auto rp_attr_rec = lot.get_restricting_attribute(key, true);
+			if (!rp_attr_rec.second.empty()) {
+				return {json(), "Failure on call to get_restricting_attribute: " + rp_attr_rec.second};
+			}
+			internal_man_pol_obj_restrictive[key] = rp_attr_rec.first;
+		}
+	}
+	output_obj["management_policy_attrs"] = internal_man_pol_obj;
+	if (recursive) {
+		output_obj["restrictive_management_policy_attrs"] = internal_man_pol_obj_restrictive;
+	}
+
+	std::array<std::string, 6> usage_keys = {"dedicated_GB", "opportunistic_GB", "total_GB",
+											 "num_objects",	 "GB_being_written", "objects_being_written"};
+	json internal_usage_obj;
+	for (const auto &key : usage_keys) {
+		auto rp_usage = lot.get_lot_usage(key, recursive);
+		if (!rp_usage.second.empty()) {
+			return {json(), "Failure on call to get_lot_usage: " + rp_usage.second};
+		}
+		internal_usage_obj[key] = rp_usage.first;
+	}
+	output_obj["usage"] = internal_usage_obj;
+
+	auto rp_attr = lot.get_parent_attributions();
+	if (!rp_attr.second.empty()) {
+		return {json(), "Failure on call to get_parent_attributions: " + rp_attr.second};
+	}
+	output_obj["parent_attributions"] = rp_attr.first;
+
+	try {
+		auto &storage = lotman::db::StorageManager::get_storage();
+		auto reclaim_row = storage.get_pointer<lotman::db::Reclamation>(lot_name);
+		if (reclaim_row) {
+			json r;
+			r["reclaimed_at"] = reclaim_row->reclaimed_at;
+			r["reason"] = reclaim_row->reclaimed_reason;
+			output_obj["reclamation"] = r;
+		}
+	} catch (const std::exception &e) {
+		return {json(), std::string("Failure on reclamation lookup: ") + e.what()};
+	}
+
+	return {output_obj, ""};
+}
+
 // Given a lot_name and a recursive flag, generate the lot's information and return it as JSON. Recursive in this case
 // indicates that we want to look up/down the tree of lots to determine the most restrictive values associated with
 // parents/children.
@@ -1745,180 +1855,16 @@ int lotman_get_lot_as_json(const char *lot_name, const bool recursive, char **ou
 			return -1;
 		}
 
-		lotman::Lot lot(lot_name);
-
-		json output_obj;
-		// Start populating fields in output_obj
-
-		// Add name
-		output_obj["lot_name"] = lot_name;
-
-		// Add owner(s) according to recursive flag
-		std::pair<std::vector<std::string>, std::string> rp_vec_str;
-		rp_vec_str = lot.get_owners(recursive);
-		if (!rp_vec_str.second.empty()) { // There was an error
+		auto rp_obj = build_lot_json_obj(lot_name, recursive);
+		if (!rp_obj.second.empty()) {
 			if (err_msg) {
-				std::string int_err = rp_vec_str.second;
-				std::string ext_err = "Failure on call to get_owners: ";
-				*err_msg = strdup((ext_err + int_err).c_str());
-			}
-			return -1;
-		}
-		if (recursive) {
-			output_obj["owners"] = rp_vec_str.first;
-		} else {
-			if (rp_vec_str.first.empty()) {
-				if (err_msg) {
-					*err_msg = strdup("get_owners returned empty result");
-				}
-				return -1;
-			}
-			output_obj["owner"] = rp_vec_str.first[0]; // Only one owner, this is where it will be.
-		}
-
-		// Add parents according to recursive flag
-		std::pair<std::vector<lotman::Lot>, std::string> rp_lotvec_str;
-		rp_lotvec_str = lot.get_parents(recursive, true);
-		if (!rp_lotvec_str.second.empty()) { // There was an error
-			if (err_msg) {
-				std::string int_err = rp_lotvec_str.second;
-				std::string ext_err = "Failure on call to get_parents: ";
-				*err_msg = strdup((ext_err + int_err).c_str());
-			}
-			return -1;
-		}
-		std::vector<std::string> tmp;
-		for (const auto &parent : rp_lotvec_str.first) {
-			tmp.push_back(parent.lot_name);
-		}
-		output_obj["parents"] = tmp;
-
-		// Add children according to recursive flag
-		rp_lotvec_str = lot.get_children(recursive, false);
-		if (!rp_lotvec_str.second.empty()) { // There was an error
-			if (err_msg) {
-				std::string int_err = rp_lotvec_str.second;
-				std::string ext_err = "Failure on call to get_children: ";
-				*err_msg = strdup((ext_err + int_err).c_str());
-			}
-			return -1;
-		}
-		tmp = {};
-		for (const auto &child : rp_lotvec_str.first) {
-			tmp.push_back(child.lot_name);
-		}
-		output_obj["children"] = tmp;
-
-		// Add paths according to recursive flag
-		std::pair<json, std::string> rp_json_str;
-		rp_json_str = lot.get_lot_dirs(recursive);
-		if (!rp_json_str.second.empty()) { // There was an error
-			if (err_msg) {
-				std::string int_err = rp_json_str.second;
-				std::string ext_err = "Failure on call to get_lot_dirs: ";
-				*err_msg = strdup((ext_err + int_err).c_str());
-			}
-			return -1;
-		}
-		output_obj["paths"] = rp_json_str.first;
-
-		// Add management policy attributes according to recursive flag
-		std::array<std::string, 6> man_pol_keys = {"dedicated_GB",	"opportunistic_GB", "max_num_objects",
-												   "creation_time", "deletion_time",	"expiration_time"};
-		json internal_man_pol_obj;
-		json internal_man_pol_obj_restrictive;
-		for (const auto &key : man_pol_keys) {
-			rp_json_str = lot.get_restricting_attribute(key, false);
-			if (!rp_json_str.second.empty()) { // There was an error
-				if (err_msg) {
-					std::string int_err = rp_json_str.second;
-					std::string ext_err = "Failure on call to get_restricting_attribute: ";
-					*err_msg = strdup((ext_err + int_err).c_str());
-				}
-				return -1;
-			}
-
-			internal_man_pol_obj[key] = rp_json_str.first["value"];
-
-			if (recursive) {
-				rp_json_str = lot.get_restricting_attribute(key, true);
-				if (!rp_json_str.second.empty()) { // There was an error
-					if (err_msg) {
-						std::string int_err = rp_json_str.second;
-						std::string ext_err = "Failure on call to get_restricting_attribute: ";
-						*err_msg = strdup((ext_err + int_err).c_str());
-					}
-					return -1;
-				}
-
-				internal_man_pol_obj_restrictive[key] = rp_json_str.first;
-			}
-		}
-		output_obj["management_policy_attrs"] = internal_man_pol_obj;
-
-		if (recursive) {
-			output_obj["restrictive_management_policy_attrs"] = internal_man_pol_obj_restrictive;
-		}
-
-		// Add usage according to recursive flag
-		std::array<std::string, 6> usage_keys = {"dedicated_GB", "opportunistic_GB", "total_GB",
-												 "num_objects",	 "GB_being_written", "objects_being_written"};
-		json internal_usage_obj;
-		for (const auto &key : usage_keys) {
-			rp_json_str = lot.get_lot_usage(key, recursive);
-			if (!rp_json_str.second.empty()) { // There was an error
-				if (err_msg) {
-					std::string int_err = rp_json_str.second;
-					std::string ext_err = "Failure on call to get_lot_usage: ";
-					*err_msg = strdup((ext_err + int_err).c_str());
-				}
-				return -1;
-			}
-			internal_usage_obj[key] = rp_json_str.first;
-		}
-		output_obj["usage"] = internal_usage_obj;
-
-		// Add per-parent attributions. Always emitted (as an object, possibly
-		// empty) so callers can round-trip create-then-read and audit the
-		// attribution graph. Self-parent-only lots simply produce {}.
-		{
-			auto rp_attr = lot.get_parent_attributions();
-			if (!rp_attr.second.empty()) {
-				if (err_msg) {
-					std::string int_err = rp_attr.second;
-					std::string ext_err = "Failure on call to get_parent_attributions: ";
-					*err_msg = strdup((ext_err + int_err).c_str());
-				}
-				return -1;
-			}
-			output_obj["parent_attributions"] = rp_attr.first;
-		}
-
-		// Reclamation: emit the ledger row when one exists. Future-dated
-		// reclamations are still surfaced here so callers can see scheduled
-		// reclaim events; runtime filters elsewhere apply `reclaimed_at <= now`.
-		try {
-			auto &storage = lotman::db::StorageManager::get_storage();
-			auto reclaim_row = storage.get_pointer<lotman::db::Reclamation>(lot_name);
-			if (reclaim_row) {
-				json r;
-				r["reclaimed_at"] = reclaim_row->reclaimed_at;
-				r["reason"] = reclaim_row->reclaimed_reason;
-				output_obj["reclamation"] = r;
-			}
-		} catch (const std::exception &e) {
-			if (err_msg) {
-				std::string msg = std::string("Failure on reclamation lookup: ") + e.what();
-				*err_msg = strdup(msg.c_str());
+				*err_msg = strdup(rp_obj.second.c_str());
 			}
 			return -1;
 		}
 
-		// Copy the object to output
-		std::string output_str = output_obj.dump();
-		auto output_str_c = static_cast<char *>(malloc(sizeof(char) * (output_str.length() + 1)));
-		output_str_c = strdup(output_str.c_str());
-		*output = output_str_c;
+		std::string output_str = rp_obj.first.dump();
+		*output = strdup(output_str.c_str());
 		return 0;
 	} catch (std::exception &exc) {
 		if (err_msg) {
@@ -1959,6 +1905,64 @@ int lotman_get_lots_from_dir(const char *dir, const bool recursive, int64_t quer
 			idx++;
 		}
 		*output = lots_from_dir_c;
+		return 0;
+	} catch (std::exception &exc) {
+		if (err_msg) {
+			*err_msg = strdup(exc.what());
+		}
+		return -1;
+	}
+}
+
+int lotman_get_lots_for_path(const char *path, bool recursive, int64_t time_lo_ms, int64_t time_hi_ms,
+							 bool include_reclaimed, char **output, char **err_msg) {
+	try {
+		if (!path) {
+			if (err_msg) {
+				*err_msg = strdup("path must not be nullpointer.");
+			}
+			return -1;
+		}
+
+		auto rp_bool_str = lotman::Lot::update_db_children_usage();
+		if (!rp_bool_str.first) {
+			if (err_msg) {
+				std::string int_err = rp_bool_str.second;
+				std::string ext_err = "Failure on call to update_db_children_usage(): ";
+				*err_msg = strdup((ext_err + int_err).c_str());
+			}
+			return -1;
+		}
+
+		auto rp = lotman::Lot::get_lots_for_path(path, recursive, time_lo_ms, time_hi_ms, include_reclaimed);
+		if (!rp.second.empty()) {
+			if (err_msg) {
+				std::string ext_err = "Failure on call to get_lots_for_path: ";
+				*err_msg = strdup((ext_err + rp.second).c_str());
+			}
+			return -1;
+		}
+
+		// Build a JSON array, one full lot object per winner. Use the same
+		// shape as lotman_get_lot_as_json(name, recursive=false) so callers
+		// can treat each element identically. update_db_children_usage was
+		// already called once above, so build_lot_json_obj is cheap to call
+		// per-lot here.
+		json arr = json::array();
+		for (const auto &lot_name : rp.first) {
+			auto rp_obj = build_lot_json_obj(lot_name, /*recursive=*/false);
+			if (!rp_obj.second.empty()) {
+				if (err_msg) {
+					std::string ext_err = "Failure building JSON for lot '" + lot_name + "': ";
+					*err_msg = strdup((ext_err + rp_obj.second).c_str());
+				}
+				return -1;
+			}
+			arr.push_back(rp_obj.first);
+		}
+
+		std::string output_str = arr.dump();
+		*output = strdup(output_str.c_str());
 		return 0;
 	} catch (std::exception &exc) {
 		if (err_msg) {

--- a/src/lotman.h
+++ b/src/lotman.h
@@ -761,16 +761,25 @@ int lotman_reclaim_lot(const char *lot_name, int64_t reclaimed_at, const char *r
 		A reference to a char array that can store any error messages.
 */
 
-int lotman_get_lots_past_exp(const bool recursive, const bool include_reclaimed, char ***output, char **err_msg);
+int lotman_get_lots_past_exp(int64_t query_time, const bool recursive, const bool include_reclaimed, char ***output,
+							 char **err_msg);
 /**
-	DESCRIPTION: A function for determining all lots in the database that are past their expiration.
-		The function can determine which lots meet this criteria either by looking at the expiration
-		directly associated with each lot, or recursively by looking at the most restricting
-		expiration in each lot's parent tree.
+	DESCRIPTION: A function for determining all lots in the database that are past their expiration
+		relative to a caller-supplied cutoff. The function can determine which lots meet this criteria
+		either by looking at the expiration directly associated with each lot, or recursively by
+		looking at the most restricting expiration in each lot's parent tree.
 
 	RETURNS: Returns 0 on success. Any other values indicate an error.
 
 	INPUTS:
+	query_time:
+		A Unix timestamp in milliseconds used as the expiration cutoff. A lot is included iff its
+		`expiration_time` is non-zero AND `expiration_time <= query_time`. The same value is used
+		for reclamation evaluation when include_reclaimed=false: a lot is treated as reclaimed iff
+		its reclamation row's `reclaimed_at <= query_time`. Pass wall-clock now() for the
+		historical "as of now" semantics; pass a future timestamp to preview which lots will be
+		expired by then.
+
 	recursive:
 		A boolean indicating whether the output should contain only lots whose personal expiration is
 		passed (recursive = false) or it should contain all lots who may also have an expired parent
@@ -778,7 +787,7 @@ int lotman_get_lots_past_exp(const bool recursive, const bool include_reclaimed,
 
 	include_reclaimed:
 		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
-		`reclaimed_at <= now`) should be included in the result. When false (the typical use
+		`reclaimed_at <= query_time`) should be included in the result. When false (the typical use
 		case for cleanup loops), reclaimed lots are filtered out so the loop will not repeatedly
 		process lots that the storage provider has already cleaned up.
 
@@ -788,18 +797,29 @@ int lotman_get_lots_past_exp(const bool recursive, const bool include_reclaimed,
 
 	err_msg:
 		A reference to a char array that can store any error messages.
+
+	NOTE: Sentinel (non-expiring, all-zero timestamp) lots are never returned regardless of
+		query_time, matching the rest of LotMan's sentinel handling.
 */
 
-int lotman_get_lots_past_del(const bool recursive, const bool include_reclaimed, char ***output, char **err_msg);
+int lotman_get_lots_past_del(int64_t query_time, const bool recursive, const bool include_reclaimed, char ***output,
+							 char **err_msg);
 /**
-	DESCRIPTION: A function for determining all lots in the database that are past their deletion time.
-		The function can determine which lots meet this criteria either by looking at the deletion time
-		directly associated with each lot, or recursively by looking at the most restricting deletion
-		time in each lot's parent tree.
+	DESCRIPTION: A function for determining all lots in the database that are past their deletion time
+		relative to a caller-supplied cutoff. The function can determine which lots meet this criteria
+		either by looking at the deletion time directly associated with each lot, or recursively by
+		looking at the most restricting deletion time in each lot's parent tree.
 
 	RETURNS: Returns 0 on success. Any other values indicate an error.
 
 	INPUTS:
+	query_time:
+		A Unix timestamp in milliseconds used as the deletion cutoff. A lot is included iff its
+		`deletion_time` is non-zero AND `deletion_time <= query_time`. The same value is used for
+		reclamation evaluation when include_reclaimed=false. Pass wall-clock now() for the
+		historical "as of now" semantics; pass a future timestamp to preview which lots will be
+		past their deletion time by then.
+
 	recursive:
 		A boolean indicating whether the output should contain only lots whose personal deletion time is
 		passed (recursive = false) or it should contain all lots who may also have a parent passed its
@@ -807,7 +827,7 @@ int lotman_get_lots_past_del(const bool recursive, const bool include_reclaimed,
 
 	include_reclaimed:
 		A boolean indicating whether reclaimed lots (rows in the `reclamations` ledger whose
-		`reclaimed_at <= now`) should be included in the result. Cleanup loops should typically
+		`reclaimed_at <= query_time`) should be included in the result. Cleanup loops should typically
 		pass false so they do not repeatedly process lots that have already been reclaimed.
 
 	output:
@@ -816,6 +836,9 @@ int lotman_get_lots_past_del(const bool recursive, const bool include_reclaimed,
 
 	err_msg:
 		A reference to a char array that can store any error messages.
+
+	NOTE: Sentinel (non-expiring, all-zero timestamp) lots are never returned regardless of
+		query_time.
 */
 
 int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_children, const bool include_reclaimed,
@@ -1111,6 +1134,63 @@ int lotman_get_lots_from_dir(const char *dir, const bool recursive, int64_t quer
 	output:
 		A reference to a char ** for storing the output array.
 		NOTE: Requires the use of lotman_free_string_list to free the memory allocated for this array.
+
+	err_msg:
+		A reference to a char array that can store any error messages.
+*/
+
+int lotman_get_lots_for_path(const char *path, bool recursive, int64_t time_lo_ms, int64_t time_hi_ms,
+							 bool include_reclaimed, char **output, char **err_msg);
+/**
+	DESCRIPTION: Window-aware variant of lotman_get_lots_from_dir. Returns the union of every lot
+		that "wins" the longest-prefix path-resolution contest at any instant in the half-open
+		window [time_lo_ms, time_hi_ms). Two lots may both be returned when each owns the path
+		during disjoint sub-intervals of the window (for example a sublot that takes over from
+		its parent partway through the window). The dynamic-ownership rules from
+		lotman_get_lots_from_dir apply unchanged: same lot, longer included path wins; an
+		excluded path row strictly longer than a candidate inclusion suppresses it; the default
+		lot is appended iff some instant in the window has no candidate active.
+
+	RETURNS: Returns 0 on success. Any other values indicate an error.
+
+	INPUTS:
+	path:
+		A string indicating the path to be queried for. Trailing slashes are normalized internally;
+		matching is performed against the lots' stored path rows.
+
+	recursive:
+		A boolean indicating whether only the directly-resolved owning lot(s) should be returned
+		(recursive = false), or whether all parent lots of each winner should also be returned
+		(recursive = true). Matches the meaning of the recursive argument on lotman_get_lots_from_dir.
+
+	time_lo_ms:
+		Beginning of the query window, as a Unix timestamp in milliseconds (inclusive).
+
+	time_hi_ms:
+		End of the query window, as a Unix timestamp in milliseconds (exclusive). A lot's
+		[creation_time, expiration_time) interval is considered to overlap the window iff
+		creation_time < time_hi_ms AND expiration_time > time_lo_ms. Sentinel (all-zero
+		timestamp) lots are treated as always-live and overlap every window. Must be strictly
+		greater than time_lo_ms; otherwise the function fails with err_msg set.
+
+	include_reclaimed:
+		A boolean indicating how reclamation rows interact with the window. When true, reclaimed
+		lots are included as if no reclamation row existed. When false, lots whose reclamation
+		row has reclaimed_at <= time_lo_ms are dropped entirely (their storage has been released
+		for the entirety of the window), while lots reclaimed mid-window have their effective
+		active interval clipped to [..., reclaimed_at) before the longest-prefix sweep — they
+		may still be returned iff their pre-reclamation interval makes them a winner. When
+		recursive=true, ancestors are filtered under the same rule: an ancestor is suppressed
+		only when it is reclaimed for the entirety of the window (reclaimed_at <= time_lo_ms).
+
+	output:
+		A reference to a char * for storing the result, formatted as a JSON array string. Each
+		element of the array is a full lot object identical in shape to a single
+		lotman_get_lot_as_json(lot_name, recursive=false) result; see that API's output JSON
+		specification for the field set. The result always contains at least one element: when
+		no lot wins anywhere in the window, the default lot is appended (matching
+		lotman_get_lots_from_dir's fallback behavior).
+		NOTE: The caller owns the returned string and must free() it.
 
 	err_msg:
 		A reference to a char array that can store any error messages.

--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -2418,17 +2418,17 @@ std::pair<bool, std::string> lotman::Lot::update_usage_by_dirs(const json &updat
 }
 
 // Helper: if include_reclaimed is false, filter out any lot whose reclamation
-// row exists with reclaimed_at <= now. Centralizes the post-filter applied to
-// every get_lots_past_* result so that cleanup loops do not repeatedly process
-// already-reclaimed lots.
-static void filter_reclaimed_in_place(std::vector<std::string> &lots, bool include_reclaimed) {
+// row exists with reclaimed_at <= query_time. Centralizes the post-filter
+// applied to every get_lots_past_* result so that cleanup loops do not
+// repeatedly process already-reclaimed lots. The caller supplies the
+// timestamp used both as the reclamation cutoff; pass wall-clock now() for
+// the historical "as-of-now" semantics.
+static void filter_reclaimed_in_place(std::vector<std::string> &lots, bool include_reclaimed, int64_t query_time) {
 	if (include_reclaimed || lots.empty()) {
 		return;
 	}
-	auto now = std::chrono::system_clock::now();
-	int64_t now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch().count();
 	auto new_end = std::remove_if(lots.begin(), lots.end(), [&](const std::string &name) {
-		auto rp = lotman::Lot::is_reclaimed(name, now_ms);
+		auto rp = lotman::Lot::is_reclaimed(name, query_time);
 		if (!rp.second.empty()) {
 			// On lookup error, conservatively leave the lot in.
 			return false;
@@ -2438,24 +2438,35 @@ static void filter_reclaimed_in_place(std::vector<std::string> &lots, bool inclu
 	lots.erase(new_end, lots.end());
 }
 
-std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_exp(const bool recursive,
-																				const bool include_reclaimed) {
-	auto rp_inner = get_lots_past_exp(recursive);
+// Convenience overload: existing quota past_* APIs (past_opp/past_ded/past_obj)
+// continue to use wall-clock now() for reclamation evaluation, since their
+// result already reflects current usage rather than a caller-supplied time.
+static void filter_reclaimed_in_place(std::vector<std::string> &lots, bool include_reclaimed) {
+	if (include_reclaimed || lots.empty()) {
+		return;
+	}
+	auto now = std::chrono::system_clock::now();
+	int64_t now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch().count();
+	filter_reclaimed_in_place(lots, include_reclaimed, now_ms);
+}
+
+std::pair<std::vector<std::string>, std::string>
+lotman::Lot::get_lots_past_exp(int64_t query_time, const bool recursive, const bool include_reclaimed) {
+	auto rp_inner = get_lots_past_exp(query_time, recursive);
 	if (!rp_inner.second.empty()) {
 		return rp_inner;
 	}
-	filter_reclaimed_in_place(rp_inner.first, include_reclaimed);
+	filter_reclaimed_in_place(rp_inner.first, include_reclaimed, query_time);
 	return rp_inner;
 }
 
-std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_exp(const bool recursive) {
+std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_exp(int64_t query_time,
+																				const bool recursive) {
 	std::vector<std::string> expired_lots;
-	auto now = std::chrono::system_clock::now();
-	int64_t ms_since_epoch = std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch().count();
 
 	std::string expired_query =
 		"SELECT lot_name FROM management_policy_attributes WHERE expiration_time != 0 AND expiration_time <= ?;";
-	std::map<int64_t, std::vector<int>> expired_map{{ms_since_epoch, {1}}};
+	std::map<int64_t, std::vector<int>> expired_map{{query_time, {1}}};
 	auto rp = lotman::db::SQL_get_matches(expired_query, std::map<std::string, std::vector<int>>(), expired_map);
 	if (!rp.second.empty()) { // There was an error
 		std::string int_err = rp.second;
@@ -2490,23 +2501,21 @@ std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_exp(
 	return std::make_pair(expired_lots, "");
 }
 
-std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_del(const bool recursive,
-																				const bool include_reclaimed) {
-	auto rp_inner = get_lots_past_del(recursive);
+std::pair<std::vector<std::string>, std::string>
+lotman::Lot::get_lots_past_del(int64_t query_time, const bool recursive, const bool include_reclaimed) {
+	auto rp_inner = get_lots_past_del(query_time, recursive);
 	if (!rp_inner.second.empty()) {
 		return rp_inner;
 	}
-	filter_reclaimed_in_place(rp_inner.first, include_reclaimed);
+	filter_reclaimed_in_place(rp_inner.first, include_reclaimed, query_time);
 	return rp_inner;
 }
 
-std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_del(const bool recursive) {
-	auto now = std::chrono::system_clock::now();
-	int64_t ms_since_epoch = std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch().count();
-
+std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_past_del(int64_t query_time,
+																				const bool recursive) {
 	std::string deletion_query =
 		"SELECT lot_name FROM management_policy_attributes WHERE deletion_time != 0 AND deletion_time <= ?;";
-	std::map<int64_t, std::vector<int>> deletion_map{{ms_since_epoch, {1}}};
+	std::map<int64_t, std::vector<int>> deletion_map{{query_time, {1}}};
 	auto rp = lotman::db::SQL_get_matches(deletion_query, std::map<std::string, std::vector<int>>(), deletion_map);
 	if (!rp.second.empty()) { // There was an error
 		std::string int_err = rp.second;
@@ -3136,6 +3145,235 @@ lotman::Lot::get_lots_from_dir(const std::string &dir_input, const bool recursiv
 	return std::make_pair(matching_lots_vec, "");
 }
 
+std::pair<std::vector<std::string>, std::string> lotman::Lot::get_lots_for_path(const std::string &path_input,
+																				bool recursive, int64_t time_lo_ms,
+																				int64_t time_hi_ms,
+																				bool include_reclaimed) {
+	if (time_hi_ms <= time_lo_ms) {
+		return std::make_pair(std::vector<std::string>(),
+							  "Invalid time window: time_hi_ms must be strictly greater than time_lo_ms");
+	}
+
+	// Same path-normalization convention as get_lots_from_dir: stored paths
+	// always have a trailing slash; the input path is normalized to match,
+	// while a separate "no trailing slash" form is used on the LIKE side so
+	// that "/foobar" cannot accidentally match a stored path of "/foo/".
+	std::string dir = ensure_trailing_slash(path_input);
+	std::string dir_for_like = dir;
+	if (dir_for_like.length() > 1 && dir_for_like.back() == '/') {
+		dir_for_like.pop_back();
+	}
+
+	// Per-lot candidate query: gather every lot with at least one *included*
+	// matching path row, the longest such path's length (its "claim length"),
+	// the lot's own active window, and any reclamation row. The NOT EXISTS
+	// guard mirrors get_lots_from_dir: an inclusion of length L is dropped
+	// when the same lot has a longer matching exclusion. Because we then
+	// take MAX(LENGTH(p.path)), exclusions shorter than the longest inclusion
+	// have no effect; longer exclusions correctly suppress shorter inclusions.
+	//
+	// Active-window predicate is the half-open overlap of the lot's MPA
+	// interval with [time_lo_ms, time_hi_ms), with the all-zero sentinel
+	// triple treated as always-live. Reclamation pre-filtering (drop lots
+	// reclaimed at or before time_lo_ms) is applied here only when
+	// include_reclaimed=false; mid-window reclamation clipping is applied in
+	// C++ below using the returned reclaimed_at value.
+	std::string base_query = "SELECT p.lot_name, MAX(LENGTH(p.path)) AS claim_len, "
+							 "       mpa.creation_time, mpa.expiration_time, "
+							 "       COALESCE(r.reclaimed_at, 0) "
+							 "FROM paths p "
+							 "JOIN management_policy_attributes mpa ON p.lot_name = mpa.lot_name "
+							 "LEFT JOIN reclamations r ON r.lot_name = p.lot_name "
+							 "WHERE (p.path = ?1 OR ?2 LIKE p.path || '%') "
+							 "  AND (p.recursive OR p.path = ?3) "
+							 "  AND p.exclude = 0 "
+							 "  AND ((mpa.creation_time = 0 AND mpa.expiration_time = 0 AND mpa.deletion_time = 0) "
+							 "       OR (mpa.creation_time < ?5 AND mpa.expiration_time > ?4)) ";
+	if (!include_reclaimed) {
+		base_query += "  AND (r.lot_name IS NULL OR r.reclaimed_at > ?4) ";
+	}
+	base_query += "  AND NOT EXISTS ( "
+				  "      SELECT 1 FROM paths e "
+				  "      WHERE e.lot_name = p.lot_name "
+				  "        AND e.exclude = 1 "
+				  "        AND (e.path = ?1 OR ?2 LIKE e.path || '%') "
+				  "        AND (e.recursive OR e.path = ?3) "
+				  "        AND LENGTH(e.path) > LENGTH(p.path) "
+				  "  ) "
+				  "GROUP BY p.lot_name, mpa.creation_time, mpa.expiration_time, r.reclaimed_at;";
+
+	std::map<std::string, std::vector<int>> str_map{{dir, {1, 3}}, {dir_for_like, {2}}};
+	std::map<int64_t, std::vector<int>> int_map{{time_lo_ms, {4}}, {time_hi_ms, {5}}};
+	auto rp = lotman::db::SQL_get_matches_multi_col(base_query, 5, str_map, int_map);
+	if (!rp.second.empty()) {
+		return std::make_pair(std::vector<std::string>(),
+							  std::string("Failure on call to SQL_get_matches_multi_col: ") + rp.second);
+	}
+
+	struct Candidate {
+		std::string lot_name;
+		int64_t active_start;
+		int64_t active_end;
+		int claim_len;
+	};
+	std::vector<Candidate> candidates;
+	candidates.reserve(rp.first.size());
+
+	for (const auto &row : rp.first) {
+		if (row.size() < 5) {
+			continue;
+		}
+		Candidate c;
+		c.lot_name = row[0];
+		try {
+			c.claim_len = std::stoi(row[1]);
+		} catch (...) {
+			c.claim_len = 0;
+		}
+		int64_t creation = 0;
+		int64_t expiration = 0;
+		int64_t reclaimed_at = 0;
+		try {
+			creation = static_cast<int64_t>(std::stoll(row[2]));
+			expiration = static_cast<int64_t>(std::stoll(row[3]));
+			reclaimed_at = static_cast<int64_t>(std::stoll(row[4]));
+		} catch (...) {
+			continue;
+		}
+
+		// Compute the lot's active window inside [time_lo_ms, time_hi_ms).
+		// Sentinel (all-zero) MPAs treat the lot as always-live, so the
+		// active window equals the query window; the SQL above already
+		// requires deletion_time=0 alongside creation/expiration=0 for the
+		// sentinel branch, so we can reliably detect it via creation==0
+		// and expiration==0 here.
+		int64_t start;
+		int64_t end;
+		if (creation == 0 && expiration == 0) {
+			start = time_lo_ms;
+			end = time_hi_ms;
+		} else {
+			start = std::max<int64_t>(creation, time_lo_ms);
+			end = std::min<int64_t>(expiration, time_hi_ms);
+		}
+		// Mid-window reclamation clipping: only applies when filtering and
+		// when the row's reclaimed_at falls strictly inside the window.
+		// reclaimed_at <= time_lo cases were already dropped by the SQL
+		// pre-filter; we never store reclaimed_at == 0 in practice (the
+		// public API rejects it), so we use 0 as "no reclamation" via the
+		// COALESCE above.
+		if (!include_reclaimed && reclaimed_at > 0 && reclaimed_at < end) {
+			end = reclaimed_at;
+		}
+		if (end <= start) {
+			continue;
+		}
+		c.active_start = start;
+		c.active_end = end;
+		candidates.push_back(std::move(c));
+	}
+
+	// Per-candidate sweep: a lot wins iff some instant in its active interval
+	// is NOT covered by the active interval of any candidate with a strictly
+	// greater claim length. Ties at the same claim_len do not shadow each
+	// other, so both tied lots can win simultaneously. (Same-path collisions
+	// during overlapping windows are rejected at insert time, so genuine ties
+	// at the maximum claim length are rare in practice.)
+	auto interval_union_covers = [](std::vector<std::pair<int64_t, int64_t>> intervals, int64_t target_start,
+									int64_t target_end) -> bool {
+		if (intervals.empty()) {
+			return target_end <= target_start;
+		}
+		std::sort(intervals.begin(), intervals.end());
+		int64_t cursor = target_start;
+		for (const auto &iv : intervals) {
+			if (iv.first > cursor) {
+				return false;
+			}
+			cursor = std::max(cursor, iv.second);
+			if (cursor >= target_end) {
+				return true;
+			}
+		}
+		return cursor >= target_end;
+	};
+
+	std::vector<std::string> winners;
+	for (const auto &c : candidates) {
+		std::vector<std::pair<int64_t, int64_t>> shadowing;
+		for (const auto &other : candidates) {
+			if (other.claim_len <= c.claim_len) {
+				continue;
+			}
+			int64_t s = std::max(other.active_start, c.active_start);
+			int64_t e = std::min(other.active_end, c.active_end);
+			if (s < e) {
+				shadowing.emplace_back(s, e);
+			}
+		}
+		if (!interval_union_covers(shadowing, c.active_start, c.active_end)) {
+			winners.push_back(c.lot_name);
+		}
+	}
+
+	// Default-lot fallback: emit "default" iff some instant in the window
+	// has no candidate active at all (matching get_lots_from_dir's behavior
+	// when no path row resolves).
+	{
+		std::vector<std::pair<int64_t, int64_t>> all_intervals;
+		all_intervals.reserve(candidates.size());
+		for (const auto &c : candidates) {
+			all_intervals.emplace_back(c.active_start, c.active_end);
+		}
+		if (!interval_union_covers(all_intervals, time_lo_ms, time_hi_ms)) {
+			winners.push_back("default");
+		}
+	}
+
+	// Note: winners cannot contain duplicates here. Each lot appears at most
+	// once in `candidates` (the SQL groups by lot_name), and "default" is
+	// appended at most once by the fallback above. The recursive ancestor
+	// expansion below uses a `seen` set seeded from winners, so it cannot
+	// introduce duplicates either.
+
+	if (recursive) {
+		// Append ancestors of every winner. An ancestor is suppressed only
+		// when filtering reclaimed lots AND the ancestor is reclaimed for
+		// the entirety of the window (reclaimed_at <= time_lo_ms), matching
+		// the union-of-winners semantics: an ancestor reclaimed mid-window
+		// was still alive earlier, so it should still surface.
+		std::set<std::string> seen(winners.begin(), winners.end());
+		std::vector<std::string> additions;
+		for (const auto &name : winners) {
+			if (name == "default") {
+				continue;
+			}
+			Lot lot(name);
+			lot.get_parents(true, false);
+			for (const auto &parent : lot.recursive_parents) {
+				if (seen.count(parent.lot_name)) {
+					continue;
+				}
+				if (!include_reclaimed) {
+					auto rec_rp = is_reclaimed(parent.lot_name, time_lo_ms);
+					if (!rec_rp.second.empty()) {
+						return std::make_pair(std::vector<std::string>(), "Failure checking reclamation for parent '" +
+																			  parent.lot_name + "': " + rec_rp.second);
+					}
+					if (rec_rp.first) {
+						continue;
+					}
+				}
+				seen.insert(parent.lot_name);
+				additions.push_back(parent.lot_name);
+			}
+		}
+		winners.insert(winners.end(), additions.begin(), additions.end());
+	}
+
+	return std::make_pair(winners, "");
+}
+
 std::pair<bool, std::string> lotman::Lot::check_context_for_parents(const std::vector<std::string> &parents,
 																	bool include_self, bool new_lot) {
 	if (new_lot && parents.size() == 1 &&
@@ -3185,6 +3423,7 @@ std::pair<bool, std::string> lotman::Lot::check_context_for_parents(const std::v
 
 	return std::make_pair(true, "");
 }
+
 std::pair<bool, std::string> lotman::Lot::check_context_for_parents(const std::vector<Lot> &parents, bool include_self,
 																	bool new_lot) {
 	if (new_lot && parents.size() == 1 &&

--- a/src/lotman_internal.h
+++ b/src/lotman_internal.h
@@ -337,9 +337,9 @@ class Lot {
 															bool include_self = false);
 	std::pair<bool, std::string> check_context_for_children(const std::vector<Lot> &children,
 															bool include_self = false);
-	static std::pair<std::vector<std::string>, std::string> get_lots_past_exp(const bool recursive,
+	static std::pair<std::vector<std::string>, std::string> get_lots_past_exp(int64_t query_time, const bool recursive,
 																			  const bool include_reclaimed);
-	static std::pair<std::vector<std::string>, std::string> get_lots_past_del(const bool recursive,
+	static std::pair<std::vector<std::string>, std::string> get_lots_past_del(int64_t query_time, const bool recursive,
 																			  const bool include_reclaimed);
 	static std::pair<std::vector<std::string>, std::string>
 	get_lots_past_opp(const bool recursive_quota, const bool recursive_children, const bool include_reclaimed);
@@ -350,8 +350,8 @@ class Lot {
 
 	// Internal "no-filter" overloads kept for the include_reclaimed=true path
 	// and reused by the include_reclaimed-aware overloads above.
-	static std::pair<std::vector<std::string>, std::string> get_lots_past_exp(const bool recursive);
-	static std::pair<std::vector<std::string>, std::string> get_lots_past_del(const bool recursive);
+	static std::pair<std::vector<std::string>, std::string> get_lots_past_exp(int64_t query_time, const bool recursive);
+	static std::pair<std::vector<std::string>, std::string> get_lots_past_del(int64_t query_time, const bool recursive);
 	static std::pair<std::vector<std::string>, std::string> get_lots_past_opp(const bool recursive_quota,
 																			  const bool recursive_children);
 	static std::pair<std::vector<std::string>, std::string> get_lots_past_ded(const bool recursive_quota,
@@ -411,6 +411,23 @@ class Lot {
 	static std::pair<std::vector<std::string>, std::string> list_all_lots();
 	static std::pair<std::vector<std::string>, std::string> get_lots_from_dir(const std::string &dir,
 																			  const bool recursive, int64_t query_time);
+
+	// Window-aware variant of get_lots_from_dir. Returns the union of every lot
+	// that "wins" the longest-prefix path-resolution contest at any instant in
+	// the half-open window [time_lo_ms, time_hi_ms). Two lots may both be
+	// returned when each owns the path during disjoint sub-intervals of the
+	// window (e.g. a sublot that takes over from its parent partway through).
+	// When include_reclaimed=false, lots reclaimed at or before time_lo_ms are
+	// dropped entirely; lots reclaimed mid-window have their effective active
+	// interval clipped to [..., reclaimed_at) before the sweep. Sentinel
+	// (all-zero timestamp) lots are treated as always-live and overlap every
+	// window. The default lot is appended iff some instant in the window has
+	// no candidate active. When recursive=true, each winner's ancestors are
+	// also included (matching get_lots_from_dir's recursive semantics), with
+	// ancestors filtered by reclamation under the same rules.
+	static std::pair<std::vector<std::string>, std::string> get_lots_for_path(const std::string &path, bool recursive,
+																			  int64_t time_lo_ms, int64_t time_hi_ms,
+																			  bool include_reclaimed);
 
 	// Advisory: compute available capacity under a parent lot during a time window.
 	// Returns JSON with available and peak values for each resource type.

--- a/test/dynamic_ownership_tests.cpp
+++ b/test/dynamic_ownership_tests.cpp
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
+#include <set>
 
 using json = nlohmann::json;
 
@@ -942,6 +943,328 @@ TEST_F(DynamicOwnershipTest, DeepAncestryChainResolvesCorrectly) {
 						err2);
 	EXPECT_NE(rv2, 0) << "Unrelated lot must still be rejected under deep recursive root. err=" << err2;
 	EXPECT_NE(err2.find("Descendancy violation"), std::string::npos) << "err=" << err2;
+}
+
+// ---------------------------------------------------------------------------
+// lotman_get_lots_for_path: window-aware variant of lotman_get_lots_from_dir.
+// Returns the union of every lot that wins the longest-prefix resolution
+// contest at any instant in [time_lo_ms, time_hi_ms), as a JSON array of full
+// lot objects.
+// ---------------------------------------------------------------------------
+
+class GetLotsForPathTest : public DynamicOwnershipTest {
+  protected:
+	// Invoke lotman_get_lots_for_path and return the parsed JSON array.
+	// Asserts success and that the response parses as a JSON array.
+	json call(const char *path, bool recursive, int64_t time_lo_ms, int64_t time_hi_ms, bool include_reclaimed) {
+		char *raw_out = nullptr;
+		char *raw_err = nullptr;
+		int rv =
+			lotman_get_lots_for_path(path, recursive, time_lo_ms, time_hi_ms, include_reclaimed, &raw_out, &raw_err);
+		UniqueCString out(raw_out);
+		UniqueCString err(raw_err);
+		EXPECT_EQ(rv, 0) << "lotman_get_lots_for_path failed: " << (err.get() ? err.get() : "unknown");
+		if (rv != 0 || !out.get()) {
+			return json::array();
+		}
+		json parsed = json::parse(out.get());
+		EXPECT_TRUE(parsed.is_array()) << "Expected JSON array, got: " << out.get();
+		return parsed;
+	}
+
+	// Invoke lotman_get_lots_for_path and capture the error string. Used for
+	// negative tests where rv != 0 is the expected outcome.
+	int callExpectingError(const char *path, bool recursive, int64_t time_lo_ms, int64_t time_hi_ms,
+						   bool include_reclaimed, std::string &err_out) {
+		char *raw_out = nullptr;
+		char *raw_err = nullptr;
+		int rv =
+			lotman_get_lots_for_path(path, recursive, time_lo_ms, time_hi_ms, include_reclaimed, &raw_out, &raw_err);
+		UniqueCString out(raw_out);
+		if (raw_err) {
+			err_out.assign(raw_err);
+			free(raw_err);
+		} else {
+			err_out.clear();
+		}
+		return rv;
+	}
+
+	// Project the array to a sorted set of lot_name fields for easy assertions.
+	std::set<std::string> names(const json &arr) {
+		std::set<std::string> out;
+		for (const auto &obj : arr) {
+			if (obj.contains("lot_name") && obj["lot_name"].is_string()) {
+				out.insert(obj["lot_name"].get<std::string>());
+			}
+		}
+		return out;
+	}
+
+	// Reclaim a lot at a given timestamp via the public C API.
+	void reclaimLot(const char *name, int64_t when_ms, const char *reason) {
+		char *raw_err = nullptr;
+		int rv = lotman_reclaim_lot(name, when_ms, reason, &raw_err);
+		UniqueCString err(raw_err);
+		ASSERT_EQ(rv, 0) << "set_reclaimed failed: " << (err.get() ? err.get() : "unknown");
+	}
+};
+
+// Single match: a recursively-owned subtree returns exactly its owning lot
+// for any path inside the subtree, and each element is a full lot object.
+TEST_F(GetLotsForPathTest, SingleMatchReturnsFullLotObject) {
+	addLotFooRecursive("lot1");
+
+	json arr = call("/foo/bar", /*recursive=*/false, /*time_lo=*/500, /*time_hi=*/501,
+					/*include_reclaimed=*/true);
+	ASSERT_EQ(arr.size(), 1u);
+	const auto &obj = arr[0];
+	EXPECT_EQ(obj["lot_name"], "lot1");
+	// Shape: full lot object (matches lotman_get_lot_as_json with recursive=false).
+	EXPECT_TRUE(obj.contains("owner"));
+	EXPECT_TRUE(obj.contains("parents"));
+	EXPECT_TRUE(obj.contains("children"));
+	EXPECT_TRUE(obj.contains("paths"));
+	EXPECT_TRUE(obj.contains("management_policy_attrs"));
+	EXPECT_TRUE(obj.contains("usage"));
+	EXPECT_TRUE(obj.contains("parent_attributions"));
+	// recursive=false: no "owners" or "restrictive_management_policy_attrs".
+	EXPECT_FALSE(obj.contains("owners"));
+	EXPECT_FALSE(obj.contains("restrictive_management_policy_attrs"));
+}
+
+// Two lots covering the path during disjoint sub-windows are both returned
+// when the query window straddles the takeover.
+TEST_F(GetLotsForPathTest, DisjointSubWindowsReturnsBoth) {
+	addLotFooRecursive("lot1"); // active [100, 9000)
+
+	// lot2 takes over /foo/bar starting at t=5000.
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["lot1"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 5000,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Window straddles the takeover; lot1 wins [1000, 5000), lot2 wins [5000, 7000).
+	auto got = names(call("/foo/bar", false, 1000, 7000, true));
+	EXPECT_EQ(got, (std::set<std::string>{"lot1", "lot2"}));
+
+	// Window entirely before takeover: only lot1.
+	EXPECT_EQ(names(call("/foo/bar", false, 1000, 4000, true)), (std::set<std::string>{"lot1"}));
+
+	// Window entirely after takeover: only lot2.
+	EXPECT_EQ(names(call("/foo/bar", false, 5500, 7000, true)), (std::set<std::string>{"lot2"}));
+}
+
+// Full sublot shadowing: a sublot whose active interval fully covers the
+// query window suppresses its longer-prefix-losing parent for this path.
+TEST_F(GetLotsForPathTest, FullSublotShadowsParent) {
+	addLotFooRecursive("lot1"); // recursive on /foo, active [100, 9000)
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["lot1"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// /foo/bar is fully covered by lot2's longer claim throughout the window.
+	EXPECT_EQ(names(call("/foo/bar", false, 1000, 7000, true)), (std::set<std::string>{"lot2"}));
+}
+
+// An excluded path on the longer-prefix-winning lot does NOT shadow the
+// shorter-prefix candidate.
+TEST_F(GetLotsForPathTest, ExcludedSublotDoesNotShadow) {
+	addLotFooRecursive("lot1");
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["lot1"],
+		"paths": [{"path": "/foo/bar", "recursive": true, "exclude": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Excluded lot2 row does not own /foo/bar; lot1 still wins.
+	EXPECT_EQ(names(call("/foo/bar", false, 1000, 7000, true)), (std::set<std::string>{"lot1"}));
+}
+
+// recursive=true appends the ancestor chain of every winner.
+TEST_F(GetLotsForPathTest, RecursiveAppendsAncestors) {
+	addLotFooRecursive("lot1");
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["lot1"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	auto got = names(call("/foo/bar", /*recursive=*/true, 1000, 7000, true));
+	// Ancestors of lot2: lot1 -> default (and lot2 itself wins directly).
+	EXPECT_TRUE(got.count("lot2"));
+	EXPECT_TRUE(got.count("lot1"));
+	EXPECT_TRUE(got.count("default"));
+}
+
+// Default-lot fallback: no lot covers the path anywhere in the window.
+TEST_F(GetLotsForPathTest, DefaultLotFallback) {
+	// No /foo lot; only the default lot from SetUp scaffolds /default.
+	auto got = names(call("/no/such/path", false, 100, 200, true));
+	EXPECT_EQ(got, (std::set<std::string>{"default"}));
+}
+
+// A lot whose MPA window is entirely outside the query window does not appear,
+// and the default lot is appended for the gap.
+TEST_F(GetLotsForPathTest, OutOfWindowFallsBackToDefault) {
+	addLotFooRecursive("lot1"); // [100, 9000)
+	auto got = names(call("/foo/bar", false, 20000, 30000, true));
+	EXPECT_EQ(got, (std::set<std::string>{"default"}));
+}
+
+// Sentinel (all-zero MPA timestamps) lots are always-live and overlap any
+// window, including far-future windows.
+TEST_F(GetLotsForPathTest, SentinelAlwaysReturned) {
+	addLot(R"({
+		"lot_name": "always_live",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/foo", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 0,
+			"expiration_time": 0,
+			"deletion_time": 0
+		}
+	})");
+	// Far-future window: sentinel still wins.
+	EXPECT_EQ(names(call("/foo/bar", false, 1'000'000'000'000LL, 2'000'000'000'000LL, true)),
+			  (std::set<std::string>{"always_live"}));
+}
+
+// Reclamation timestamp before the query window drops the lot entirely
+// when include_reclaimed=false; passing include_reclaimed=true brings it back.
+TEST_F(GetLotsForPathTest, ReclaimedBeforeWindowDroppedUnlessIncluded) {
+	addLotFooRecursive("lot1"); // [100, 9000)
+	reclaimLot("lot1", 500, "test");
+
+	// include_reclaimed=false, window entirely after reclamation: lot1 dropped,
+	// fall back to default.
+	EXPECT_EQ(names(call("/foo/bar", false, 1000, 2000, /*include_reclaimed=*/false)),
+			  (std::set<std::string>{"default"}));
+
+	// include_reclaimed=true: reclamation is ignored; lot1 wins.
+	EXPECT_EQ(names(call("/foo/bar", false, 1000, 2000, /*include_reclaimed=*/true)), (std::set<std::string>{"lot1"}));
+}
+
+// Reclamation in the middle of the window clips the active interval; the lot
+// still wins for the pre-reclaim slice and the default lot covers the tail.
+TEST_F(GetLotsForPathTest, ReclaimedMidWindowClipped) {
+	addLotFooRecursive("lot1");		 // [100, 9000)
+	reclaimLot("lot1", 1500, "mid"); // mid-window
+
+	// Window [1000, 2000): lot1 wins [1000, 1500), default covers [1500, 2000).
+	auto got = names(call("/foo/bar", false, 1000, 2000, /*include_reclaimed=*/false));
+	EXPECT_EQ(got, (std::set<std::string>{"lot1", "default"}));
+}
+
+// Invalid window: time_hi <= time_lo is rejected with a descriptive error.
+TEST_F(GetLotsForPathTest, InvalidWindowRejected) {
+	std::string err;
+	int rv = callExpectingError("/foo", false, 1000, 1000, true, err);
+	EXPECT_NE(rv, 0);
+	EXPECT_FALSE(err.empty());
+
+	rv = callExpectingError("/foo", false, 1000, 500, true, err);
+	EXPECT_NE(rv, 0);
+	EXPECT_FALSE(err.empty());
+}
+
+// Null path argument is rejected with an error.
+TEST_F(GetLotsForPathTest, NullPathRejected) {
+	std::string err;
+	int rv = callExpectingError(nullptr, false, 1000, 2000, true, err);
+	EXPECT_NE(rv, 0);
+	EXPECT_FALSE(err.empty());
+}
+
+// Path outside any lot's coverage returns just the default lot.
+TEST_F(GetLotsForPathTest, NonExistentPathReturnsDefault) {
+	addLotFooRecursive("lot1");
+	auto got = names(call("/totally/unrelated", false, 200, 300, true));
+	EXPECT_EQ(got, (std::set<std::string>{"default"}));
+}
+
+// Reclamation cascades to descendants (lotman_reclaim_lot semantics):
+// reclaiming an ancestor reclaims every descendant in the same cascade. As a
+// result, lotman_get_lots_for_path with include_reclaimed=false on a path
+// owned by a sublot of a reclaimed ancestor returns only the default lot for
+// any window after the reclamation timestamp, even when the sublot's MPA
+// would otherwise place it inside the window.
+TEST_F(GetLotsForPathTest, AncestorReclamationCascadesIntoSublot) {
+	addLotFooRecursive("lot1"); // ancestor on /foo, active [100, 9000)
+	addLot(R"({
+		"lot_name": "lot2",
+		"owner": "owner1",
+		"parents": ["lot1"],
+		"paths": [{"path": "/foo/bar", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 200,
+			"expiration_time": 8000,
+			"deletion_time": 8500
+		}
+	})");
+
+	// Reclaim the ancestor; cascade applies the same reclaimed_at to lot2.
+	reclaimLot("lot1", 500, "ancestor-cascade");
+
+	// Window strictly after the cascade reclamation: both lot1 and lot2 are
+	// reclaimed for the entire window, so neither survives the SQL pre-filter.
+	// Only the default lot remains.
+	auto got_filtered = names(call("/foo/bar", /*recursive=*/true, 1000, 7000, /*include_reclaimed=*/false));
+	EXPECT_EQ(got_filtered, (std::set<std::string>{"default"}))
+		<< "Cascaded reclamation must drop both ancestor and descendant from the result";
+
+	// include_reclaimed=true brings both back, with lot2 winning /foo/bar
+	// directly and lot1 + default appearing as recursive ancestors.
+	auto got_unfiltered = names(call("/foo/bar", /*recursive=*/true, 1000, 7000, /*include_reclaimed=*/true));
+	EXPECT_TRUE(got_unfiltered.count("lot2"));
+	EXPECT_TRUE(got_unfiltered.count("lot1"));
+	EXPECT_TRUE(got_unfiltered.count("default"));
 }
 
 } // namespace

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,4 +1,5 @@
 #include "../src/lotman.h"
+#include "test_utils.h"
 
 #include <cstdlib>
 #include <cstring>
@@ -10,23 +11,6 @@
 #include <typeinfo>
 
 using json = nlohmann::json;
-
-// RAII wrappers for C-style memory management
-struct CStringDeleter {
-	void operator()(char *ptr) const {
-		if (ptr)
-			free(ptr);
-	}
-};
-using UniqueCString = std::unique_ptr<char, CStringDeleter>;
-
-struct StringListDeleter {
-	void operator()(char **ptr) const {
-		if (ptr)
-			lotman_free_string_list(ptr);
-	}
-};
-using UniqueStringList = std::unique_ptr<char *, StringListDeleter>;
 
 // Test class to handle setup and teardown for each individual test
 class LotManTest : public ::testing::Test {
@@ -1265,7 +1249,7 @@ TEST_F(LotManTest, LotsQueryTest) {
 	char **raw_output = nullptr;
 
 	// Check for lots past expiration
-	auto rv = lotman_get_lots_past_exp(true, /*include_reclaimed=*/true, &raw_output, &raw_err);
+	auto rv = lotman_get_lots_past_exp(test_now_ms(), true, /*include_reclaimed=*/true, &raw_output, &raw_err);
 	UniqueCString err_msg(raw_err);
 	UniqueStringList output(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();
@@ -1281,7 +1265,7 @@ TEST_F(LotManTest, LotsQueryTest) {
 	// Check for lots past deletion
 	raw_output = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_del(true, /*include_reclaimed=*/true, &raw_output, &raw_err);
+	rv = lotman_get_lots_past_del(test_now_ms(), true, /*include_reclaimed=*/true, &raw_output, &raw_err);
 	err_msg.reset(raw_err);
 	UniqueStringList output2(raw_output);
 	ASSERT_EQ(rv, 0) << err_msg.get();

--- a/test/reclamation_tests.cpp
+++ b/test/reclamation_tests.cpp
@@ -35,6 +35,7 @@
 #include <cstring>
 #include <filesystem>
 #include <gtest/gtest.h>
+#include <limits>
 #include <nlohmann/json.hpp>
 #include <set>
 #include <string>
@@ -546,7 +547,7 @@ TEST_F(ReclamationTest, PastExpQueryRespectsIncludeReclaimed) {
 	// Sanity: appears in past_exp before reclaim.
 	char *raw_err = nullptr;
 	char **raw_lots = nullptr;
-	ASSERT_EQ(lotman_get_lots_past_exp(false, /*include_reclaimed=*/true, &raw_lots, &raw_err), 0);
+	ASSERT_EQ(lotman_get_lots_past_exp(test_now_ms(), false, /*include_reclaimed=*/true, &raw_lots, &raw_err), 0);
 	UniqueCString cleanup_err(raw_err);
 	UniqueStringList lots(raw_lots);
 	std::set<std::string> before;
@@ -561,7 +562,7 @@ TEST_F(ReclamationTest, PastExpQueryRespectsIncludeReclaimed) {
 	// include_reclaimed=true -> still present.
 	raw_err = nullptr;
 	char **raw_lots_inc = nullptr;
-	ASSERT_EQ(lotman_get_lots_past_exp(false, true, &raw_lots_inc, &raw_err), 0);
+	ASSERT_EQ(lotman_get_lots_past_exp(test_now_ms(), false, true, &raw_lots_inc, &raw_err), 0);
 	UniqueCString eg1(raw_err);
 	UniqueStringList lots_inc(raw_lots_inc);
 	std::set<std::string> with_inc;
@@ -572,7 +573,7 @@ TEST_F(ReclamationTest, PastExpQueryRespectsIncludeReclaimed) {
 	// include_reclaimed=false -> filtered out.
 	raw_err = nullptr;
 	char **raw_lots_exc = nullptr;
-	ASSERT_EQ(lotman_get_lots_past_exp(false, false, &raw_lots_exc, &raw_err), 0);
+	ASSERT_EQ(lotman_get_lots_past_exp(test_now_ms(), false, false, &raw_lots_exc, &raw_err), 0);
 	UniqueCString eg2(raw_err);
 	UniqueStringList lots_exc(raw_lots_exc);
 	std::set<std::string> without;
@@ -596,7 +597,7 @@ TEST_F(ReclamationTest, PastDelQueryRespectsIncludeReclaimed) {
 
 	char *raw_err = nullptr;
 	char **raw_lots = nullptr;
-	ASSERT_EQ(lotman_get_lots_past_del(false, true, &raw_lots, &raw_err), 0);
+	ASSERT_EQ(lotman_get_lots_past_del(test_now_ms(), false, true, &raw_lots, &raw_err), 0);
 	UniqueCString cleanup_err(raw_err);
 	UniqueStringList lots(raw_lots);
 	std::set<std::string> before;
@@ -609,7 +610,7 @@ TEST_F(ReclamationTest, PastDelQueryRespectsIncludeReclaimed) {
 
 	raw_err = nullptr;
 	char **raw_lots_exc = nullptr;
-	ASSERT_EQ(lotman_get_lots_past_del(false, false, &raw_lots_exc, &raw_err), 0);
+	ASSERT_EQ(lotman_get_lots_past_del(test_now_ms(), false, false, &raw_lots_exc, &raw_err), 0);
 	UniqueCString eg(raw_err);
 	UniqueStringList lots_exc(raw_lots_exc);
 	std::set<std::string> after;
@@ -720,7 +721,7 @@ TEST_F(ReclamationTest, PastQueriesIncludeFutureScheduledReclamation) {
 
 	char *raw_err = nullptr;
 	char **raw_lots = nullptr;
-	ASSERT_EQ(lotman_get_lots_past_exp(false, /*include_reclaimed=*/false, &raw_lots, &raw_err), 0);
+	ASSERT_EQ(lotman_get_lots_past_exp(test_now_ms(), false, /*include_reclaimed=*/false, &raw_lots, &raw_err), 0);
 	UniqueCString cleanup_err(raw_err);
 	UniqueStringList lots(raw_lots);
 	std::set<std::string> got;
@@ -990,7 +991,9 @@ TEST_F(ReclamationTest, GetLotsPastExpRecursiveIncludesDescendants) {
 
 	char *raw_err = nullptr;
 	char **raw_lots = nullptr;
-	ASSERT_EQ(lotman_get_lots_past_exp(/*recursive=*/true, /*include_reclaimed=*/true, &raw_lots, &raw_err), 0);
+	ASSERT_EQ(
+		lotman_get_lots_past_exp(test_now_ms(), /*recursive=*/true, /*include_reclaimed=*/true, &raw_lots, &raw_err),
+		0);
 	UniqueCString cleanup_err(raw_err);
 	UniqueStringList lots(raw_lots);
 	std::set<std::string> got;
@@ -998,6 +1001,214 @@ TEST_F(ReclamationTest, GetLotsPastExpRecursiveIncludesDescendants) {
 		got.insert(lots.get()[i]);
 	EXPECT_TRUE(got.count("exp_root"));
 	EXPECT_TRUE(got.count("exp_child")) << "Recursive past_exp must include children of expired ancestors";
+}
+
+// query_time parameter on past_exp/past_del: a cutoff strictly in the past
+// (before any expiration_time) must yield an empty list, while a cutoff far
+// in the future must include the expired/deleted lot. The cutoff overrides
+// "now"; this is the parameterization that lets callers reason about future
+// or past states of the ledger.
+TEST_F(ReclamationTest, GetLotsPastExpRespectsQueryTimeCutoff) {
+	addDefaultLot();
+	// expiration_time = 5000 in the past (since PAST_TS = 1 and tests run with
+	// real wall-clock); we control inclusion via the query_time argument.
+	addLot(R"({
+		"lot_name": "soon_expired",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/soon", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 5000,
+			"deletion_time": 6000
+		}
+	})");
+
+	// Cutoff = 4000 (before expiration_time): should NOT be returned.
+	{
+		char *raw_err = nullptr;
+		char **raw_lots = nullptr;
+		ASSERT_EQ(lotman_get_lots_past_exp(/*query_time=*/4000, /*recursive=*/false,
+										   /*include_reclaimed=*/true, &raw_lots, &raw_err),
+				  0)
+			<< (raw_err ? raw_err : "");
+		UniqueCString err(raw_err);
+		UniqueStringList lots(raw_lots);
+		std::set<std::string> got;
+		for (int i = 0; lots.get()[i]; ++i)
+			got.insert(lots.get()[i]);
+		EXPECT_EQ(got.count("soon_expired"), 0u);
+	}
+
+	// Cutoff = 6000 (after expiration_time, before deletion_time): should be
+	// returned by past_exp but NOT by past_del.
+	{
+		char *raw_err = nullptr;
+		char **raw_lots = nullptr;
+		ASSERT_EQ(lotman_get_lots_past_exp(/*query_time=*/6000, /*recursive=*/false,
+										   /*include_reclaimed=*/true, &raw_lots, &raw_err),
+				  0)
+			<< (raw_err ? raw_err : "");
+		UniqueCString err(raw_err);
+		UniqueStringList lots(raw_lots);
+		std::set<std::string> got;
+		for (int i = 0; lots.get()[i]; ++i)
+			got.insert(lots.get()[i]);
+		EXPECT_EQ(got.count("soon_expired"), 1u);
+	}
+
+	// Cutoff = 5500 (between expiration and deletion): past_del should NOT
+	// return it.
+	{
+		char *raw_err = nullptr;
+		char **raw_lots = nullptr;
+		ASSERT_EQ(lotman_get_lots_past_del(/*query_time=*/5500, /*recursive=*/false,
+										   /*include_reclaimed=*/true, &raw_lots, &raw_err),
+				  0)
+			<< (raw_err ? raw_err : "");
+		UniqueCString err(raw_err);
+		UniqueStringList lots(raw_lots);
+		std::set<std::string> got;
+		for (int i = 0; lots.get()[i]; ++i)
+			got.insert(lots.get()[i]);
+		EXPECT_EQ(got.count("soon_expired"), 0u);
+	}
+
+	// Cutoff = 7000 (after deletion_time): past_del should return it.
+	{
+		char *raw_err = nullptr;
+		char **raw_lots = nullptr;
+		ASSERT_EQ(lotman_get_lots_past_del(/*query_time=*/7000, /*recursive=*/false,
+										   /*include_reclaimed=*/true, &raw_lots, &raw_err),
+				  0)
+			<< (raw_err ? raw_err : "");
+		UniqueCString err(raw_err);
+		UniqueStringList lots(raw_lots);
+		std::set<std::string> got;
+		for (int i = 0; lots.get()[i]; ++i)
+			got.insert(lots.get()[i]);
+		EXPECT_EQ(got.count("soon_expired"), 1u);
+	}
+}
+
+// Sentinel (creation == expiration == deletion == 0) lots are non-expiring
+// and must never be returned by past_exp / past_del regardless of the cutoff.
+TEST_F(ReclamationTest, SentinelLotNeverReturnedByPastQueriesAtAnyCutoff) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "sentinel",
+		"owner": "owner1",
+		"parents": ["sentinel"],
+		"paths": [{"path": "/sentinel", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 0,
+			"expiration_time": 0,
+			"deletion_time": 0
+		}
+	})");
+
+	for (int64_t cutoff : {static_cast<int64_t>(1), static_cast<int64_t>(1'000'000'000'000LL),
+						   std::numeric_limits<int64_t>::max() / 2}) {
+		char *raw_err = nullptr;
+		char **raw_lots = nullptr;
+		ASSERT_EQ(lotman_get_lots_past_exp(cutoff, false, true, &raw_lots, &raw_err), 0) << (raw_err ? raw_err : "");
+		UniqueCString err(raw_err);
+		UniqueStringList lots(raw_lots);
+		for (int i = 0; lots.get()[i]; ++i) {
+			EXPECT_STRNE(lots.get()[i], "sentinel") << "sentinel must never appear in past_exp at cutoff=" << cutoff;
+		}
+
+		raw_err = nullptr;
+		raw_lots = nullptr;
+		ASSERT_EQ(lotman_get_lots_past_del(cutoff, false, true, &raw_lots, &raw_err), 0) << (raw_err ? raw_err : "");
+		UniqueCString err2(raw_err);
+		UniqueStringList lots2(raw_lots);
+		for (int i = 0; lots2.get()[i]; ++i) {
+			EXPECT_STRNE(lots2.get()[i], "sentinel") << "sentinel must never appear in past_del at cutoff=" << cutoff;
+		}
+	}
+}
+
+// Reclamation evaluation uses the supplied query_time, not wall-clock now:
+// a future-scheduled reclamation only takes effect for cutoffs after the
+// scheduled reclaimed_at.
+TEST_F(ReclamationTest, PastQueriesEvaluateReclamationAtSuppliedQueryTime) {
+	addDefaultLot();
+	addLot(R"({
+		"lot_name": "scheduled",
+		"owner": "owner1",
+		"parents": ["default"],
+		"paths": [{"path": "/sched", "recursive": true}],
+		"management_policy_attrs": {
+			"dedicated_GB": 10,
+			"opportunistic_GB": 5,
+			"max_num_objects": 100,
+			"creation_time": 100,
+			"expiration_time": 5000,
+			"deletion_time": 6000
+		}
+	})");
+
+	// Schedule reclamation for t=8000 (in the future relative to the
+	// expiration/deletion timestamps used here).
+	{
+		char *raw_err = nullptr;
+		ASSERT_EQ(lotman_reclaim_lot("scheduled", 8000, "test-scheduled", &raw_err), 0) << (raw_err ? raw_err : "");
+		free(raw_err);
+	}
+
+	// Cutoff = 7000 (post-expiration, pre-reclamation): include_reclaimed=false
+	// should still return the lot because reclaimed_at > query_time.
+	{
+		char *raw_err = nullptr;
+		char **raw_lots = nullptr;
+		ASSERT_EQ(lotman_get_lots_past_exp(7000, false, /*include_reclaimed=*/false, &raw_lots, &raw_err), 0)
+			<< (raw_err ? raw_err : "");
+		UniqueCString err(raw_err);
+		UniqueStringList lots(raw_lots);
+		std::set<std::string> got;
+		for (int i = 0; lots.get()[i]; ++i)
+			got.insert(lots.get()[i]);
+		EXPECT_EQ(got.count("scheduled"), 1u)
+			<< "Reclaimed-in-future-relative-to-query_time lot must still appear under include_reclaimed=false";
+	}
+
+	// Cutoff = 9000 (post-reclamation): include_reclaimed=false should NOT
+	// return the lot because reclaimed_at <= query_time.
+	{
+		char *raw_err = nullptr;
+		char **raw_lots = nullptr;
+		ASSERT_EQ(lotman_get_lots_past_exp(9000, false, /*include_reclaimed=*/false, &raw_lots, &raw_err), 0)
+			<< (raw_err ? raw_err : "");
+		UniqueCString err(raw_err);
+		UniqueStringList lots(raw_lots);
+		std::set<std::string> got;
+		for (int i = 0; lots.get()[i]; ++i)
+			got.insert(lots.get()[i]);
+		EXPECT_EQ(got.count("scheduled"), 0u)
+			<< "Reclaimed-before-query_time lot must be filtered out under include_reclaimed=false";
+	}
+
+	// Same cutoff with include_reclaimed=true should still return the lot.
+	{
+		char *raw_err = nullptr;
+		char **raw_lots = nullptr;
+		ASSERT_EQ(lotman_get_lots_past_exp(9000, false, /*include_reclaimed=*/true, &raw_lots, &raw_err), 0)
+			<< (raw_err ? raw_err : "");
+		UniqueCString err(raw_err);
+		UniqueStringList lots(raw_lots);
+		std::set<std::string> got;
+		for (int i = 0; lots.get()[i]; ++i)
+			got.insert(lots.get()[i]);
+		EXPECT_EQ(got.count("scheduled"), 1u)
+			<< "include_reclaimed=true must surface the lot regardless of reclamation status";
+	}
 }
 
 } // namespace

--- a/test/strict_hierarchy_tests.cpp
+++ b/test/strict_hierarchy_tests.cpp
@@ -6290,7 +6290,8 @@ TEST_F(StrictHierarchyTest, NonExpiringLotNotReturnedFromPastExpQuery) {
 	// the past relative to "now"; it should be returned. ne_root must NOT.
 	char **raw_lots = nullptr;
 	raw_err = nullptr;
-	int rv = lotman_get_lots_past_exp(/*recursive=*/false, /*include_reclaimed=*/true, &raw_lots, &raw_err);
+	int rv =
+		lotman_get_lots_past_exp(test_now_ms(), /*recursive=*/false, /*include_reclaimed=*/true, &raw_lots, &raw_err);
 	UniqueStringList lots(raw_lots);
 	UniqueCString err(raw_err);
 	ASSERT_EQ(rv, 0) << (err.get() ? err.get() : "");
@@ -6308,7 +6309,7 @@ TEST_F(StrictHierarchyTest, NonExpiringLotNotReturnedFromPastExpQuery) {
 	// Same expectation for past-deletion.
 	raw_lots = nullptr;
 	raw_err = nullptr;
-	rv = lotman_get_lots_past_del(/*recursive=*/false, /*include_reclaimed=*/true, &raw_lots, &raw_err);
+	rv = lotman_get_lots_past_del(test_now_ms(), /*recursive=*/false, /*include_reclaimed=*/true, &raw_lots, &raw_err);
 	UniqueStringList del_lots(raw_lots);
 	UniqueCString del_err(raw_err);
 	ASSERT_EQ(rv, 0) << (del_err.get() ? del_err.get() : "");

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -10,6 +10,8 @@
 
 #include "../src/lotman.h"
 
+#include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <iostream>
@@ -79,6 +81,16 @@ inline std::string create_temp_directory(const std::string &prefix = "lotman_tes
 	}
 
 	return temp_dir_template;
+}
+
+/**
+ * Wall-clock "now" expressed in Unix-epoch milliseconds. Returned as a
+ * signed 64-bit integer to match the int64_t timestamp parameters used
+ * throughout the LotMan public API.
+ */
+inline int64_t test_now_ms() {
+	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+		.count();
 }
 
 #endif // LOTMAN_TEST_UTILS_H


### PR DESCRIPTION
Pelican's cleanup and billing code needs to reason about lot state at arbitrary points in time, not just "right now". The two changes here address that:

1. `lotman_get_lots_past_exp` / `lotman_get_lots_past_del` now accept an explicit query_time cutoff instead of capturing wall-clock `now()` internally. This lets callers preview which lots will be expired by a future timestamp, reconstruct historical states, and — critically — keep reclamation evaluation temporally consistent with the expiration cutoff (both now use the same caller-supplied value).

2. `lotman_get_lots_for_path` is a window-aware companion to `lotman_get_lots_from_dir`. A single-instant resolution cannot answer "which lot(s) owned this path during billing window [lo, hi)?" when ownership changed hands mid-window. The new API returns the union of every lot that wins the longest-prefix contest at any instant in the half-open window, allowing callers to attribute storage across ownership transitions without losing coverage. Mid-window reclamation is handled by clipping a lot's active interval to its reclaimed_at timestamp before the sweep, rather than dropping it outright, preserving attribution for the pre-reclamation portion of the window.

To avoid duplicating the full lot JSON assembly that `lotman_get_lot_as_json` already performs, that logic was extracted into a static `build_lot_json_obj` helper shared by both the single-lot and array-returning paths. This also corrects a pre-existing memory leak in `get_lot_as_json` where a malloc'd buffer was immediately overwritten by strdup.